### PR TITLE
allow for non-standard ssh port in status check

### DIFF
--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -58,7 +58,7 @@ def run_services_checks(env, output):
 		{ "name": "Sieve (dovecot)", "port": 4190, "public": True, },
 		{ "name": "Mail-in-a-Box Management Daemon", "port": 10222, "public": False, },
 
-		{ "name": "SSH Login (ssh)", "port": 22, "public": True, },
+		{ "name": "SSH Login (ssh)", "port": int(env['SSH_PORT']), "public": True, },
 		{ "name": "Public DNS (nsd4)", "port": 53, "public": True, },
 		{ "name": "Incoming Mail (SMTP/postfix)", "port": 25, "public": True, },
 		{ "name": "Outgoing Mail (SMTP 587/postfix)", "port": 587, "public": True, },

--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -107,7 +107,7 @@ def check_service(i, service, env):
 		running = True
 
 	except OSError as e:
-		if service['name'] == 'ssh':
+		if service['name'] == 'SSH Login (ssh)':
 			output.print_error("%s is not running (%s). (Should be running on port %s)" % (service['name'], str(e), str(get_ssh_port())))
 		else:
 			output.print_error("%s is not running (%s)." % (service['name'], str(e)))

--- a/setup/start.sh
+++ b/setup/start.sh
@@ -109,7 +109,6 @@ PUBLIC_IPV6=$PUBLIC_IPV6
 PRIVATE_IP=$PRIVATE_IP
 PRIVATE_IPV6=$PRIVATE_IPV6
 CSR_COUNTRY=$CSR_COUNTRY
-SSH_PORT=$(sshd -T 2>/dev/null | grep "^port " | sed "s/port //")
 EOF
 
 # Start service configuration.

--- a/setup/start.sh
+++ b/setup/start.sh
@@ -109,6 +109,7 @@ PUBLIC_IPV6=$PUBLIC_IPV6
 PRIVATE_IP=$PRIVATE_IP
 PRIVATE_IPV6=$PRIVATE_IPV6
 CSR_COUNTRY=$CSR_COUNTRY
+SSH_PORT=$(sshd -T 2>/dev/null | grep "^port " | sed "s/port //")
 EOF
 
 # Start service configuration.


### PR DESCRIPTION
Currently the ssh status check fails when ssh is running on a non-standard port.