### PR TITLE
enable site-wide bayesian filtering

### DIFF
--- a/setup/spamassassin.sh
+++ b/setup/spamassassin.sh
@@ -35,7 +35,7 @@ sudo sed -i "s/#mail_plugins = .*/mail_plugins = \$mail_plugins antispam/" /etc/
 # from http://wiki2.dovecot.org/Plugins/Antispam
 cat > /usr/bin/sa-learn-pipe.sh << EOF;
 cat<&0 >> /tmp/sendmail-msg-\$\$.txt
-/usr/bin/sa-learn \$* /tmp/sendmail-msg-\$\$.txt > /dev/null
+/usr/bin/sa-learn \$* /tmp/sendmail-msg-\$\$.txt --username user-data > /dev/null
 rm -f /tmp/sendmail-msg-\$\$.txt
 exit 0
 EOF
@@ -52,6 +52,15 @@ plugin {
     antispam_pipe_program = /bin/bash
 }
 EOF
+
+# Configure spamassassin to use site-wide bayesian filtering
+source /etc/mailinabox.conf # get global vars
+
+mkdir -p $STORAGE_ROOT/mail/spamassassin
+chown -R mail:mail $STORAGE_ROOT/mail/spamassassin
+chmod -R 775 $STORAGE_ROOT/mail/spamassassin
+
+tools/editconf.py /etc/spamassassin/local.cf -s bayes_path=$STORAGE_ROOT/mail/spamassassin/bayes
 
 # Initial training?
 # sa-learn --ham storage/mail/mailboxes/*/*/cur/


### PR DESCRIPTION
Create directory in $STORAGE_ROOT for bayes database.
Added --username arg to sa-learn as the user mail does not have permission to edit files in $STORAGE_ROOT. 

/usr/bin/sa-learn-pipe.sh is run as user mail
