### PR TITLE
Use lowercase h for consistency in aliases template - it reads better…

### DIFF
--- a/management/mailconfig.py
+++ b/management/mailconfig.py
@@ -135,7 +135,7 @@ def get_mail_users_ex(env, with_archived=False, with_slow_info=False):
 				mbox = os.path.join(root, domain, user)
 				if email in active_accounts: continue
 				user = {
-					"email": email, 
+					"email": email,
 					"privileges": "",
 					"status": "inactive",
 					"mailbox": mbox,
@@ -313,7 +313,7 @@ def add_mail_user(email, pw, privs, env):
 def set_mail_password(email, pw, env):
 	# validate that password is acceptable
 	validate_password(pw)
-	
+
 	# hash the password
 	pw = hash_password(pw)
 
@@ -416,7 +416,7 @@ def add_mail_alias(source, destination, env, update_if_exists=False, do_kick=Tru
 	# validate destination
 	dests = []
 	destination = destination.strip()
-	
+
 	# Postfix allows a single @domain.tld as the destination, which means
 	# the local part on the address is preserved in the rewrite. We must
 	# try to convert Unicode to IDNA first before validating that it's a
@@ -511,7 +511,7 @@ def get_required_aliases(env):
 def kick(env, mail_result=None):
 	results = []
 
-	# Inclde the current operation's result in output.
+	# Include the current operation's result in output.
 
 	if mail_result is not None:
 		results.append(mail_result + "\n")

--- a/management/templates/aliases.html
+++ b/management/templates/aliases.html
@@ -57,7 +57,7 @@
   </tbody>
 </table>
 
-<p style="margin-top: 1.5em"><small>Hostmaster@, postmaster@, and admin@ email addresses are required on some domains.</small></p>
+<p style="margin-top: 1.5em"><small>hostmaster@, postmaster@, and admin@ email addresses are required on some domains.</small></p>
 
 <div style="display: none">
   <table>


### PR DESCRIPTION
… (IMO!)

This also includes fixes for a typo and some whitespace inconsistencies in
mailconfig.py. In fact the capitalisation change and those fixes are the
remnants of a patch I had been running that changed the default aliases - it
was through developing it that I found the issues.

(I wanted to bring the number of patches I apply before deploying to zero and
in the case of this one I've come to view the way MIAB already is as superior,
so I've undone the core of my patch and these tiny issues are all that remain).