### PR TITLE
Force the scripts to run in bash

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This is the entry point for configuring the system.
 #####################################################
 


### PR DESCRIPTION
The script needs to have a shebang to ensure that they all are run in bash as other shells (e.g. sh, zsh) do not have similar read commands which causes issues.
