### PR TITLE
Set PHPs default charset to UTF-8, since we use it. Closes #367.

### DIFF
--- a/setup/web.sh
+++ b/setup/web.sh
@@ -36,6 +36,10 @@ tools/editconf.py /etc/nginx/nginx.conf -s \
 tools/editconf.py /etc/php5/fpm/php.ini -c ';' \
 	expose_php=Off
 
+# Set PHPs default charset to UTF-8, since we use it. See #367.
+tools/editconf.py /etc/php5/fpm/php.ini -c ';' \
+        default_charset="UTF-8"
+
 # Bump up PHP's max_children to support more concurrent connections
 tools/editconf.py /etc/php5/fpm/pool.d/www.conf -c ';' \
 	pm.max_children=8


### PR DESCRIPTION
This will close #367 