### PR TITLE
remove unnecessary munin source call

### DIFF
--- a/setup/start.sh
+++ b/setup/start.sh
@@ -158,9 +158,6 @@ tools/web_update
 # If there aren't any mail users yet, create one.
 source setup/firstuser.sh
 
-# Grant admins access to Munin
-source tools/munin_update.sh
-
 # Done.
 echo
 echo "-----------------------------------------------"


### PR DESCRIPTION
Due to a9ed9ae93643170bd1bc9557e4dcab3d0c8fb4f3 not necessary anymore.