### PR TITLE
Jump to the panel_aliases anchor (top) to directly edit the selected alias

### DIFF
--- a/management/templates/aliases.html
+++ b/management/templates/aliases.html
@@ -58,7 +58,7 @@
   <table>
   <tr id="alias-template">
     <td class='actions'>
-        <a href="#" onclick="aliases_edit(this); document.location += #panel_aliases'; return false;" class='edit' title="Edit Alias">
+        <a href="#" onclick="aliases_edit(this); scroll_top(); return false;" class='edit' title="Edit Alias">
           <span class="glyphicon glyphicon-pencil"></span>
         </a>
         <a href="#" onclick="aliases_remove(this); return false;" class='remove' title="Remove Alias">
@@ -188,5 +188,11 @@ function aliases_remove(elem) {
           show_aliases();
         });
     });
+}
+
+function scroll_top() {
+        $('html, body').animate({
+            scrollTop: $("#panel_aliases").offset().top
+        }, 1000);
 }
 </script>


### PR DESCRIPTION
If you have many aliases and you scroll to the bottom of the page and click the small pencil, nothing happend, but then I realized, that the form at the top of the page changed. So I have manually scroll up to see the form.
