### PR TITLE
Added fix to allow access to all files under owncloud webdav.

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -54,8 +54,8 @@ server {
 		alias /var/lib/mailinabox/mozilla-autoconfig.xml;
 	}
 
-	# Disable viewing dotfiles (.htaccess, .svn, .git, etc.)
-	location ~ /\.(ht|svn|git|hg|bzr) {
+	# Disable viewing dotfiles (.htaccess, .svn, .git, etc.), but not under php-controlled pages
+	location ~ ^/(?!.*\.php).*/\.(ht|svn|git|bzr)$ {
 		log_not_found off;
 		access_log off;
 		deny all;


### PR DESCRIPTION
The nginx config blocks dotfiles, which prevents any of those dotfiles from being accessed in ownCloud. This fix allows access to everything under ownCloud webdav while still keeping the dotfile restrictions elsewhere.