### PR TITLE
Enable php5-fpm slowlog

### DIFF
--- a/setup/web.sh
+++ b/setup/web.sh
@@ -36,6 +36,12 @@ tools/editconf.py /etc/nginx/nginx.conf -s \
 tools/editconf.py /etc/php5/fpm/pool.d/www.conf -c ';' \
 	pm.max_children=8
 
+# Enable PHP's slowlog to better diagnose slow running scripts
+tools/editconf.py /etc/php5/fpm/pool.d/www.conf -c ';' \
+	slowlog=/var/log/php5-fpm.log.slow
+tools/editconf.py /etc/php5/fpm/pool.d/www.conf -c ';' \
+	request_slowlog_timeout=600
+
 # Other nginx settings will be configured by the management service
 # since it depends on what domains we're serving, which we don't know
 # until mail accounts have been created.


### PR DESCRIPTION
This log can give additional information in case the server starts having timeouts. Seems like PHP is configured for a timeout of 600 (`max_execution_time` on `setup/owncloud.sh`). And nginx has a timeout of 630 for PHP on `conf/nginx.conf`.