### PR TITLE
Changed incomming-email-input to type text

### DIFF
--- a/management/templates/aliases.html
+++ b/management/templates/aliases.html
@@ -13,7 +13,7 @@
   <div class="form-group">
     <label for="addaliasEmail" class="col-sm-2 control-label">Email Address</label>
     <div class="col-sm-10">
-      <input type="email" class="form-control" id="addaliasEmail" placeholder="Incoming Email Address">
+      <input type="text" class="form-control" id="addaliasEmail" placeholder="Incoming Email Address">
     </div>
   </div>
   <div class="form-group">


### PR DESCRIPTION
The input type="email" validation won't allow "@example.com", which is needed for catch-all-aliases.
