### PR TITLE
Fix nginx rewrite redirects when box is behind port masquerading

### DIFF
--- a/conf/nginx-primaryonly.conf
+++ b/conf/nginx-primaryonly.conf
@@ -8,9 +8,9 @@
 	}
 
 	# ownCloud configuration.
-	rewrite ^/cloud$ /cloud/ redirect;
+	rewrite ^/cloud$ $scheme://$http_host/cloud/ redirect;
 	rewrite ^/cloud/$ /cloud/index.php;
-	rewrite ^/cloud/(contacts|calendar|files)$ /cloud/index.php/apps/$1/ redirect;
+	rewrite ^/cloud/(contacts|calendar|files)$ $scheme://$http_host/cloud/index.php/apps/$1/ redirect;
 	rewrite ^(/cloud/core/doc/[^\/]+/)$ $1/index.html;
 	location /cloud/ {
 		alias /usr/local/lib/owncloud/;
@@ -50,6 +50,6 @@
 	}
 	rewrite ^/.well-known/host-meta /cloud/public.php?service=host-meta last;
 	rewrite ^/.well-known/host-meta.json /cloud/public.php?service=host-meta-json last;
-	rewrite ^/.well-known/carddav /cloud/remote.php/carddav/ redirect;
-	rewrite ^/.well-known/caldav /cloud/remote.php/caldav/ redirect;
+	rewrite ^/.well-known/carddav $scheme://$http_host/cloud/remote.php/carddav/ redirect;
+	rewrite ^/.well-known/caldav $scheme://$http_host/cloud/remote.php/caldav/ redirect;
 

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -62,7 +62,7 @@ server {
 	}
 
 	# Roundcube Webmail configuration.
-	rewrite ^/mail$ /mail/ redirect;
+	rewrite ^/mail$ $scheme://$http_host/mail/ redirect;
 	rewrite ^/mail/$ /mail/index.php;
 	location /mail/ {
 		index index.php;


### PR DESCRIPTION
Current nginx redirects doesn't work when nginx is behind a port masquerading.

For example, if NAT router maps `tcp/18443` to `tcp/443`, trying to access `https://mailinabox:18443/mail` redirects to `https://mailinabox/mail/` instead of `https://mailinbox:18443/mail/`

It can be really common using docker (docker run -p `18443:443` ...).