### PR TITLE
hide nginx version an OS information for better privacy

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -7,6 +7,11 @@ server {
 
 	server_name $HOSTNAME;
 	root /tmp/invalid-path-nothing-here;
+
+	# Improve privacy: Hide version an OS information on
+	# error pages and in the "Server" HTTP-Header.
+	server_tokens off;
+
 	# Redirect using the 'return' directive and the built-in
 	# variable '$request_uri' to avoid any capturing, matching
 	# or evaluation of regular expressions.
@@ -19,6 +24,10 @@ server {
 	listen [::]:443 ssl;
 
 	server_name $HOSTNAME;
+
+	# Improve privacy: Hide version an OS information on
+	# error pages and in the "Server" HTTP-Header.
+	server_tokens off;
 
 	ssl_certificate $SSL_CERTIFICATE;
 	ssl_certificate_key $SSL_KEY;


### PR DESCRIPTION
Improve the privacy (just a little bit ;) ) by hiding version an OS information on error pages and in the "Server" HTTP-Header.
See: http://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens


e.g.
Before:
```
curl -i http://box.occams.info
HTTP/1.1 301 Moved Permanently
Server: nginx/1.4.6 (Ubuntu)
Date: Sun, 01 Feb 2015 19:18:27 GMT
Content-Type: text/html
Content-Length: 178
Connection: keep-alive
Location: https://box.occams.info/
[...]
```
After:
```
curl -i http://box.occams.info
HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Sun, 01 Feb 2015 19:18:27 GMT
Content-Type: text/html
Content-Length: 178
Connection: keep-alive
Location: https://box.occams.info/
[...]
```