### PR TITLE
do better redirection from http to https

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -7,7 +7,10 @@ server {
 
 	server_name $HOSTNAME;
 	root /tmp/invalid-path-nothing-here;
-	rewrite ^/(.*)$ https://$HOSTNAME/$1 permanent;
+	# Redirect using the 'return' directive and the built-in
+	# variable '$request_uri' to avoid any capturing, matching
+	# or evaluation of regular expressions.
+	return 301 https://$HOSTNAME$request_uri;
 }
 
 # The secure HTTPS server.


### PR DESCRIPTION
The RegEx matching can and should be avoided in such a case. 
Please see: http://wiki.nginx.org/Pitfalls#Taxing_Rewrites