### PR TITLE
Dovecot lucene pull req

### DIFF
--- a/ppa/Makefile
+++ b/ppa/Makefile
@@ -41,10 +41,10 @@ build_dovecot_lucene:
 	(cd /tmp/build/dovecot-2.2.9; dpkg-buildpackage -S -us -uc -nc)
 
 	# Sign the packages.
-	#debsign /tmp/build/dovecot_2.2.9-1ubuntu2.1_amd64.changes
+	debsign /tmp/build/dovecot_2.2.9-1ubuntu2.2~ppa0~trusty0_source.changes
 
 	# Upload it.
-	#dput ppa:mail-in-a-box/ppa /tmp/build/dovecot_2.2.9-1ubuntu2.1_amd64.changes
+	dput ppa:mail-in-a-box/ppa /tmp/build/dovecot_2.2.9-1ubuntu2.2~ppa0~trusty0_source.changes
 
 	# TESTING BINARY PACKAGE
 	# Install build dependencies and build dependencies we've added in our patch,

--- a/ppa/dovecot_lucene.diff
+++ b/ppa/dovecot_lucene.diff
@@ -1,6 +1,6 @@
 --- a/debian/control
 +++ b/debian/control
-@@ -1,210 +1,22 @@
+@@ -1,210 +1,23 @@
  Source: dovecot
  Section: mail
  Priority: optional
@@ -13,11 +13,14 @@
 +Build-Depends: debhelper (>= 7.2.3~), dpkg-dev (>= 1.16.1), pkg-config, libssl-dev, libpam0g-dev, libldap2-dev, libpq-dev, libmysqlclient-dev, libsqlite3-dev, libsasl2-dev, zlib1g-dev, libkrb5-dev, drac-dev (>= 1.12-5), libbz2-dev, libdb-dev, libcurl4-gnutls-dev, libexpat-dev, libwrap0-dev, dh-systemd, po-debconf, lsb-release, libclucene-dev (>= 2.3), liblzma-dev, libexttextcat-dev, libstemmer-dev, hardening-wrapper, dh-autoreconf, autotools-dev
  Standards-Version: 3.9.4
  Homepage: http://dovecot.org/
- Vcs-Git: git://git.debian.org/git/collab-maint/dovecot.git
- Vcs-Browser: http://git.debian.org/?p=collab-maint/dovecot.git
+-Vcs-Git: git://git.debian.org/git/collab-maint/dovecot.git
+-Vcs-Browser: http://git.debian.org/?p=collab-maint/dovecot.git
++Vcs-Git: https://github.com/mail-in-a-box/mailinabox
++Vcs-Browser: https://github.com/mail-in-a-box/mailinabox
  
 -Package: dovecot-core
--Architecture: any
++Package: dovecot-lucene
+ Architecture: any
 -Depends: ${shlibs:Depends}, ${misc:Depends}, libpam-runtime (>= 0.76-13.1), openssl, adduser, ucf (>= 2.0020), ssl-cert (>= 1.0-11ubuntu1), lsb-base (>= 3.2-12ubuntu3)
 -Suggests: ntp, dovecot-gssapi, dovecot-sieve, dovecot-pgsql, dovecot-mysql, dovecot-sqlite, dovecot-ldap, dovecot-imapd, dovecot-pop3d, dovecot-lmtpd, dovecot-managesieved, dovecot-solr, ufw
 -Recommends: ntpdate
@@ -25,12 +28,14 @@
 -Replaces: dovecot-common (<< 1:2.0.14-2~), mailavenger (<< 0.8.1-4)
 -Breaks: dovecot-common (<< 1:2.0.14-2~), mailavenger (<< 0.8.1-4)
 -Description: secure POP3/IMAP server - core files
-- Dovecot is a mail server whose major goals are security and extreme
-- reliability. It tries very hard to handle all error conditions and verify
-- that all data is valid, making it nearly impossible to crash. It supports
-- mbox/Maildir and its own dbox/mdbox formats, and should also be pretty
-- fast, extensible, and portable.
-- .
++Depends: ${shlibs:Depends}, ${misc:Depends}, dovecot-core (>= 1:2.2.9-1ubuntu2.1)
++Description: secure POP3/IMAP server - Lucene support
+  Dovecot is a mail server whose major goals are security and extreme
+  reliability. It tries very hard to handle all error conditions and verify
+  that all data is valid, making it nearly impossible to crash. It supports
+  mbox/Maildir and its own dbox/mdbox formats, and should also be pretty
+  fast, extensible, and portable.
+  .
 - This package contains the Dovecot main server and its command line utility.
 -
 -Package: dovecot-dev
@@ -151,17 +156,15 @@
 - This package provides LDAP support for Dovecot.
 -
 -Package: dovecot-gssapi
-+Package: dovecot-lucene
- Architecture: any
- Depends: ${shlibs:Depends}, ${misc:Depends}, dovecot-core (= ${binary:Version})
+-Architecture: any
+-Depends: ${shlibs:Depends}, ${misc:Depends}, dovecot-core (= ${binary:Version})
 -Description: secure POP3/IMAP server - GSSAPI support
-+Description: secure POP3/IMAP server - Lucene support
-  Dovecot is a mail server whose major goals are security and extreme
-  reliability. It tries very hard to handle all error conditions and verify
-  that all data is valid, making it nearly impossible to crash. It supports
-  mbox/Maildir and its own dbox/mdbox formats, and should also be pretty
-  fast, extensible, and portable.
-  .
+- Dovecot is a mail server whose major goals are security and extreme
+- reliability. It tries very hard to handle all error conditions and verify
+- that all data is valid, making it nearly impossible to crash. It supports
+- mbox/Maildir and its own dbox/mdbox formats, and should also be pretty
+- fast, extensible, and portable.
+- .
 - This package provides GSSAPI authentication support for Dovecot.
 -
 -Package: dovecot-sieve
@@ -216,7 +219,9 @@
 - This package contains configuration files for dovecot.
 - .
 - This package modifies postfix's configuration to integrate with dovecot
-+ This package provides Lucene full text search support for Dovecot.
++ This package provides Lucene full text search support for Dovecot. It has been modified by Mail-in-a-Box
++ to supply a dovecot-lucene package compatible with the official ubuntu trusty dovecot-core.
+
 diff --git a/debian/dovecot-lucene.links b/debian/dovecot-lucene.links
 new file mode 100644
 index 0000000..6ffcbeb
@@ -247,11 +252,9 @@ index 0000000..3d933a5
 +++ b/debian/dovecot-lucene.triggers
 @@ -0,0 +1 @@
 +activate register-dovecot-plugin
-diff --git a/debian/rules b/debian/rules
-index dcee2f6..9533a4a 100755
 --- a/debian/rules
 +++ b/debian/rules
-@@ -40,6 +40,7 @@ config-stamp: configure
+@@ -40,6 +40,7 @@
  		        --with-solr \
  	            --with-ioloop=best \
  	            --with-libwrap \
@@ -259,7 +262,7 @@ index dcee2f6..9533a4a 100755
  	            --host=$(DEB_HOST_GNU_TYPE) \
  	            --build=$(DEB_BUILD_GNU_TYPE) \
  	            --prefix=/usr \
-@@ -95,6 +96,10 @@ install: build
+@@ -95,6 +96,10 @@
  	dh_testroot
  	dh_clean -k
  	dh_installdirs
@@ -270,7 +273,7 @@ index dcee2f6..9533a4a 100755
  	$(MAKE) install DESTDIR=$(CURDIR)/debian/dovecot-core
  	$(MAKE) -C $(PIGEONHOLE_DIR) install DESTDIR=$(CURDIR)/debian/dovecot-core
  	rm `find $(CURDIR)/debian -name '*.la'`
-@@ -209,7 +214,7 @@ binary-arch: build install
+@@ -209,7 +214,7 @@
  	dh_installdocs -a
  	dh_installexamples -a
  	dh_installpam -a
@@ -279,7 +282,7 @@ index dcee2f6..9533a4a 100755
  	dh_systemd_enable
  	dh_installinit -pdovecot-core --name=dovecot
  	dh_systemd_start
-@@ -220,10 +225,10 @@ binary-arch: build install
+@@ -220,10 +225,10 @@
  	dh_lintian -a
  	dh_installchangelogs -a ChangeLog
  	dh_link -a
@@ -292,3 +295,25 @@ index dcee2f6..9533a4a 100755
  	dh_makeshlibs -a -n
  	dh_installdeb -a
  	dh_shlibdeps -a
+--- a/debian/changelog
++++ a/debian/changelog
+@@ -1,3 +1,9 @@
++dovecot (1:2.2.9-1ubuntu2.2~ppa0~trusty0) trusty; urgency=low
++
++  * Changed to just build dovecot-lucene for Mail-in-a-box PPA
++
++ -- Joshua Tauberer <jt@occams.info>  Sat, 14 May 2015 16:13:00 -0400
++
+ dovecot (1:2.2.9-1ubuntu2.1) trusty-security; urgency=medium
+ 
+   * SECURITY UPDATE: denial of service via SSL connection exhaustion
+--- a/debian/copyright	2014-03-07 07:26:37.000000000 -0500
++++ b/debian/copyright	2015-05-23 18:17:42.668005535 -0400
+@@ -1,3 +1,7 @@
++This package is a fork by Mail-in-a-box (https://mailinabox.email). Original 
++copyright statement follows:
++----------------------------------------------------------------------------
++
+ This package was debianized by Jaldhar H. Vyas <jaldhar@debian.org> on
+ Tue,  3 Dec 2002 01:10:07 -0500.
+ 

--- a/setup/lucene.sh
+++ b/setup/lucene.sh
@@ -44,5 +44,5 @@ EOF
 chown -R mail:dovecot /etc/dovecot
 chmod -R o-rwx /etc/dovecot
 
-# Restart services to reload solr schema & dovecot plugins
+# Restart services to reload dovecot plugins
 restart_service dovecot

--- a/setup/lucene.sh
+++ b/setup/lucene.sh
@@ -18,6 +18,9 @@ source /etc/mailinabox.conf # load global vars
 # Add official ppa
 hide_output add-apt-repository -y ppa:brock/mailinabox-brocktice
 
+# Update apt
+hide_output apt-get update
+
 # Install packages
 apt_install dovecot-lucene
 

--- a/setup/lucene.sh
+++ b/setup/lucene.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# IMAP search with lucene
+# --------------------------------
+#
+# Adapted from https://github.com/Jonty/mailinabox/blob/solr_support/setup/solr.sh
+#
+# By default dovecot uses its own Squat search index that has awful performance
+# on large mailboxes. Dovecot 2.1+ has support for using Lucene internally but
+# this didn't make it into the Ubuntu packages, so we maintain our own
+# dovecot-lucene package in a ppa.
+
+source setup/functions.sh # load our functions
+source /etc/mailinabox.conf # load global vars
+
+# Install packages and basic configuation
+# ---------------------------------------
+
+# Add official ppa
+hide_output add-apt-repository -y ppa:brock/mailinabox-brocktice
+
+# Install packages
+apt_install dovecot-lucene
+
+# Update the dovecot plugin configuration
+#
+# Break-imap-search makes search work the way users expect, rather than the way
+# the IMAP specification expects
+tools/editconf.py /etc/dovecot/conf.d/10-mail.conf \
+        mail_plugins="$mail_plugins fts fts_lucene"
+
+cat > /etc/dovecot/conf.d/90-plugin.conf << EOF;
+plugin {
+  fts = lucene
+  fts_lucene = whitespace_chars=@.
+}
+EOF
+
+# PERMISSIONS
+
+# Ensure configuration files are owned by dovecot and not world readable.
+chown -R mail:dovecot /etc/dovecot
+chmod -R o-rwx /etc/dovecot
+
+# Restart services to reload solr schema & dovecot plugins
+restart_service dovecot

--- a/setup/lucene.sh
+++ b/setup/lucene.sh
@@ -16,7 +16,7 @@ source /etc/mailinabox.conf # load global vars
 # ---------------------------------------
 
 # Add official ppa
-hide_output add-apt-repository -y ppa:brock/mailinabox-brocktice
+hide_output add-apt-repository -y ppa:mail-in-a-box/ppa
 
 # Update apt
 hide_output apt-get update

--- a/setup/start.sh
+++ b/setup/start.sh
@@ -139,6 +139,7 @@ source setup/mail-postfix.sh
 source setup/mail-dovecot.sh
 source setup/mail-users.sh
 source setup/dkim.sh
+source setup/lucene.sh
 source setup/spamassassin.sh
 source setup/web.sh
 source setup/webmail.sh


### PR DESCRIPTION
This sets everything up for using the official MIAB PPA to serve a dovecot-lucene package compatible with the official dovecot-core. It also makes all changes necessary to enable lucene for full-text search in dovecot.

The source package will have to be built and uploaded to the PPA by the maintainer, after which launchpad will build the package. There is a working version of the package on my PPA here:

https://launchpad.net/~brock/+archive/ubuntu/mailinabox-brocktice

Please accept my apologies for any problems here, I have done my best to correctly cherry-pick the required changes.