### PR TITLE
outgoing_mail_header_filters use local hostname and ip

### DIFF
--- a/conf/postfix_outgoing_mail_header_filters
+++ b/conf/postfix_outgoing_mail_header_filters
@@ -1,7 +1,7 @@
 # Remove the first line of the Received: header. Note that we cannot fully remove the Received: header
 # because OpenDKIM requires that a header be present when signing outbound mail. The first line is
 # where the user's home IP address would be.
-/^\s*Received:[^\n]*(.*)/         REPLACE Received: from authenticated-user (unknown [127.0.0.1])$1
+/^\s*Received:[^\n]*(.*)/         REPLACE Received: from authenticated-user (PRIMARY_HOSTNAME [PUBLIC_IP])$1
 
 # Remove other typically private information.
 /^\s*User-Agent:/        IGNORE

--- a/setup/mail-postfix.sh
+++ b/setup/mail-postfix.sh
@@ -93,6 +93,12 @@ tools/editconf.py /etc/postfix/master.cf -s -w \
 # Install the `outgoing_mail_header_filters` file required by the new 'authclean' service.
 cp conf/postfix_outgoing_mail_header_filters /etc/postfix/outgoing_mail_header_filters
 
+# Modify the `outgoing_mail_header_filters` file to use the local machine name and ip 
+# on the first received header line.  This may help reduce the spam score of email by
+# removing the 127.0.0.1 reference.
+sed -i "s/PRIMARY_HOSTNAME/$PRIMARY_HOSTNAME/" /etc/postfix/outgoing_mail_header_filters
+sed -i "s/PUBLIC_IP/$PUBLIC_IP/" /etc/postfix/outgoing_mail_header_filters
+
 # Enable TLS on these and all other connections (i.e. ports 25 *and* 587) and
 # require TLS before a user is allowed to authenticate. This also makes
 # opportunistic TLS available on *incoming* mail.


### PR DESCRIPTION
Modify the `outgoing_mail_header_filters` file to use the local machine name and ip on the first received header line.  This may help reduce the spam score of email by removing the 127.0.0.1 reference.