### PR TITLE
Fix secondary NS status check

### DIFF
--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -207,10 +207,10 @@ def check_dns_zone(domain, env, dns_zonefiles):
 	# to do a DNS trace.
 	custom_dns = get_custom_dns_config(env)
 	existing_ns = query_dns(domain, "NS")
-	correct_ns = "; ".join([
+	correct_ns = "; ".join(sorted([
 		"ns1." + env['PRIMARY_HOSTNAME'],
 		custom_dns.get("_secondary_nameserver", "ns2." + env['PRIMARY_HOSTNAME']),
-		])
+		]))
 	if existing_ns.lower() == correct_ns.lower():
 		env['out'].print_ok("Nameservers are set correctly at registrar. [%s]" % correct_ns)
 	else:


### PR DESCRIPTION
If you have added an external secondary NS server the status check fails if the name of the secondary NS starts with a letter lower than `n`. 

**Example:**

```
The nameservers set on this domain are incorrect. They are currently c.ns.buddyns.com; ns1.example.com. Use your domain name registrar's control panel to set the nameservers to ns1.example.com; c.ns.buddyns.com.
```

The Problem is that the [query_dns function](https://github.com/mail-in-a-box/mailinabox/blob/master/management/status_checks.py#L370) sorts its results. In contrast to that in the [check_dns_zone function](https://github.com/m4rcs/mailinabox/blob/master/management/status_checks.py#L210) the result of the query_dns function is compared to the unsorted NS.

I fixed the problem by sorting the correct_ns variable before comparing it to the currently set NS.
