### PR TITLE
Change read_password() logic to catch short passwords

### DIFF
--- a/tools/mail.py
+++ b/tools/mail.py
@@ -28,13 +28,17 @@ def mgmt(cmd, data=None, is_json=False):
 	return resp
 
 def read_password():
-	first  = getpass.getpass('password: ')
-	second = getpass.getpass(' (again): ')
-	while first != second:
-		print('Passwords not the same. Try again.')
-		first  = getpass.getpass('password: ')
-		second = getpass.getpass(' (again): ')
-	return first
+    while True:
+        first = getpass.getpass('password: ')
+        if len(first) < 4:
+            print('Passwords must be at least four characters.')
+            continue
+        second = getpass.getpass(' (again): ')
+        if first != second:
+            print('Passwords not the same. Try again.')
+            continue
+        break
+    return first
 
 def setup_key_auth(mgmt_uri):
 	key = open('/var/lib/mailinabox/api.key').read().strip()


### PR DESCRIPTION
Currently read_password does not verify password length. But further down the chain, passwords are checked to make sure they are longer than four characters.

If during initial setup, the user enters a password that is shorter than four characters, this will not be caught here, but when the script actually calls management/mailconfig.py to add the user, it will fail without a chance to correct the short password.

The setup script will then continue without an inital user being created and this will confuse users.