### PR TITLE
Use /dev/random instead of /dev/urandom

### DIFF
--- a/setup/dns.sh
+++ b/setup/dns.sh
@@ -41,13 +41,13 @@ if [ ! -f "$STORAGE_ROOT/dns/dnssec/keys.conf" ]; then
 	# instead of /dev/random for noise or else we'll be waiting
 	# a very long time. The domain name we provide ("_domain_")
 	# doesn't matter -- we'll use the same keys for all our domains.
-	KSK=$(umask 077; cd $STORAGE_ROOT/dns/dnssec; ldns-keygen -a RSASHA1-NSEC3-SHA1 -b 2048 -k -r /dev/urandom _domain_);
+	KSK=$(umask 077; cd $STORAGE_ROOT/dns/dnssec; ldns-keygen -a RSASHA1-NSEC3-SHA1 -b 2048 -k -r /dev/random _domain_);
 
 	# Now create a Zone-Signing Key (ZSK) which is expected to be
 	# rotated more often than a KSK, although we have no plans to
 	# rotate it (and doing so would be difficult to do without
 	# disturbing DNS availability.) Omit '-k' and use a shorter key.
-	ZSK=$(umask 077; cd $STORAGE_ROOT/dns/dnssec; ldns-keygen -a RSASHA1-NSEC3-SHA1 -b 1024 -r /dev/urandom _domain_);
+	ZSK=$(umask 077; cd $STORAGE_ROOT/dns/dnssec; ldns-keygen -a RSASHA1-NSEC3-SHA1 -b 1024 -r /dev/random _domain_);
 
 	# These generate two sets of files like:
 	# K_domain_.+007+08882.ds <- DS record for adding to NSD configuration files

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -8,7 +8,7 @@ hide_output apt-get -y upgrade
 
 # Install basic utilities.
 
-apt_install python3 python3-pip wget curl bind9-host
+apt_install python3 python3-pip wget curl bind9-host haveged
 
 # Turn on basic services:
 #

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -36,7 +36,7 @@ if [ ! -d /usr/local/lib/roundcubemail ]; then
 fi
 
 # Generate a safe 24-character secret key of safe characters.
-SECRET_KEY=$(dd if=/dev/urandom bs=20 count=1 2>/dev/null | base64 | fold -w 24 | head -n 1)
+SECRET_KEY=$(dd if=/dev/random bs=20 count=1 2>/dev/null | base64 | fold -w 24 | head -n 1)
 
 # Create a configuration file.
 #


### PR DESCRIPTION
/dev/random should be used for crypto-grade RNG.

To make sure use of /dev/random doesn't stall due to lack of entropy, install haveged which fills the entropy pool with sources such as network traffic, key strokes, etc.

On branch master
Your branch is up-to-date with 'origin/master'.

Changes to be committed:
    modified:   setup/dns.sh
    modified:   setup/system.sh
    modified:   setup/webmail.sh
