### PR TITLE
Pass additional_records to recursive build_zone calls, closes #229

### DIFF
--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -192,7 +192,7 @@ def build_zone(domain, all_domains, additional_records, env, is_zone=True):
 	subdomains = [d for d in all_domains if d.endswith("." + domain)]
 	for subdomain in subdomains:
 		subdomain_qname = subdomain[0:-len("." + domain)]
-		subzone = build_zone(subdomain, [], {}, env, is_zone=False)
+		subzone = build_zone(subdomain, [], additional_records, env, is_zone=False)
 		for child_qname, child_rtype, child_value, child_explanation in subzone:
 			if child_qname == None:
 				child_qname = subdomain_qname
@@ -483,7 +483,7 @@ zone:
 	name: %s
 	zonefile: %s
 """ % (domain, zonefile)
-	
+
 		# If a custom secondary nameserver has been set, allow zone transfers
 		# and notifies to that nameserver.
 		if additional_records.get("_secondary_nameserver"):
@@ -727,7 +727,7 @@ def set_custom_dns_record(qname, rtype, value, env):
 
 def set_secondary_dns(hostname, env):
 	config = get_custom_dns_config(env)
-		
+
 	if hostname in (None, ""):
 		# Clear.
 		if "_secondary_nameserver" in config:


### PR DESCRIPTION
The problem was that custom records defined for a subdomain where implicit
records are otherwise defined (e.g. A/AAAA records for the root) were ignored.

Though additional_records for a subdomain are processed in the base call to
build_zone (the call for the parent domain), and so custom records that don't
override implicits were working fine, those that overrode implicits were
ignored.

This was because the recursive call to build_zone for the subdomain creates the
implicit records (including A/AAAA records for the root), and so by relying on
the base call to add the additional_records fails because has_rec returned
true.

Adding a subdomain's additional_records in the child call works because has_rec
returns false when testing whether to add an e.g. A/AAAA override for the root,
as the defaults have not yet been added.
