### PR TITLE
Fix typo in zpush.sh comment

### DIFF
--- a/setup/zpush.sh
+++ b/setup/zpush.sh
@@ -3,7 +3,7 @@
 # Z-Push: The Microsoft Exchange protocol server
 # ----------------------------------------------
 #
-# Mostly for use on iOS which doesn't support IMAP.
+# Mostly for use on iOS which doesn't support IMAP IDLE.
 #
 # Although Ubuntu ships Z-Push (as d-push) it has a dependency on Apache
 # so we won't install it that way.


### PR DESCRIPTION
Looks like a simple typo/misunderstanding.  iOS supports IMAP, but not IMAP IDLE, which is probably what this comment meant to say.
