### PR TITLE
Increase DKIM key length to 2048

### DIFF
--- a/setup/dkim.sh
+++ b/setup/dkim.sh
@@ -41,7 +41,7 @@ fi
 # entry which we'll want to include in our DNS setup.
 if [ ! -f "$STORAGE_ROOT/mail/dkim/mail.private" ]; then
 	# Should we specify -h rsa-sha256?
-	opendkim-genkey -r -s mail -D $STORAGE_ROOT/mail/dkim
+	opendkim-genkey -b 2048 -r -s mail -D $STORAGE_ROOT/mail/dkim
 fi
 
 # Ensure files are owned by the opendkim user and are private otherwise.


### PR DESCRIPTION
Currently MiaB creates 1024 bit keys which is seen as a minimum standard
by several providers such as Google who already uses a 2048 bit key.
Increasing the keysize beyond 2048 is an issue as it often goes beyond
supported DNS record sizes.