### PR TITLE
Minor tweaks and fixes

### DIFF
--- a/conf/nginx-primaryonly.conf
+++ b/conf/nginx-primaryonly.conf
@@ -11,7 +11,12 @@
 	rewrite ^/cloud/(contacts|calendar|files)$ /cloud/index.php/apps/$1/ redirect;
 	rewrite ^(/cloud/core/doc/[^\/]+/)$ $1/index.html;
 	location /cloud/ {
+
+		access_log /var/log/owncloud/access.log;
+		error_log /var/log/owncloud/error.log;
+
 		alias /usr/local/lib/owncloud/;
+
 		location ~ ^/(data|config|\.ht|db_structure\.xml|README) {
 			deny all;
 	 	}

--- a/conf/nginx-primaryonly.conf
+++ b/conf/nginx-primaryonly.conf
@@ -15,6 +15,11 @@
 		location ~ ^/(data|config|\.ht|db_structure\.xml|README) {
 			deny all;
 	 	}
+		location ~ /remote.php/ {
+			# Don't log requests that uses DAV (results in heavy spam)
+			log_not_found off;
+			access_log off;
+	 	}
 	}
 	location ~ ^(/cloud)(/[^/]+\.php)(/.*)?$ {
 		# note: ~ has precendence over a regular location block
@@ -41,6 +46,9 @@
 		# Z-Push doesn't like getting a redirect, and a plain rewrite didn't work either.
 		# Properly proxying like this seems to work fine.
 		proxy_pass https://$HOSTNAME/cloud/remote.php/$1;
+
+		# Don't log requests that uses DAV (results in heavy spam)
+		access_log off;
 	}
 	rewrite ^/.well-known/host-meta /cloud/public.php?service=host-meta last;
 	rewrite ^/.well-known/host-meta.json /cloud/public.php?service=host-meta-json last;

--- a/conf/nginx-primaryonly.conf
+++ b/conf/nginx-primaryonly.conf
@@ -20,11 +20,6 @@
 		location ~ ^/(data|config|\.ht|db_structure\.xml|README) {
 			deny all;
 	 	}
-		location ~ /remote.php/ {
-			# Don't log requests that uses DAV (results in heavy spam)
-			log_not_found off;
-			access_log off;
-	 	}
 	}
 	location ~ ^(/cloud)(/[^/]+\.php)(/.*)?$ {
 		# note: ~ has precendence over a regular location block
@@ -46,6 +41,10 @@
 		# so that this is not exposed to the world.
 		internal;
 		alias $STORAGE_ROOT/owncloud;
+	}
+	location ~ ^/cloud/remote.php/(caldav|webdav|carddav)(.*)$ {
+		# Don't log requests that uses DAV (results in heavy spam)
+		access_log off;
 	}
 	location ~ ^/((caldav|carddav|webdav).*)$ {
 		# Z-Push doesn't like getting a redirect, and a plain rewrite didn't work either.

--- a/conf/nginx-primaryonly.conf
+++ b/conf/nginx-primaryonly.conf
@@ -11,18 +11,22 @@
 	rewrite ^/cloud/(contacts|calendar|files)$ /cloud/index.php/apps/$1/ redirect;
 	rewrite ^(/cloud/core/doc/[^\/]+/)$ $1/index.html;
 	location /cloud/ {
-
-		access_log /var/log/owncloud/access.log;
-		error_log /var/log/owncloud/error.log;
-
 		alias /usr/local/lib/owncloud/;
 
 		location ~ ^/(data|config|\.ht|db_structure\.xml|README) {
 			deny all;
 	 	}
+	 	location ~ ^/((caldav|webdav|carddav).*)$ {
+			# Don't log requests that uses DAV (results in heavy spam)
+			access_log off;
+	 	}
 	}
 	location ~ ^(/cloud)(/[^/]+\.php)(/.*)?$ {
 		# note: ~ has precendence over a regular location block
+
+		access_log /var/log/owncloud/access.log;
+		error_log /var/log/owncloud/error.log;
+
 		include fastcgi_params;
 		fastcgi_param SCRIPT_FILENAME /usr/local/lib/owncloud/$2;
 		fastcgi_param SCRIPT_NAME $1$2;
@@ -41,10 +45,6 @@
 		# so that this is not exposed to the world.
 		internal;
 		alias $STORAGE_ROOT/owncloud;
-	}
-	location ~ ^/cloud/remote.php/(caldav|webdav|carddav)(.*)$ {
-		# Don't log requests that uses DAV (results in heavy spam)
-		access_log off;
 	}
 	location ~ ^/((caldav|carddav|webdav).*)$ {
 		# Z-Push doesn't like getting a redirect, and a plain rewrite didn't work either.

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -57,7 +57,8 @@ server {
 		include /etc/nginx/fastcgi_params;
 		fastcgi_param SCRIPT_FILENAME /usr/local/lib/z-push/index.php;
 		fastcgi_param PHP_VALUE "include_path=.:/usr/share/php:/usr/share/pear:/usr/share/awl/inc";
-		fastcgi_read_timeout 630;
+		fastcgi_read_timeout 1750s;
+		fastcgi_send_timeout 1750s;
 		fastcgi_pass php-fpm;
 	}
 	location /autodiscover/autodiscover.xml {

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -24,6 +24,16 @@ server {
 	root $ROOT;
 	index index.html index.htm;
 
+	location = /robots.txt {
+		log_not_found off;
+		access_log off;
+	}
+
+	location = /favicon.ico {
+		log_not_found off;
+		access_log off;
+	}
+
 	# Roundcube Webmail configuration.
 	rewrite ^/mail$ /mail/ redirect;
 	rewrite ^/mail/$ /mail/index.php;

--- a/setup/owncloud.sh
+++ b/setup/owncloud.sh
@@ -90,9 +90,10 @@ EOF
 ?>
 EOF
 
-	# Create user data directory and set permissions
+	# Create user data directory, log directory and set permissions
 	mkdir -p $STORAGE_ROOT/owncloud
-	chown -R www-data.www-data $STORAGE_ROOT/owncloud /usr/local/lib/owncloud
+	mkdir -p /var/log/owncloud
+	chown -R www-data.www-data $STORAGE_ROOT/owncloud /usr/local/lib/owncloud /var/log/owncloud
 
 	# Execute ownCloud's setup step, which creates the ownCloud sqlite database.
 	# It also wipes it if it exists. And it deletes the autoconfig.php file.


### PR DESCRIPTION
- Changes log location for ownCloud
- Ignores robot.txt, favicon.ico in nginx log file
- Attempt made at ignoring calls to /cloud/remote.php/ (please review, perhaps you have an working regexp?). Anyhow calls made at /carddav/ or /webdav/ or /caldav/ is ignored
- Increased timeouts for z-push
- Since ownCloud is based on SabreDav it has support for the "fast" sync option in z-push

I'd also like to see a move for seperateing out the "web apps" and configurations into separate config files and include them in one "streamlined" config. Thoughts on that? (would make it a lot more manageble)