### PR TITLE
Read timezone from /etc/timezone.

### DIFF
--- a/setup/zpush.sh
+++ b/setup/zpush.sh
@@ -41,7 +41,7 @@ if [ $needs_update == 1 ]; then
 fi
 
 # Configure default config.
-sed -i "s/define('TIMEZONE', .*/define('TIMEZONE', 'Etc\/UTC');/" /usr/local/lib/z-push/config.php
+sed -i "s^define('TIMEZONE', .*^define('TIMEZONE', '$(cat /etc/timezone)');^" /usr/local/lib/z-push/config.php
 sed -i "s/define('BACKEND_PROVIDER', .*/define('BACKEND_PROVIDER', 'BackendCombined');/" /usr/local/lib/z-push/config.php
 
 # Configure BACKEND


### PR DESCRIPTION
According to [this](https://github.com/fmbiete/Z-Push-contrib/wiki/Example-Configuration#main-basic-configuration), the timezone for z-push might be important. Reading `/etc/timezone` and using it in z-push' config.php seems to be a good idea.

I had to change the delimiter for sed to compensate the `/` in the timezones name. 
