### PR TITLE
enable and configure password-change plugin for roundcube

### DIFF
--- a/scripts/webmail.sh
+++ b/scripts/webmail.sh
@@ -55,7 +55,7 @@ cp /usr/share/roundcube/plugins/password/config.inc.php.dist \
 
 tools/editconf.py /etc/roundcube/plugins/password/config.inc.php \
 	"\$rcmail_config['password_minimum_length']=6;" \
-	"\$rcmail_config['password_db_dsn']='sqlite:////home/user-data/mail/users.sqlite';" \
+	"\$rcmail_config['password_db_dsn']='sqlite:///$STORAGE_ROOT/mail/users.sqlite';" \
 	"\$rcmail_config['password_query']='UPDATE users SET password=%D WHERE email=%u';" \
 	"\$rcmail_config['password_dovecotpw']='/usr/bin/doveadm pw';" \
 	"\$rcmail_config['password_dovecotpw_method']='SHA512-CRYPT';" \


### PR DESCRIPTION
For those of us who are our family's and/or friends' tech support person, allowing other people to use the mailserver is a natural step, which means either 
1. allowing everyone root to use the users and aliases tool
2. changing people's password for them (uncomfortable, right after advocating privacy with said person)
3. enabling the roundcube password changingn plugin

I did (3), and here it is in case that seems like a good idea for the original, too.
