### PR TITLE
Clarify what the password does

### DIFF
--- a/guide.html
+++ b/guide.html
@@ -269,6 +269,8 @@ cd mailinabox</pre>
 
 					<p>You will be asked to enter the email address you want and a few other configuration questions. At the end you will be asked for a password for your email address.</p>
 
+					<p>This password will be used to login to webmail, and to authorize sending and receiving mail through SMTP and IMAP. It will <strong>not</strong> be used to log onto your Mail-in-a-Box server.</p>
+
 					<p>When the setup script is done running, you have a working mail server. But first check that everything is correct so far by typing:</p>
 
 					<pre>sudo management/whats_next.py</pre>


### PR DESCRIPTION
Clarifies that the password is for webmail, SMTP, and IMAP (but not logging into the box itself).
