### PR TITLE
Ubuntu 14.04 nsd package is broken

### DIFF
--- a/scripts/dns.sh
+++ b/scripts/dns.sh
@@ -9,7 +9,14 @@
 
 # Install nsd, our DNS server software.
 
-useradd nsd
+# ...but first, we have to create the user because the 
+# current Ubuntu forgets to do so in the .deb
+if id nsd > /dev/null 2>&1; then
+	echo "nsd user exists... good";
+else
+	useradd nsd;
+if
+	
 apt-get -qq -y install nsd
 
 # Prepare nsd's configuration.


### PR DESCRIPTION
Installing fails because there's no 'nsd' user and it doesn't create one, leaving the package in a "partially configured" state, where it won't start.  Creating the user ahead of time seems to avoid this failure.
