### PR TITLE
allow the backup process to work after a hostname change

### DIFF
--- a/management/backup.py
+++ b/management/backup.py
@@ -191,7 +191,8 @@ def perform_backup(full_backup):
 			"--volsize", "250",
 			"--gpg-options", "--cipher-algo=AES256",
 			env["STORAGE_ROOT"],
-			"file://" + backup_dir
+			"file://" + backup_dir,
+                        "--allow-source-mismatch"
 			],
 			env_with_passphrase)
 	finally:


### PR DESCRIPTION
After a few days I of use, I had to change  the hostname of the server.
I am using an external dns, so at first I had to change things only there. But after a some days, I saw that daily backup was failing because of that. So I fixed it and because it might happen to someone else I am sharing the patch.