### PR TITLE
Enabled Managesieve Plugins for Dovecot and Roundcube

### DIFF
--- a/setup/managesieve.sh
+++ b/setup/managesieve.sh
@@ -1,0 +1,29 @@
+# Managesieve: Manage a user's sieve script collection.
+#######################################################
+
+source setup/functions.sh # load our functions
+source /etc/mailinabox.conf # load global vars
+managesieveDir=$STORAGE_ROOT/mail/managesieve
+
+apt_install \
+	dovecot-managesieved
+
+cat - > /etc/dovecot/conf.d/90-sieve.conf << EOF;
+##
+## Settings for the Sieve interpreter
+##
+plugin {
+  # The path to the user's main active script. If ManageSieve is used, this the
+  # location of the symbolic link controlled by ManageSieve.
+  sieve = $managesieveDir/%d/%n/.dovecot.sieve
+
+  # Directory for :personal include scripts for the include extension. This
+  # is also where the ManageSieve service stores the user's scripts.
+  sieve_dir = $managesieveDir/%d/%n
+}
+EOF
+
+mkdir $managesieveDir 
+chown -R mail.mail  $managesieveDir
+
+service dovecot restart

--- a/setup/start.sh
+++ b/setup/start.sh
@@ -186,6 +186,7 @@ EOF
 . setup/dkim.sh
 . setup/spamassassin.sh
 . setup/web.sh
+. setup/managesieve.sh
 . setup/webmail.sh
 . setup/management.sh
 
@@ -222,10 +223,8 @@ if [ -z "`tools/mail.py user`" ]; then
 		echo "Okay. I'm about to set up $EMAIL_ADDR for you."
 	fi
 
-	# Create the user's mail account. This will ask for a password if none was given above.
-	tools/mail.py user add $EMAIL_ADDR $EMAIL_PW
-
-	# Create an alias to which we'll direct all automatically-created administrative aliases.
-	tools/mail.py alias add administrator@$PRIMARY_HOSTNAME $EMAIL_ADDR
+	tools/mail.py user add $EMAIL_ADDR $EMAIL_PW # will ask for password if none given
+	tools/mail.py alias add hostmaster@$PRIMARY_HOSTNAME $EMAIL_ADDR
+	tools/mail.py alias add postmaster@$PRIMARY_HOSTNAME $EMAIL_ADDR
 fi
 

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -62,7 +62,7 @@ cat - > /usr/local/lib/roundcubemail/config/config.inc.php <<EOF;
 \$config['support_url'] = 'https://mailinabox.email/';
 \$config['product_name'] = 'Mail-in-a-Box/Roundcube Webmail';
 \$config['des_key'] = '$SECRET_KEY';
-\$config['plugins'] = array('archive', 'zipdownload', 'password');
+\$config['plugins'] = array('archive', 'zipdownload', 'password','managesieve');
 \$config['skin'] = 'larry';
 \$config['login_autocomplete'] = 2;
 \$config['password_charset'] = 'UTF-8';


### PR DESCRIPTION
> c) Can you test that this doesn't interfere with the default sieve script to put spam in the spam folder?

The user's sieve script collection created by roundcube is stored in $STORAGE_ROOT/mail/managesieve not in $STORAGE_ROOT/mail/mailboxes so roundcube can't overwrite the other .dovecot.sieve.

See  #102 
