### PR TITLE
Create owncloud configuration files even if database exists

### DIFF
--- a/setup/owncloud.sh
+++ b/setup/owncloud.sh
@@ -31,13 +31,15 @@ fi
 
 # ### Configuring ownCloud
 
+OWNCLOUD_CONFIG=/usr/local/lib/owncloud/config/config.php
+
 # Setup ownCloud if the ownCloud database does not yet exist. Running setup when
 # the database does exist wipes the database and user data.
-if [ ! -f $STORAGE_ROOT/owncloud/owncloud.db ]; then
+if [ ! -f $OWNCLOUD_CONFIG ]; then
 	# Create a configuration file.
 	TIMEZONE=$(cat /etc/timezone)
 	instanceid=oc$(echo $PRIMARY_HOSTNAME | sha1sum | fold -w 10 | head -n 1)
-	cat > /usr/local/lib/owncloud/config/config.php <<EOF;
+	cat > $OWNCLOUD_CONFIG <<EOF;
 <?php
 \$CONFIG = array (
   'datadirectory' => '$STORAGE_ROOT/owncloud',
@@ -74,7 +76,13 @@ if [ ! -f $STORAGE_ROOT/owncloud/owncloud.db ]; then
 );
 ?>
 EOF
+fi
 
+# Create user data directory and set permissions
+mkdir -p $STORAGE_ROOT/owncloud
+chown -R www-data.www-data $STORAGE_ROOT/owncloud /usr/local/lib/owncloud
+
+if [ ! -f $STORAGE_ROOT/owncloud/owncloud.db ]; then
 	# Create an auto-configuration file to fill in database settings
 	# when the install script is run. Make an administrator account
 	# here or else the install can't finish.
@@ -93,10 +101,6 @@ EOF
 );
 ?>
 EOF
-
-	# Create user data directory and set permissions
-	mkdir -p $STORAGE_ROOT/owncloud
-	chown -R www-data.www-data $STORAGE_ROOT/owncloud /usr/local/lib/owncloud
 
 	# Execute ownCloud's setup step, which creates the ownCloud sqlite database.
 	# It also wipes it if it exists. And it deletes the autoconfig.php file.


### PR DESCRIPTION
This is related to https://github.com/mail-in-a-box/mailinabox/pull/338#issuecomment-77295930

When running setup an a new box where $STORAGE_ROOT has existing data (docker case), there's some configuration file missing from owncloud.

This splits the configuration process into 2 distinct condition:

- config.php file doesn't exists (=> Create the configuration file)
- Owncloud database doesn't exists (=> Run owncloud installation PHP script)