### PR TITLE
WIP: Add Munin

### DIFF
--- a/setup/munin.sh
+++ b/setup/munin.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Munin: resource monitoring tool
+#################################################
+
+source setup/functions.sh # load our functions
+source /etc/mailinabox.conf # load global vars
+
+# install Munin
+apt_install munin munin-plugins-extra
+
+# edit config
+cat > /etc/munin/munin.conf <<EOF;
+  dbdir /var/lib/munin
+  htmldir /var/cache/munin/www
+  logdir /var/log/munin
+  rundir /var/run/munin
+  tmpldir /etc/munin/templates
+
+  includedir /etc/munin/munin-conf.d
+
+  # a simple host tree
+  [$PRIMARY_HOSTNAME]
+  address 127.0.0.1
+  use_node_name yes
+
+  # send alerts to the following address
+  contacts admin
+  contact.admin.command mail -s "Munin notification ${var:host}" administrator@$PRIMARY_HOSTNAME
+  contact.admin.always_send warning critical
+EOF
+
+
+# set subdomain
+DOMAIN=${PRIMARY_HOSTNAME#[[:alpha:]]*.}
+hide_output curl -d "" --user $(</var/lib/mailinabox/api.key): http://127.0.0.1:10222/dns/set/munin.$DOMAIN
+
+# write nginx config
+cat > /etc/nginx/conf.d/munin.conf <<EOF;
+  # Redirect all HTTP to HTTPS.
+  server {
+    listen 80;
+    listen [::]:80;
+
+    server_name munin.$DOMAIN;
+    root /tmp/invalid-path-nothing-here;
+    rewrite ^/(.*)$ https://munin.$DOMAIN/$1 permanent;
+  }
+
+  server {
+    listen 443 ssl;
+
+    server_name munin.$DOMAIN;
+
+    ssl_certificate $STORAGE_ROOT/ssl/ssl_certificate.pem;
+    ssl_certificate_key $STORAGE_ROOT/ssl/ssl_private_key.pem;
+    include /etc/nginx/nginx-ssl.conf;
+
+    auth_basic "Authenticate";
+    auth_basic_user_file /etc/nginx/htpasswd;
+
+    root /var/cache/munin/www;
+
+    location = /robots.txt {
+      log_not_found off;
+      access_log off;
+    }
+  }
+EOF

--- a/setup/start.sh
+++ b/setup/start.sh
@@ -125,6 +125,7 @@ source setup/webmail.sh
 source setup/owncloud.sh
 source setup/zpush.sh
 source setup/management.sh
+source setup/munin.sh
 
 # Write the DNS and nginx configuration files.
 sleep 5 # wait for the daemon to start
@@ -133,6 +134,9 @@ curl -s -d POSTDATA --user $(</var/lib/mailinabox/api.key): http://127.0.0.1:102
 
 # If there aren't any mail users yet, create one.
 source setup/firstuser.sh
+
+# Grant admins access to Munin
+source tools/munin_update.sh
 
 # Done.
 echo

--- a/tools/munin_update.sh
+++ b/tools/munin_update.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Grant admins access to munin
+
+source setup/functions.sh # load our functions
+source /etc/mailinabox.conf # load global vars
+
+db=$STORAGE_ROOT'/mail/users.sqlite'
+
+users=`sqlite3 $db "SELECT email FROM users WHERE privileges = 'admin'"`;
+passwords=`sqlite3 $db "SELECT password FROM users WHERE privileges = 'admin'"`;
+
+# Define the arrays
+users_array=(${users// / })
+passwords_array=(${passwords// / })
+
+# clear htpasswd
+>/etc/nginx/htpasswd
+
+# write user:password
+for i in "${!users_array[@]}"; do
+  echo "${users_array[i]}:${passwords_array[i]:14}" >> /etc/nginx/htpasswd
+done


### PR DESCRIPTION
Basic implementation of Munin monitoring & alerts [1] for Mail-in-a-Box. Administrators are able to login at ``https://munin.example.com`` . Critical alerts are send to ``administrator@box.example.com``.

### ToDo
* run ``tools/munin_update.sh`` after an user with admin privilege is created/edited/deleted.
* add documentation about Munin, e.g. add a linkt to the control panel
* generate own SSL certificate for ``munin.example.com`` ?

More thoughts on this? Feel free to close if this is out of the scope of this project. 
(*Only tested in a development environment.*)

[Previous](https://discourse.mailinabox.email/t/monitoring-tools/186) discussion on monitoring tools.

[1] http://munin-monitoring.org