### PR TITLE
Add IPv6 glue records as well

### DIFF
--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -144,8 +144,8 @@ def build_zone(domain, all_domains, additional_records, env, is_zone=True):
 		records.append(("ns1", "A", env["PUBLIC_IP"], False))
 		records.append(("ns2", "A", env["PUBLIC_IP"], False))
 		if env.get('PUBLIC_IPV6'):
-			records.append(("ns1", "AAAA", env["PUBLIC_IPV6"]))
-			records.append(("ns2", "AAAA", env["PUBLIC_IPV6"]))
+			records.append(("ns1", "AAAA", env["PUBLIC_IPV6"], False))
+			records.append(("ns2", "AAAA", env["PUBLIC_IPV6"], False))
 
 		# Set the A/AAAA records. Do this early for the PRIMARY_HOSTNAME so that the user cannot override them
 		# and we can provide different explanatory text.


### PR DESCRIPTION
The dns_update script didn't generate IPv6 (AAAA) glue records for the name servers.

This caused http://dnscheck.pingdom.com to complain about a mismatch between the glue records reported by the parent name server and mailinabox nsd.

Here's the failing dnscheck output for reference:

> Checking glue for ns1.my.domain.tld (1.2.3.4).
> Child glue for bgwe.eu found: ns1.my.domain.tld (1.2.3.4)
> Checking glue for ns1.my.domain.tld (1234::1).
> Missing glue at child: ns1.my.domain.tld
> Checking glue for ns2.my.domain.tld (1.2.3.4).
> Child glue for bgwe.eu found: ns2.my.domain.tld (1.2.3.4)
> Checking glue for ns2.my.domain.tld (1234::1).
> Missing glue at child: ns2.my.domain.tld

I'm not very familiar with Python and DNS, please verify ;)
