### PR TITLE
Configure fail2ban jails to prevent dumb brute-force attacks

### DIFF
--- a/conf/fail2ban/dovecotimap.conf
+++ b/conf/fail2ban/dovecotimap.conf
@@ -1,0 +1,22 @@
+# Fail2Ban filter Dovecot authentication and pop3/imap server
+# For Mail-in-a-Box
+
+[INCLUDES]
+
+before = common.conf
+
+[Definition]
+
+_daemon = (auth|dovecot(-auth)?|auth-worker)
+
+failregex = ^%(__prefix_line)s(pop3|imap)-login: (Info: )?(Aborted login|Disconnected)(: Inactivity)? \(((no auth attempts|auth failed, \d+ attempts)( in \d+ secs)?|tried to use (disabled|disallowed) \S+ auth)\):( user=<\S*>,)?( method=\S+,)? rip=<HOST>, lip=(\d{1,3}\.){3}\d{1,3}(, TLS( handshaking)?(: Disconnected)?)?(, session=<\S+>)?\s*$
+
+ignoreregex =
+
+# DEV Notes:
+# * the first regex is essentially a copy of pam-generic.conf
+# * Probably doesn't do dovecot sql/ldap backends properly
+#
+# Author: Martin Waschbuesch
+#         Daniel Black (rewrote with begin and end anchors)
+#         Mail-in-a-Box (swapped session=...)

--- a/conf/fail2ban/jail.local
+++ b/conf/fail2ban/jail.local
@@ -1,0 +1,34 @@
+# Fail2Ban configuration file.
+# For Mail-in-a-Box
+[DEFAULT]
+
+# bantime in seconds
+bantime  = 60
+
+# This should ban dumb brute-force attacks, not oblivious users.
+findtime = 30
+maxretry = 20
+
+#
+# JAILS
+#
+
+[ssh]
+
+enabled  = true
+logpath  = /var/log/auth.log
+maxretry = 20
+
+[ssh-ddos]
+
+enabled  = true
+maxretry = 20
+
+[sasl]
+
+enabled  = true
+
+[dovecot]
+
+enabled = true
+filter  = dovecotimap

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -106,3 +106,11 @@ fi
 
 restart_service bind9
 restart_service resolvconf
+
+# ### Fail2Ban Service
+
+# Configure the Fail2Ban installation to prevent dumb bruce-force attacks against dovecot, postfix and ssh
+cp conf/fail2ban/jail.local /etc/fail2ban/jail.local
+cp conf/fail2ban/dovecotimap.conf /etc/fail2ban/filter.d/dovecotimap.conf
+
+restart_service fail2ban


### PR DESCRIPTION
Configure the Fail2Ban installation to prevent dumb bruce-force attacks against dovecot, postfix and ssh.

See #319.

I've tested my settings with [patator](https://github.com/lanjelot/patator) and it seems to work. Patator is a brute-forcer with different modules, i.e. `smtp_login` `ssh_login` `imap_login`. 

This configuration should ban brute-force attackers and not oblivious users. Therefore the bantime is only one minute, which for a brute-force could be a pain in the ass. For the "normal" user in my opinion its O.K. but this case should never happen because a "normal" user have to do 20 false attempts in just 30 seconds.

Fail2Ban is not configured for the web services, because I think for now it's out of scope, the attacker have to know the web service addresses (box.domain.tld/mail or box.domain.tld/admin or box.domain.tld/cloud) and most bots don't do / know that. It's much easier to attack the well-known ports.
