### PR TITLE
Allow start.sh to handle a system without sshd installed.

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -13,17 +13,6 @@ if [ "`lsb_release -d | sed 's/.*:\s*//'`" != "Ubuntu 14.04 LTS" ]; then
 	exit
 fi
 
-# Check that SSH login with password is disabled. Stop if it's enabled.
-if grep -q "^PasswordAuthentication yes" /etc/ssh/sshd_config \
- || ! grep -q "^PasswordAuthentication no" /etc/ssh/sshd_config ; then
-        echo
-        echo "The SSH server on this machine permits password-based login."
-        echo "Add your SSH public key to $HOME/.ssh/authorized_keys, check"
-        echo "check that you can log in without a password, set the option"
-        echo "'PasswordAuthentication no' in /etc/ssh/sshd_config, and then"
-        echo "restart the machine."
-        exit
-fi
 
 # Gather information from the user about the hostname and public IP
 # address of this host.

--- a/scripts/system.sh
+++ b/scripts/system.sh
@@ -3,6 +3,21 @@
 apt-get -q -q update
 apt-get -q -y upgrade
 
+# Install openssh-server to ensure that the end result is consistent across all Mail-in-a-Boxes.
+apt-get -q -y install openssh-server
+
+# Check that SSH login with password is disabled. Stop if it's enabled.
+if grep -q "^PasswordAuthentication yes" /etc/ssh/sshd_config \
+ || ! grep -q "^PasswordAuthentication no" /etc/ssh/sshd_config ; then
+        echo
+        echo "The SSH server on this machine permits password-based login."
+        echo "Add your SSH public key to $HOME/.ssh/authorized_keys, check"
+        echo "check that you can log in without a password, set the option"
+        echo "'PasswordAuthentication no' in /etc/ssh/sshd_config, and then"
+        echo "restart the openssh via 'sudo service ssh restart'"
+        exit
+fi
+
 apt-get -q -y install python3
 
 # Turn on basic services:


### PR DESCRIPTION
Added `test -f /etc/ssh/sshd_config` to the start of the `PasswordAuthentication` test.
This will make sure that only if sshd is installed will we enforce the configuration constraint.
