### PR TITLE
Fixes #309, removed hardcoded /home directory to apply the existing config

### DIFF
--- a/setup/start.sh
+++ b/setup/start.sh
@@ -102,7 +102,7 @@ if [ -z "$STORAGE_ROOT" ]; then
 fi
 
 # Create the STORAGE_USER if it not exists
-if [ ! $(id -u $STORAGE_USER >/dev/null 2>&1;) ]; then
+if ! id -u $STORAGE_USER >/dev/null 2>&1; then
 	useradd -m $STORAGE_USER
 fi
 

--- a/setup/start.sh
+++ b/setup/start.sh
@@ -93,8 +93,13 @@ fi
 #
 # If the config file exists:
 # Apply the existing configuration options for STORAGE_USER/ROOT
-STORAGE_USER=$([[ -z "$DEFAULT_STORAGE_USER" ]] && echo "user-data" || echo "$DEFAULT_STORAGE_USER")
-STORAGE_ROOT=$([[ -z "$DEFAULT_STORAGE_ROOT" ]] && echo "/home/$STORAGE_USER" || echo "$DEFAULT_STORAGE_ROOT")
+if [ -z "$STORAGE_USER" ]; then
+	STORAGE_USER=$([[ -z "$DEFAULT_STORAGE_USER" ]] && echo "user-data" || echo "$DEFAULT_STORAGE_USER")
+fi
+
+if [ -z "$STORAGE_ROOT" ]; then
+	STORAGE_ROOT=$([[ -z "$DEFAULT_STORAGE_ROOT" ]] && echo "/home/$STORAGE_USER" || echo "$DEFAULT_STORAGE_ROOT")
+fi
 
 # Create the STORAGE_USER if it not exists
 if [ ! $(id -u $STORAGE_USER >/dev/null 2>&1;) ]; then
@@ -104,10 +109,10 @@ fi
 # Create the STORAGE_ROOT if it not exists
 if [ ! -d $STORAGE_ROOT ]; then
 	mkdir -p $STORAGE_ROOT
+	echo $(setup/migrate.py --current) > $STORAGE_ROOT/mailinabox.version
+	chown $STORAGE_USER.$STORAGE_USER $STORAGE_ROOT/mailinabox.version
 fi
 
-echo $(setup/migrate.py --current) > $STORAGE_ROOT/mailinabox.version
-chown $STORAGE_USER.$STORAGE_USER $STORAGE_ROOT/mailinabox.version
 
 # Save the global options in /etc/mailinabox.conf so that standalone
 # tools know where to look for data.


### PR DESCRIPTION
What I've tested so far:
Install miab (the default way).
Changed the STORAGE_USER and STORAGE_ROOT in the config file and start `mailinabox` again.
Removed the config file and start `mailinabox` again.

Everything seems to work fine. I can solely rely on a VM to test the PR, above I'm not able to test sending and receiving mails.

```bash
# Create the STORAGE_USER if it not exists
if [ ! $(id -u $STORAGE_USER >/dev/null 2>&1;) ]; then
  useradd -m $STORAGE_USER
fi
```

The intention of this part is to create the non-existing user even when the directory already exists. Ok I don't know why somebody wants to do that. But things can happen ...

Furthermore I think this condition ``if [ -z "$STORAGE_ROOT" ];`` is now unnecessary, because STORAGE_ROOT has not been set before.