### PR TITLE
Add a helper script to unlock ownClouds admin features

### DIFF
--- a/tools/owncloud-unlockadmin.sh
+++ b/tools/owncloud-unlockadmin.sh
@@ -2,7 +2,7 @@
 
 source /etc/mailinabox.conf # load global vars
 
-ADMIN=$(sqlite3 $STORAGE_ROOT/mail/users.sqlite "SELECT email FROM users WHERE privileges = 'admin' ORDER BY id ASC LIMIT 1")
+ADMIN=$(./mail.py user admins | head -n 1)
 test -z "$1" || ADMIN=$1 
 
 echo I am going to unlock admin features for $ADMIN.


### PR DESCRIPTION
I agree that enabling ownClouds admin features by default could lead to many broken setups and useless issues. But on the other hand, if you create a user-account for a friend, you could quickly end up with a full disk because you don't have quota. It is much easier to fill a disk with files synced by ownCloud than a mailbox. Also, I would like to use the Bookmark feature of ownCloud. There is even a Firefox sync plugin!

This is a nice way to let experienced users decide if they want to take care of their setups.
