### PR TITLE
Start script enhancements

### DIFF
--- a/setup/migrate.py
+++ b/setup/migrate.py
@@ -84,13 +84,22 @@ def run_migrations():
 	env = load_environment()
 
 	migration_id_file = os.path.join(env['STORAGE_ROOT'], 'mailinabox.version')
+	migration_id = None
 	if os.path.exists(migration_id_file):
 		with open(migration_id_file) as f:
-			ourver = int(f.read().strip())
-	else:
+			migration_id = f.read().strip();
+
+	if migration_id is None:
 		# Load the legacy location of the migration ID. We'll drop support
 		# for this eventually.
-		ourver = int(env.get("MIGRATIONID", "0"))
+		migration_id = env.get("MIGRATIONID")
+
+	if migration_id is None:
+		print()
+		print("%s file doesn't exists. Skipping migration..." % (migration_id_file,))
+		return
+
+	ourver = int(migration_id)
 
 	while True:
 		next_ver = (ourver + 1)

--- a/setup/start.sh
+++ b/setup/start.sh
@@ -109,6 +109,10 @@ fi
 # Create the STORAGE_ROOT if it not exists
 if [ ! -d $STORAGE_ROOT ]; then
 	mkdir -p $STORAGE_ROOT
+fi
+
+# Create mailinabox.version file if not exists
+if [ ! -f $STORAGE_ROOT/mailinabox.version ]; then
 	echo $(setup/migrate.py --current) > $STORAGE_ROOT/mailinabox.version
 	chown $STORAGE_USER.$STORAGE_USER $STORAGE_ROOT/mailinabox.version
 fi


### PR DESCRIPTION
Changes :

- Support missing `mailinabox.version` file properly in `migrate.py` script : It will skip migrations, instead of trying to perform all migrations.

- Create `mailinabox.version` file if missing in `start.sh` script, even if `STORAGE_ROOT` directory already exists.

I was experiencing this issue when running mailinabox script when `mailinabox.version` file is missing, but it should not occur anymore.
```
mailinabox

Running migration to Mail-in-a-Box #1...

Running migration to Mail-in-a-Box #2...

Running migration to Mail-in-a-Box #3...

Running migration to Mail-in-a-Box #4...
Error: duplicate column name: privileges

Error running the migration script:

Command '['sqlite3', '/home/user-data/mail/users.sqlite', "ALTER TABLE users ADD privileges TEXT NOT NULL DEFAULT ''"]' returned non-zero exit status 1

Your system may be in an inconsistent state now. We're terribly sorry. A re-install from a backup might be the best way to continue.
```