### PR TITLE
Tell Flask to log to syslog

### DIFF
--- a/management/daemon.py
+++ b/management/daemon.py
@@ -97,4 +97,8 @@ def do_updates():
 
 if __name__ == '__main__':
 	if "DEBUG" in os.environ: app.debug = True
+
+	if not app.debug:
+		app.logger.addHandler(utils.create_syslog_handler())
+
 	app.run(port=10222)

--- a/management/utils.py
+++ b/management/utils.py
@@ -95,3 +95,9 @@ def shell(method, cmd_args, env={}, capture_stderr=False, return_bytes=False):
     ret = getattr(subprocess, method)(cmd_args, env=env, stderr=stderr)
     if not return_bytes and isinstance(ret, bytes): ret = ret.decode("utf8")
     return ret
+
+def create_syslog_handler():
+    import logging.handlers
+    handler = logging.handlers.SysLogHandler(address='/dev/log')
+    handler.setLevel(logging.WARNING)
+    return handler


### PR DESCRIPTION
- Writes Flask warnings and errors to `/var/log/syslog`
- Helps to debug issues when running in production
