### PR TITLE
Add POP3s support

### DIFF
--- a/setup/mail-dovecot.sh
+++ b/setup/mail-dovecot.sh
@@ -21,7 +21,7 @@ source /etc/mailinabox.conf # load global vars
 # Install packages...
 
 apt_install \
-	dovecot-core dovecot-imapd dovecot-lmtpd dovecot-sqlite sqlite3 \
+	dovecot-core dovecot-imapd dovecot-pop3d dovecot-lmtpd dovecot-sqlite sqlite3 \
 	dovecot-sieve dovecot-managesieved
 
 # The `dovecot-imapd` and `dovecot-lmtpd` packages automatically enable IMAP and LMTP protocols.
@@ -83,6 +83,10 @@ sed -i "s/#port = 110/port = 0/" /etc/dovecot/conf.d/10-master.conf
 # by a peer. See #129 and http://razor.occams.info/blog/2014/08/09/how-bad-is-imap-idle/.
 tools/editconf.py /etc/dovecot/conf.d/20-imap.conf \
 	imap_idle_notify_interval="4 mins"
+
+# Set POP3 UIDL
+tools/editconf.py /etc/dovecot/conf.d/20-pop3.conf \
+	pop3_uidl_format = %08Xu%08Xv
 
 # ### LDA (LMTP)
 

--- a/setup/mail-dovecot.sh
+++ b/setup/mail-dovecot.sh
@@ -85,6 +85,9 @@ tools/editconf.py /etc/dovecot/conf.d/20-imap.conf \
 	imap_idle_notify_interval="4 mins"
 
 # Set POP3 UIDL
+# UIDLs are used by POP3 clients to keep track of what messages they've downloaded. 
+# For new POP3 servers, the easiest way to set up UIDLs is to use IMAP's UIDVALIDITY
+# and UID values, the default in Dovecot.
 tools/editconf.py /etc/dovecot/conf.d/20-pop3.conf \
 	pop3_uidl_format = %08Xu%08Xv
 

--- a/setup/spamassassin.sh
+++ b/setup/spamassassin.sh
@@ -71,6 +71,7 @@ chown -R spampd:spampd $STORAGE_ROOT/mail/spamassassin
 # Enable the Dovecot antispam plugin.
 # (Be careful if we use multiple plugins later.) #NODOC
 sed -i "s/#mail_plugins = .*/mail_plugins = \$mail_plugins antispam/" /etc/dovecot/conf.d/20-imap.conf
+sed -i "s/#mail_plugins = .*/mail_plugins = \$mail_plugins antispam/" /etc/dovecot/conf.d/20-pop3.conf
 
 # Configure the antispam plugin to call sa-learn-pipe.sh.
 cat > /etc/dovecot/conf.d/99-local-spampd.conf << EOF;


### PR DESCRIPTION
Adding POP3 support is required to be able to connect mailboxes to gmail. As we are using SSL, pop3 will be secure.