### PR TITLE
Add server block customizations

### DIFF
--- a/management/web_update.py
+++ b/management/web_update.py
@@ -104,7 +104,7 @@ def make_domain_config(domain, template, template_for_primaryhost, env):
 				nginx_conf += "\tlocation %s {\n\t\tproxy_pass %s;\n\t}\n" % (path, url)
 
  	# Add in any user customizations in the includes/ folder.
-        nginx_conf_custom_include = os.path.join(env["STORAGE_ROOT"], "www", safe_domain_name(test_domain) + ".conf")
+        nginx_conf_custom_include = os.path.join(env["STORAGE_ROOT"], "www", safe_domain_name(domain) + ".conf")
         if os.path.exists(nginx_conf_custom_include):
                 nginx_conf += "\tinclude %s;\n" % (nginx_conf_custom_include)
 


### PR DESCRIPTION
This change allows users to add a file `/etc/nginx/conf.d/includes/mydomain.com.conf`, the contents of which will be loaded into the server block for `mydomain.com` using an nginx `include` directive. Naturally, the `include` is added only if the file exists.

As with the YAML customizations, this puts the user in charge of making sure that the configuration actually works (`sudo nginx -t` is a good way to find typos).

Maybe there should be a documented way of triggering the web_update—I've been making edits to a dummy alias, but maybe there's a more elegant way.
