### PR TITLE
Update MX records using DNS Update API / Management UI

### DIFF
--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -691,7 +691,7 @@ def set_custom_dns_record(qname, rtype, value, env):
 			v = ipaddress.ip_address(value)
 			if rtype == "A" and not isinstance(v, ipaddress.IPv4Address): raise ValueError("That's an IPv6 address.")
 			if rtype == "AAAA" and not isinstance(v, ipaddress.IPv6Address): raise ValueError("That's an IPv4 address.")
-		elif rtype in ("CNAME", "TXT", "SRV"):
+		elif rtype in ("CNAME", "TXT", "SRV", "MX"):
 			# anything goes
 			pass
 		else:

--- a/management/templates/custom-dns.html
+++ b/management/templates/custom-dns.html
@@ -35,6 +35,7 @@
         <option value="AAAA" data-hint="Enter an IPv6 address.">AAAA (IPv6 address)</option>
         <option value="CNAME" data-hint="Enter another domain name followed by a period at the end (e.g. mypage.github.io.).">CNAME (DNS forwarding)</option>
         <option value="TXT" data-hint="Enter arbitrary text.">TXT (text record)</option>
+        <option value="MX" data-hint="Enter record in the form of PRIORIY DOMAIN., including trailing period (e.g. 20 mx.example.com.).">MX (mail exchanger)</option>
       </select>
     </div>
   </div>


### PR DESCRIPTION
Allow custom MX records via the API / management UI. Useful if a subdomain has a different mail delivery endpoint than the one hosted by MiaB. Can also be used to define secondary MX, but are these ever used anymore...?