### PR TITLE
Add support for bidirectional mail alias controls

### DIFF
--- a/management/daemon.py
+++ b/management/daemon.py
@@ -45,7 +45,7 @@ def authorized_personnel_only(viewfunc):
 
 		# Authorized to access an API view?
 		if "admin" in privs:
-			# Call view func.	
+			# Call view func.
 			return viewfunc(*args, **kwargs)
 		elif not error:
 			error = "You are not an administrator."
@@ -179,7 +179,7 @@ def mail_aliases():
 	if request.args.get("format", "") == "json":
 		return json_response(get_mail_aliases_ex(env))
 	else:
-		return "".join(x+"\t"+y+"\n" for x, y in get_mail_aliases(env))
+		return "".join(source+"\t"+destination+"\t"+applies_inbound+"\t"+applies_outbound+"\n" for source, destination, applies_inbound, applies_outbound in get_mail_aliases(env))
 
 @app.route('/mail/aliases/add', methods=['POST'])
 @authorized_personnel_only
@@ -187,6 +187,8 @@ def mail_aliases_add():
 	return add_mail_alias(
 		request.form.get('source', ''),
 		request.form.get('destination', ''),
+		request.form.get('applies_inbound', '') == '1',
+		request.form.get('applies_outbound', '') == '1',
 		env,
 		update_if_exists=(request.form.get('update_if_exists', '') == '1')
 		)
@@ -283,7 +285,7 @@ def dns_set_record(qname, rtype="A"):
 				# make this action set (replace all records for this
 				# qname-rtype pair) rather than add (add a new record).
 				action = "set"
-		
+
 		elif request.method == "DELETE":
 			if value == '':
 				# Delete all records for this qname-type pair.

--- a/management/daemon.py
+++ b/management/daemon.py
@@ -179,16 +179,15 @@ def mail_aliases():
 	if request.args.get("format", "") == "json":
 		return json_response(get_mail_aliases_ex(env))
 	else:
-		return "".join(source+"\t"+destination+"\t"+applies_inbound+"\t"+applies_outbound+"\n" for source, destination, applies_inbound, applies_outbound in get_mail_aliases(env))
+		return "".join(address+"\t"+receivers+"\t"+senders+"\n" for address, receivers, senders in get_mail_aliases(env))
 
 @app.route('/mail/aliases/add', methods=['POST'])
 @authorized_personnel_only
 def mail_aliases_add():
 	return add_mail_alias(
-		request.form.get('source', ''),
-		request.form.get('destination', ''),
-		request.form.get('applies_inbound', '') == '1',
-		request.form.get('applies_outbound', '') == '1',
+		request.form.get('address', ''),
+		request.form.get('receivers', ''),
+		request.form.get('senders', ''),
 		env,
 		update_if_exists=(request.form.get('update_if_exists', '') == '1')
 		)

--- a/management/daemon.py
+++ b/management/daemon.py
@@ -195,7 +195,7 @@ def mail_aliases_add():
 @app.route('/mail/aliases/remove', methods=['POST'])
 @authorized_personnel_only
 def mail_aliases_remove():
-	return remove_mail_alias(request.form.get('source', ''), env)
+	return remove_mail_alias(request.form.get('address', ''), env)
 
 @app.route('/mail/domains')
 @authorized_personnel_only

--- a/management/templates/aliases.html
+++ b/management/templates/aliases.html
@@ -7,7 +7,7 @@
 
 <h3>Add a mail alias</h3>
 
-<p>Aliases are email forwarders. An alias can forward email to a <a href="javascript:show_panel('users')">mail user</a> or to any email address.</p>
+<p>An alias can forward email to a <a href="javascript:show_panel('users')">mail user</a> or to any email address. You can separately grant permission to one or more users to send as an alias.</p>
 
 <form class="form-horizontal" role="form" onsubmit="do_add_alias(); return false;">
   <div class="form-group">
@@ -31,20 +31,15 @@
     </div>
   </div>
   <div class="form-group">
-    <label for="addaliasDirection" class="col-sm-1 control-label">Direction</label>
+    <label for="addaliasReceivers" class="col-sm-1 control-label">Forwards To</label>
     <div class="col-sm-10">
-      <select class="form-control" id="addaliasDirection">
-        <option value="disabled">Disabled</option>
-        <option value="outbound">Outbound only</option>
-        <option value="inbound">Inbound only</option>
-        <option value="bidirectional">Both</option>
-      </select>
+      <textarea class="form-control" rows="3" id="addaliasReceivers"></textarea>
     </div>
   </div>
   <div class="form-group">
-    <label for="addaliasTargets" class="col-sm-1 control-label">Forward To</label>
+    <label for="addaliasSenders" class="col-sm-1 control-label">Permitted Senders</label>
     <div class="col-sm-10">
-      <textarea class="form-control" rows="3" id="addaliasTargets"></textarea>
+      <textarea class="form-control" rows="3" id="addaliasSenders"></textarea>
     </div>
   </div>
   <div class="form-group">
@@ -61,8 +56,8 @@
     <tr>
       <th></th>
       <th>Alias<br></th>
-      <th>Direction</th>
       <th>Forwards To</th>
+      <th>Permitted Senders</th>
     </tr>
   </thead>
   <tbody>
@@ -83,8 +78,8 @@
         </a>
     </td>
     <td class='email'> </td>
-    <td class='direction'> </td>
-    <td class='target'> </td>
+    <td class='receivers'> </td>
+    <td class='senders'> </td>
   </tr>
   </table>
 </div>
@@ -111,23 +106,12 @@ function show_aliases() {
           n.attr('id', '');
 
           if (alias.required) n.addClass('alias-required');
-          n.attr('data-email', alias.source_display); // this is decoded from IDNA, but will get re-coded to IDNA on the backend
-          n.find('td.email').text(alias.source_display)
-          if (!alias.applies_inbound && !alias.applies_outbound) {
-            n.find('td.direction').text('')
-            n.attr('data-direction', 'disabled');
-          } else if (!alias.applies_inbound && alias.applies_outbound) {
-            n.find('td.direction').text('↤')
-            n.attr('data-direction', 'outbound');
-          } else if (alias.applies_inbound && !alias.applies_outbound) {
-            n.find('td.direction').text('↦')
-            n.attr('data-direction', 'inbound');
-          } else if (alias.applies_inbound && alias.applies_outbound) {
-            n.find('td.direction').text('↮')
-            n.attr('data-direction', 'bidirectional');
-          }
-          for (var j = 0; j < alias.destination.length; j++)
-            n.find('td.target').append($("<div></div>").text(alias.destination[j]))
+          n.attr('data-email', alias.address_display); // this is decoded from IDNA, but will get re-coded to IDNA on the backend
+          n.find('td.email').text(alias.address_display)
+          for (var j = 0; j < alias.receivers.length; j++)
+            n.find('td.receivers').append($("<div></div>").text(alias.receivers[j]))
+          for (var j = 0; j < alias.senders.length; j++)
+            n.find('td.senders').append($("<div></div>").text(alias.senders[j]))
           $('#alias_table tbody').append(n);
         }
       }
@@ -140,22 +124,22 @@ function show_aliases() {
       if ($(this).attr('data-mode') == "regular") {
         $('#addaliasEmail').attr('type', 'email');
         $('#addaliasEmail').attr('placeholder', 'incoming email address (e.g. you@yourdomain.com)');
-        $('#addaliasDirection').val('bidirectional');
-      	$('#addaliasTargets').attr('placeholder', 'forward to these email addresses (one per line or separated by commas)');
+        $('#addaliasReceivers').attr('placeholder', 'forward to these email addresses (one per line or separated by commas)');
+        $('#addaliasSenders').attr('placeholder', 'allow these users to send as this alias (one per line or separated by commas)');
         $('#alias_mode_info').slideUp();
       } else if ($(this).attr('data-mode') == "catchall") {
         $('#addaliasEmail').attr('type', 'text');
         $('#addaliasEmail').attr('placeholder', 'incoming catch-all address (e.g. @yourdomain.com)');
-        $('#addaliasDirection').val('outbound');
-        $('#addaliasTargets').attr('placeholder', 'forward to these email addresses (one per line or separated by commas)');
+        $('#addaliasReceivers').attr('placeholder', 'forward to these email addresses (one per line or separated by commas)');
+        $('#addaliasSenders').attr('placeholder', 'allow these users to send as any address on this domain (one per line or separated by commas)');
         $('#alias_mode_info').slideDown();
         $('#alias_mode_info span').addClass('hidden');
         $('#alias_mode_info span.catchall').removeClass('hidden');
       } else if ($(this).attr('data-mode') == "domainalias") {
         $('#addaliasEmail').attr('type', 'text');
         $('#addaliasEmail').attr('placeholder', 'incoming domain (@yourdomain.com)');
-        $('#addaliasDirection').val('inbound');
-        $('#addaliasTargets').attr('placeholder', 'forward to domain (@yourdomain.com)');
+        $('#addaliasReceivers').attr('placeholder', 'forward to domain (@yourdomain.com)');
+        $('#addaliasSenders').attr('placeholder', 'allow these users to send as any address on this domain (one per line or separated by commas)');
         $('#alias_mode_info').slideDown();
         $('#alias_mode_info span').addClass('hidden');
         $('#alias_mode_info span.domainalias').removeClass('hidden');
@@ -168,18 +152,17 @@ function show_aliases() {
 var is_alias_add_update = false;
 function do_add_alias() {
   var title = (!is_alias_add_update) ? "Add Alias" : "Update Alias";
-  var email = $("#addaliasEmail").val();
-  var direction = $("#addaliasDirection").val();
-  var targets = $("#addaliasTargets").val();
+  var form_address = $("#addaliasEmail").val();
+  var form_receivers = $("#addaliasReceivers").val();
+  var form_senders = $("#addaliasSenders").val();
   api(
     "/mail/aliases/add",
     "POST",
     {
       update_if_exists: is_alias_add_update ? '1' : '0',
-      source: email,
-      destination: targets,
-      applies_inbound: (direction == 'bidirectional' || direction == 'inbound') ? '1' : '0',
-      applies_outbound: (direction == 'bidirectional' || direction == 'outbound') ? '1' : '0'
+      address: form_address,
+      receivers: form_receivers,
+      senders: form_senders
     },
     function(r) {
       // Responses are multiple lines of pre-formatted text.
@@ -196,13 +179,8 @@ function do_add_alias() {
 function aliases_reset_form() {
   $("#addaliasEmail").prop('disabled', false);
   $("#addaliasEmail").val('')
-  if ($('#alias_type_buttons button').attr('data-mode') == "regular")
-    $('#addaliasDirection').val('bidirectional');
-  else if ($('#alias_type_buttons button').attr('data-mode') == "catchall")
-    $('#alias_type_buttons').val('outbound');
-  else if ($('#addaliasDirection button').attr('data-mode') == "domainalias")
-    $('#addaliasDirection').val('inbound');
-  $("#addaliasTargets").val('')
+  $("#addaliasReceivers").val('')
+  $("#addaliasSenders").val('')
   $('#alias-cancel').addClass('hidden');
   $('#add-alias-button').text('Add Alias');
   is_alias_add_update = false;
@@ -210,12 +188,15 @@ function aliases_reset_form() {
 
 function aliases_edit(elem) {
   var email = $(elem).parents('tr').attr('data-email');
-  var targetdivs = $(elem).parents('tr').find('.target div');
-  var targets = "";
-  for (var i = 0; i < targetdivs.length; i++)
-    targets += $(targetdivs[i]).text() + "\n";
-  var direction = $(elem).parents('tr').attr('data-direction')
-  if (email.charAt(0) == '@' && targets.charAt(0) == '@')
+  var receiverdivs = $(elem).parents('tr').find('.receivers div');
+  var senderdivs = $(elem).parents('tr').find('.senders div');
+  var receivers = "";
+  for (var i = 0; i < receiverdivs.length; i++)
+    receivers += $(receiverdivs[i]).text() + "\n";
+  var senders = "";
+  for (var i = 0; i < senderdivs.length; i++)
+    senders += $(senderdivs[i]).text() + "\n";
+  if (email.charAt(0) == '@' && receivers.charAt(0) == '@')
     $('#alias_type_buttons button[data-mode="domainalias"]').click();
   else if (email.charAt(0) == '@')
     $('#alias_type_buttons button[data-mode="catchall"]').click();
@@ -224,15 +205,15 @@ function aliases_edit(elem) {
   $('#alias-cancel').removeClass('hidden');
   $("#addaliasEmail").prop('disabled', true);
   $("#addaliasEmail").val(email);
-  $('#addaliasDirection').val(direction);
-  $("#addaliasTargets").val(targets);
+  $("#addaliasReceivers").val(receivers);
+  $("#addaliasSenders").val(senders);
   $('#add-alias-button').text('Update');
   $('body').animate({ scrollTop: 0 })
   is_alias_add_update = true;
 }
 
 function aliases_remove(elem) {
-  var email = $(elem).parents('tr').attr('data-email');
+  var row_address = $(elem).parents('tr').attr('data-email');
   show_modal_confirm(
     "Remove Alias",
     "Remove " + email + "?",
@@ -242,7 +223,7 @@ function aliases_remove(elem) {
         "/mail/aliases/remove",
         "POST",
         {
-          source: email
+          address: row_address
         },
         function(r) {
           // Responses are multiple lines of pre-formatted text.

--- a/management/templates/aliases.html
+++ b/management/templates/aliases.html
@@ -216,7 +216,7 @@ function aliases_remove(elem) {
   var row_address = $(elem).parents('tr').attr('data-email');
   show_modal_confirm(
     "Remove Alias",
-    "Remove " + email + "?",
+    "Remove " + row_address + "?",
     "Remove",
     function() {
       api(

--- a/management/templates/aliases.html
+++ b/management/templates/aliases.html
@@ -24,9 +24,9 @@
     </div>
   </div>
   <div class="form-group">
-    <label for="addaliasEmail" class="col-sm-1 control-label">Alias</label>
+    <label for="addaliasAddress" class="col-sm-1 control-label">Alias</label>
     <div class="col-sm-10">
-      <input type="email" class="form-control" id="addaliasEmail">
+      <input type="email" class="form-control" id="addaliasAddress">
       <div style="margin-top: 3px; padding-left: 3px; font-size: 90%" class="text-muted">You may use international (non-ASCII) characters for the domain part of the email address only.</div>
     </div>
   </div>
@@ -77,7 +77,7 @@
           <span class="glyphicon glyphicon-trash"></span>
         </a>
     </td>
-    <td class='email'> </td>
+    <td class='address'> </td>
     <td class='receivers'> </td>
     <td class='senders'> </td>
   </tr>
@@ -106,8 +106,8 @@ function show_aliases() {
           n.attr('id', '');
 
           if (alias.required) n.addClass('alias-required');
-          n.attr('data-email', alias.address_display); // this is decoded from IDNA, but will get re-coded to IDNA on the backend
-          n.find('td.email').text(alias.address_display)
+          n.attr('data-address', alias.address_display); // this is decoded from IDNA, but will get re-coded to IDNA on the backend
+          n.find('td.address').text(alias.address_display)
           for (var j = 0; j < alias.receivers.length; j++)
             n.find('td.receivers').append($("<div></div>").text(alias.receivers[j]))
           for (var j = 0; j < alias.senders.length; j++)
@@ -122,22 +122,22 @@ function show_aliases() {
       $('#alias_type_buttons button').removeClass('active');
       $(this).addClass('active');
       if ($(this).attr('data-mode') == "regular") {
-        $('#addaliasEmail').attr('type', 'email');
-        $('#addaliasEmail').attr('placeholder', 'incoming email address (e.g. you@yourdomain.com)');
+        $('#addaliasAddress').attr('type', 'email');
+        $('#addaliasAddress').attr('placeholder', 'incoming email address (e.g. you@yourdomain.com)');
         $('#addaliasReceivers').attr('placeholder', 'forward to these email addresses (one per line or separated by commas)');
         $('#addaliasSenders').attr('placeholder', 'allow these users to send as this alias (one per line or separated by commas)');
         $('#alias_mode_info').slideUp();
       } else if ($(this).attr('data-mode') == "catchall") {
-        $('#addaliasEmail').attr('type', 'text');
-        $('#addaliasEmail').attr('placeholder', 'incoming catch-all address (e.g. @yourdomain.com)');
+        $('#addaliasAddress').attr('type', 'text');
+        $('#addaliasAddress').attr('placeholder', 'incoming catch-all address (e.g. @yourdomain.com)');
         $('#addaliasReceivers').attr('placeholder', 'forward to these email addresses (one per line or separated by commas)');
         $('#addaliasSenders').attr('placeholder', 'allow these users to send as any address on this domain (one per line or separated by commas)');
         $('#alias_mode_info').slideDown();
         $('#alias_mode_info span').addClass('hidden');
         $('#alias_mode_info span.catchall').removeClass('hidden');
       } else if ($(this).attr('data-mode') == "domainalias") {
-        $('#addaliasEmail').attr('type', 'text');
-        $('#addaliasEmail').attr('placeholder', 'incoming domain (@yourdomain.com)');
+        $('#addaliasAddress').attr('type', 'text');
+        $('#addaliasAddress').attr('placeholder', 'incoming domain (@yourdomain.com)');
         $('#addaliasReceivers').attr('placeholder', 'forward to domain (@yourdomain.com)');
         $('#addaliasSenders').attr('placeholder', 'allow these users to send as any address on this domain (one per line or separated by commas)');
         $('#alias_mode_info').slideDown();
@@ -152,7 +152,7 @@ function show_aliases() {
 var is_alias_add_update = false;
 function do_add_alias() {
   var title = (!is_alias_add_update) ? "Add Alias" : "Update Alias";
-  var form_address = $("#addaliasEmail").val();
+  var form_address = $("#addaliasAddress").val();
   var form_receivers = $("#addaliasReceivers").val();
   var form_senders = $("#addaliasSenders").val();
   api(
@@ -177,8 +177,8 @@ function do_add_alias() {
 }
 
 function aliases_reset_form() {
-  $("#addaliasEmail").prop('disabled', false);
-  $("#addaliasEmail").val('')
+  $("#addaliasAddress").prop('disabled', false);
+  $("#addaliasAddress").val('')
   $("#addaliasReceivers").val('')
   $("#addaliasSenders").val('')
   $('#alias-cancel').addClass('hidden');
@@ -187,7 +187,7 @@ function aliases_reset_form() {
 }
 
 function aliases_edit(elem) {
-  var email = $(elem).parents('tr').attr('data-email');
+  var address = $(elem).parents('tr').attr('data-address');
   var receiverdivs = $(elem).parents('tr').find('.receivers div');
   var senderdivs = $(elem).parents('tr').find('.senders div');
   var receivers = "";
@@ -196,15 +196,15 @@ function aliases_edit(elem) {
   var senders = "";
   for (var i = 0; i < senderdivs.length; i++)
     senders += $(senderdivs[i]).text() + "\n";
-  if (email.charAt(0) == '@' && receivers.charAt(0) == '@')
+  if (address.charAt(0) == '@' && receivers.charAt(0) == '@')
     $('#alias_type_buttons button[data-mode="domainalias"]').click();
-  else if (email.charAt(0) == '@')
+  else if (address.charAt(0) == '@')
     $('#alias_type_buttons button[data-mode="catchall"]').click();
   else
     $('#alias_type_buttons button[data-mode="regular"]').click();
   $('#alias-cancel').removeClass('hidden');
-  $("#addaliasEmail").prop('disabled', true);
-  $("#addaliasEmail").val(email);
+  $("#addaliasAddress").prop('disabled', true);
+  $("#addaliasAddress").val(address);
   $("#addaliasReceivers").val(receivers);
   $("#addaliasSenders").val(senders);
   $('#add-alias-button').text('Update');
@@ -213,7 +213,7 @@ function aliases_edit(elem) {
 }
 
 function aliases_remove(elem) {
-  var row_address = $(elem).parents('tr').attr('data-email');
+  var row_address = $(elem).parents('tr').attr('data-address');
   show_modal_confirm(
     "Remove Alias",
     "Remove " + row_address + "?",

--- a/management/templates/aliases.html
+++ b/management/templates/aliases.html
@@ -13,7 +13,7 @@
   <div class="form-group">
     <div class="col-sm-offset-1 col-sm-11">
       <div id="alias_type_buttons" class="btn-group btn-group-xs">
-        <button type="button" class="btn btn-default active" data-mode="regular">Regular</button>
+        <button type="button" class="btn btn-default" data-mode="regular">Regular</button>
         <button type="button" class="btn btn-default" data-mode="catchall">Catch-All</button>
         <button type="button" class="btn btn-default" data-mode="domainalias">Domain Alias</button>
       </div>
@@ -28,6 +28,17 @@
     <div class="col-sm-10">
       <input type="email" class="form-control" id="addaliasEmail">
       <div style="margin-top: 3px; padding-left: 3px; font-size: 90%" class="text-muted">You may use international (non-ASCII) characters for the domain part of the email address only.</div>
+    </div>
+  </div>
+  <div class="form-group">
+    <label for="addaliasDirection" class="col-sm-1 control-label">Direction</label>
+    <div class="col-sm-10">
+      <select class="form-control" id="addaliasDirection">
+        <option value="disabled">Disabled</option>
+        <option value="outbound">Outbound only</option>
+        <option value="inbound">Inbound only</option>
+        <option value="bidirectional">Both</option>
+      </select>
     </div>
   </div>
   <div class="form-group">
@@ -50,6 +61,7 @@
     <tr>
       <th></th>
       <th>Alias<br></th>
+      <th>Direction</th>
       <th>Forwards To</th>
     </tr>
   </thead>
@@ -71,6 +83,7 @@
         </a>
     </td>
     <td class='email'> </td>
+    <td class='direction'> </td>
     <td class='target'> </td>
   </tr>
   </table>
@@ -100,6 +113,19 @@ function show_aliases() {
           if (alias.required) n.addClass('alias-required');
           n.attr('data-email', alias.source_display); // this is decoded from IDNA, but will get re-coded to IDNA on the backend
           n.find('td.email').text(alias.source_display)
+          if (!alias.applies_inbound && !alias.applies_outbound) {
+            n.find('td.direction').text('')
+            n.attr('data-direction', 'disabled');
+          } else if (!alias.applies_inbound && alias.applies_outbound) {
+            n.find('td.direction').text('↤')
+            n.attr('data-direction', 'outbound');
+          } else if (alias.applies_inbound && !alias.applies_outbound) {
+            n.find('td.direction').text('↦')
+            n.attr('data-direction', 'inbound');
+          } else if (alias.applies_inbound && alias.applies_outbound) {
+            n.find('td.direction').text('↮')
+            n.attr('data-direction', 'bidirectional');
+          }
           for (var j = 0; j < alias.destination.length; j++)
             n.find('td.target').append($("<div></div>").text(alias.destination[j]))
           $('#alias_table tbody').append(n);
@@ -114,18 +140,21 @@ function show_aliases() {
       if ($(this).attr('data-mode') == "regular") {
         $('#addaliasEmail').attr('type', 'email');
         $('#addaliasEmail').attr('placeholder', 'incoming email address (e.g. you@yourdomain.com)');
-	$('#addaliasTargets').attr('placeholder', 'forward to these email addresses (one per line or separated by commas)');
+        $('#addaliasDirection').val('bidirectional');
+      	$('#addaliasTargets').attr('placeholder', 'forward to these email addresses (one per line or separated by commas)');
         $('#alias_mode_info').slideUp();
       } else if ($(this).attr('data-mode') == "catchall") {
         $('#addaliasEmail').attr('type', 'text');
         $('#addaliasEmail').attr('placeholder', 'incoming catch-all address (e.g. @yourdomain.com)');
-	$('#addaliasTargets').attr('placeholder', 'forward to these email addresses (one per line or separated by commas)');
+        $('#addaliasDirection').val('outbound');
+        $('#addaliasTargets').attr('placeholder', 'forward to these email addresses (one per line or separated by commas)');
         $('#alias_mode_info').slideDown();
         $('#alias_mode_info span').addClass('hidden');
         $('#alias_mode_info span.catchall').removeClass('hidden');
       } else if ($(this).attr('data-mode') == "domainalias") {
         $('#addaliasEmail').attr('type', 'text');
         $('#addaliasEmail').attr('placeholder', 'incoming domain (@yourdomain.com)');
+        $('#addaliasDirection').val('inbound');
         $('#addaliasTargets').attr('placeholder', 'forward to domain (@yourdomain.com)');
         $('#alias_mode_info').slideDown();
         $('#alias_mode_info span').addClass('hidden');
@@ -140,6 +169,7 @@ var is_alias_add_update = false;
 function do_add_alias() {
   var title = (!is_alias_add_update) ? "Add Alias" : "Update Alias";
   var email = $("#addaliasEmail").val();
+  var direction = $("#addaliasDirection").val();
   var targets = $("#addaliasTargets").val();
   api(
     "/mail/aliases/add",
@@ -147,7 +177,9 @@ function do_add_alias() {
     {
       update_if_exists: is_alias_add_update ? '1' : '0',
       source: email,
-      destination: targets
+      destination: targets,
+      applies_inbound: (direction == 'bidirectional' || direction == 'inbound') ? '1' : '0',
+      applies_outbound: (direction == 'bidirectional' || direction == 'outbound') ? '1' : '0'
     },
     function(r) {
       // Responses are multiple lines of pre-formatted text.
@@ -164,6 +196,12 @@ function do_add_alias() {
 function aliases_reset_form() {
   $("#addaliasEmail").prop('disabled', false);
   $("#addaliasEmail").val('')
+  if ($('#alias_type_buttons button').attr('data-mode') == "regular")
+    $('#addaliasDirection').val('bidirectional');
+  else if ($('#alias_type_buttons button').attr('data-mode') == "catchall")
+    $('#alias_type_buttons').val('outbound');
+  else if ($('#addaliasDirection button').attr('data-mode') == "domainalias")
+    $('#addaliasDirection').val('inbound');
   $("#addaliasTargets").val('')
   $('#alias-cancel').addClass('hidden');
   $('#add-alias-button').text('Add Alias');
@@ -176,20 +214,21 @@ function aliases_edit(elem) {
   var targets = "";
   for (var i = 0; i < targetdivs.length; i++)
     targets += $(targetdivs[i]).text() + "\n";
-
-  is_alias_add_update = true;
-  $('#alias-cancel').removeClass('hidden');
-  $("#addaliasEmail").prop('disabled', true);
-  $("#addaliasEmail").val(email);
-  $("#addaliasTargets").val(targets);
-  $('#add-alias-button').text('Update');
+  var direction = $(elem).parents('tr').attr('data-direction')
   if (email.charAt(0) == '@' && targets.charAt(0) == '@')
     $('#alias_type_buttons button[data-mode="domainalias"]').click();
   else if (email.charAt(0) == '@')
     $('#alias_type_buttons button[data-mode="catchall"]').click();
   else
     $('#alias_type_buttons button[data-mode="regular"]').click();
+  $('#alias-cancel').removeClass('hidden');
+  $("#addaliasEmail").prop('disabled', true);
+  $("#addaliasEmail").val(email);
+  $('#addaliasDirection').val(direction);
+  $("#addaliasTargets").val(targets);
+  $('#add-alias-button').text('Update');
   $('body').animate({ scrollTop: 0 })
+  is_alias_add_update = true;
 }
 
 function aliases_remove(elem) {

--- a/setup/migrate.py
+++ b/setup/migrate.py
@@ -102,9 +102,56 @@ def migration_8(env):
 	os.unlink(os.path.join(env['STORAGE_ROOT'], 'mail/dkim/mail.private'))
 
 def migration_9(env):
+	# Switch from storing alias ownership in one column (used for both
+	# directions) to two columns (one for determining inbound forward-tos and
+	# one for determining outbound permitted-senders). This was motivated by the
+	# addition of #427 ("Reject outgoing mail if FROM does not match Login") -
+	# which introduced the notion of outbound permitted-senders.
 	db = os.path.join(env["STORAGE_ROOT"], 'mail/users.sqlite')
-	shell("check_call", ["sqlite3", db, "ALTER TABLE aliases ADD COLUMN applies_inbound INTEGER NOT NULL DEFAULT 1"])
-	shell("check_call", ["sqlite3", db, "ALTER TABLE aliases ADD COLUMN applies_outbound INTEGER NOT NULL DEFAULT 1"])
+	# Move the old aliases table to one side.
+	shell("check_call", ["sqlite3", db, "ALTER TABLE aliases RENAME TO aliases_8"])
+	# Create the new aliases table, initially empty.
+	shell("check_call", ["sqlite3", db, "CREATE TABLE aliases (id INTEGER PRIMARY KEY AUTOINCREMENT, address TEXT NOT NULL UNIQUE, receivers TEXT NOT NULL, senders TEXT NOT NULL)"])
+
+	import sqlite3
+	conn = sqlite3.connect(os.path.join(env["STORAGE_ROOT"], "mail/users.sqlite"))
+
+	c = conn.cursor()
+	c.execute('SELECT email FROM users')
+	valid_logins = [ row[0] for row in c.fetchall() ]
+
+	c = conn.cursor()
+	c.execute('SELECT source, destination FROM aliases_8')
+	aliases = { row[0]: row[1] for row in c.fetchall() }
+
+	# Populate the new aliases table. Forward-to addresses (receivers) is taken
+	# directly from the old destination column. Permitted-sender logins
+	# (senders) is made up of only those addresses in the old destination column
+	# that are valid logins, as other values are not relevant. Their presence
+	# would not do any harm, except that it would make the aliases UI confusing
+	# on upgraded boxes.
+	for source in aliases:
+
+		address = source
+		receivers = aliases[source]
+
+		validated_senders = []
+		for login in aliases[source].split(","):
+			login = login.strip()
+			if login == "": continue
+			if login in valid_logins:
+				validated_senders.append(login)
+
+		senders = ",".join(validated_senders)
+
+		c = conn.cursor()
+		c.execute("INSERT INTO aliases (address, receivers, senders) VALUES (?, ?, ?)", (address, receivers, senders))
+
+	# Save.
+	conn.commit()
+
+	# Delete the old aliases table.
+	shell("check_call", ["sqlite3", db, "DROP TABLE aliases_8"])
 
 def get_current_migration():
 	ver = 0

--- a/setup/migrate.py
+++ b/setup/migrate.py
@@ -101,6 +101,11 @@ def migration_8(env):
 	# a new key, which will be 2048 bits.
 	os.unlink(os.path.join(env['STORAGE_ROOT'], 'mail/dkim/mail.private'))
 
+def migration_9(env):
+	db = os.path.join(env["STORAGE_ROOT"], 'mail/users.sqlite')
+	shell("check_call", ["sqlite3", db, "ALTER TABLE aliases ADD COLUMN applies_inbound INTEGER NOT NULL DEFAULT 1"])
+	shell("check_call", ["sqlite3", db, "ALTER TABLE aliases ADD COLUMN applies_outbound INTEGER NOT NULL DEFAULT 1"])
+
 def get_current_migration():
 	ver = 0
 	while True:


### PR DESCRIPTION
This is an extension of #427. Building on that change it adds support in the
aliases table for flagging aliases as:
 1. Applicable to inbound and outbound mail.
 2. Applicable to inbound mail only.
 3. Applicable to outbound mail only.
 4. Disabled.

The aliases UI is also updated to allow administrators to set the direction of
each alias.

Using this extra information, the sqlite queries executed by Postfix are
updated so only the relevant alias types are checked.

The goal and result of this change is that outbound-only catch-all aliases can
now be defined (in fact catch-all aliases of any type can be defined).

This allow us to continue supporting relaying as described at
https://mailinabox.email/advanced-configuration.html#relay
without requiring that administrators either create regular aliases for each
outbound *relay* address, or that they create a catch-all alias and then face a
flood of spam.

I have tested the code as it is in this commit and fixed every issue I found,
so in that regard the change is complete. However I see room for improvement
in terms of updating terminology to make the UI etc. easier to understand.
I'll make those changes as subsequent commits so that this tested checkpoint is
not lost, but also so they can be rejected independently of the actual change
if not wanted.

As per my comment on #427 I don't mean for this PR to be an actual pull *request* yet, because of those terminology changes I intend to make. But I wanted to open it now as an invitation for questions/comments on what I have done.

Another note to self: http://www.unicode.org/charts/PDF/U2190.pdf might be useful if you want to find better arrows for the UI.