### PR TITLE
Z-Push autoconfiguration fails due to URL case sensitivity 

### DIFF
--- a/conf/nginx-alldomains.conf
+++ b/conf/nginx-alldomains.conf
@@ -55,7 +55,7 @@
 		# file upload limit to match the corresponding Postfix limit.
 		client_max_body_size 128M;
 	}
-	location /autodiscover/autodiscover.xml {
+	location ~* ^/autodiscover/autodiscover.xml$ {
 		include fastcgi_params;
 		fastcgi_param SCRIPT_FILENAME /usr/local/lib/z-push/autodiscover/autodiscover.php;
 		fastcgi_param PHP_VALUE "include_path=.:/usr/share/php:/usr/share/pear:/usr/share/awl/inc";


### PR DESCRIPTION
Recently I noticed that autoconfiguration for Z-Push on my iPhone didn't work. I found the following lines in my log file:

    2015/06/25 01:51:18 [error] 1345#0: *2168 open() "/home/user-data/www/schiller.im/Autodiscover/Autodiscover.xml" failed (2: No such file or directory), client: 109.84.3.226, server: schiller.im, request: "POST /Autodiscover/Autodiscover.xml HTTP/1.1", host: "schiller.im"

I fixed this by making the location match directive case insensive.