### PR TITLE
update ownCloud

### DIFF
--- a/setup/owncloud.sh
+++ b/setup/owncloud.sh
@@ -13,9 +13,9 @@ apt_install \
 apt-get purge -qq -y owncloud*
 
 # Install ownCloud from source
-# Check if ownCloud dir exist, and check if version matches 7.0.1 (if it does, upgrade)
 owncloud_ver=7.0.2
 
+# Check if ownCloud dir exist, and check if version matches owncloud_ver (if either doesn't - install/upgrade)
 if [ ! -d /usr/local/lib/owncloud/ ] \
 	|| ! grep -q $owncloud_ver /usr/local/lib/owncloud/version.php; then
 


### PR DESCRIPTION
this will always download the latest ownCloud and upgrade if ownCloud install dir exist, this apphroach allows us to keep existing user plugins. currently not checking if currently installed version is equal to the one we're downloading as I couldn't find a proper solution for that
