### PR TITLE
Don't expose php version in favor of #433 hide php version

### DIFF
--- a/setup/web.sh
+++ b/setup/web.sh
@@ -80,6 +80,10 @@ if [ -L /etc/init.d/php-fastcgi ]; then
 	apt-get -y purge php5-cgi #NODOC
 fi
 
+# Don't expose the php version
+tools/editconf.py /etc/nginx/fastcgi_params \
+	 "fastcgi_param PHP_VALUE \"expose_php"="Off\";"
+
 # Remove obsoleted scripts. #NODOC
 # exchange-autodiscover is now handled by Z-Push. #NODOC
 for f in webfinger exchange-autodiscover; do #NODOC


### PR DESCRIPTION
Hide the php version in favor of #433!
Sorry @JoshData but I didn't figure out how to use your `editconf.py` script correctly. So I have this dirty hack here (key: fastcgi_param PHP_VALUE \"expose_php, value: Off\";).

Because this one:
```
tools/editconf.py /etc/nginx/fastcgi_params \
	 fastcgi_param="PHP_VALUE \"expose_php = Off\";"
```
results in:
```
 fastcgi_param=PHP_VALUE "expose_php = Off";
```

and 

```
tools/editconf.py /etc/nginx/fastcgi_params -s\
	 fastcgi_param="PHP_VALUE \"expose_php = Off\";"
```
results in the correct parameters:
```
 fastcgi_param PHP_VALUE "expose_php = Off";
```
but comment the other values out.
