### PR TITLE
softer the greylisting delay restriction

### DIFF
--- a/setup/mail-postfix.sh
+++ b/setup/mail-postfix.sh
@@ -172,7 +172,7 @@ tools/editconf.py /etc/postfix/main.cf \
 # Postfix connects to Postgrey on the 127.0.0.1 interface specifically. Ensure that
 # Postgrey listens on the same interface (and not IPv6, for instance).
 tools/editconf.py /etc/default/postgrey \
-	POSTGREY_OPTS=\"--inet=127.0.0.1:10023\"
+	POSTGREY_OPTS=\"--inet=127.0.0.1:10023 --delay=180\"
 
 # Increase the message size limit from 10MB to 128MB.
 # The same limit is specified in nginx.conf for mail submitted via webmail and Z-Push.

--- a/setup/mail-postfix.sh
+++ b/setup/mail-postfix.sh
@@ -171,6 +171,11 @@ tools/editconf.py /etc/postfix/main.cf \
 
 # Postfix connects to Postgrey on the 127.0.0.1 interface specifically. Ensure that
 # Postgrey listens on the same interface (and not IPv6, for instance).
+# A lot of legit mail servers try to resend before 300 seconds.
+# As a matter of fact RFC is not strict about retry timer so postfix and
+# other MTA have their own intervals. To fix the problem of receiving
+# e-mails really latter, delay of greylisting has been set to
+# 180 seconds (default is 300 seconds).
 tools/editconf.py /etc/default/postgrey \
 	POSTGREY_OPTS=\"--inet=127.0.0.1:10023 --delay=180\"
 


### PR DESCRIPTION
A lot of legit mail server try again between 200 and 285 seconds, then 3 hours later. Why ? RFC is not strict about retry timer so postfix and other MTA have their own intervals.
To fix the problem of receiving these e-mail really latter, I reduced the delay of postgrey to 180 seconds (default is 300 seconds).

Discussion: https://discourse.mailinabox.email/t/sometime-e-mail-come-3h30-later-to-the-mailbox/484