### PR TITLE
Fix wrong hostname suggestion box.box.example.com

### DIFF
--- a/setup/start.sh
+++ b/setup/start.sh
@@ -86,6 +86,7 @@ if [ -z "$PRIMARY_HOSTNAME" ]; then
 
 		# Take the part after the @-sign as the user's domain name, and add
 		# 'box.' to the beginning to create a default hostname for this machine.
+		# If there is already a 'box.' in the EMAIL_ADDR, strip it from the string.
 		DEFAULT_PRIMARY_HOSTNAME=box.$(echo $EMAIL_ADDR | sed -e 's/.*@//' -e 's/^box\.//')
 	fi
 


### PR DESCRIPTION
FIX: If you use me@box.example.com (as advised by the script) as your mail address, the default primary hostname will be box.box.example.com. 

sed already strips the local part of $EMAIL_ADDR to advise a PRIMARY_HOSTNAME so I appended another sed-script that strips "box." if it is in the beginning of $EMAIL_ADDR after the local part is gone.
