### PR TITLE
Initial cleanup and harden of fail2ban

### DIFF
--- a/conf/fail2ban/jail.local
+++ b/conf/fail2ban/jail.local
@@ -16,7 +16,6 @@ maxretry = 20
 [ssh]
 
 enabled  = true
-logpath  = /var/log/auth.log
 maxretry = 20
 
 [ssh-ddos]

--- a/conf/fail2ban/jail.local
+++ b/conf/fail2ban/jail.local
@@ -1,29 +1,23 @@
-# Fail2Ban configuration file.
-# For Mail-in-a-Box
+# Fail2Ban configuration file for Mail-in-a-Box
+
 [DEFAULT]
 
 # This should ban dumb brute-force attacks, not oblivious users.
 findtime = 30
 maxretry = 20
 
-#
 # JAILS
-#
 
 [ssh]
-
 maxretry = 20
 
 [ssh-ddos]
-
 enabled  = true
 maxretry = 20
 
 [sasl]
-
 enabled  = true
 
 [dovecot]
-
 enabled = true
 filter  = dovecotimap

--- a/conf/fail2ban/jail.local
+++ b/conf/fail2ban/jail.local
@@ -2,9 +2,6 @@
 # For Mail-in-a-Box
 [DEFAULT]
 
-# bantime in seconds
-bantime  = 60
-
 # This should ban dumb brute-force attacks, not oblivious users.
 findtime = 30
 maxretry = 20

--- a/conf/fail2ban/jail.local
+++ b/conf/fail2ban/jail.local
@@ -8,12 +8,8 @@ maxretry = 20
 
 # JAILS
 
-[ssh]
-maxretry = 20
-
 [ssh-ddos]
 enabled  = true
-maxretry = 20
 
 [sasl]
 enabled  = true

--- a/conf/fail2ban/jail.local
+++ b/conf/fail2ban/jail.local
@@ -12,7 +12,6 @@ maxretry = 20
 
 [ssh]
 
-enabled  = true
 maxretry = 20
 
 [ssh-ddos]


### PR DESCRIPTION
This is a proposed first stage cleanup of the previous fail2ban enhancements. Primarily it removes any config items that are duplicates of default. It also reverts the bantime to the defaults as our previous changes were a little to safe to be effective.

If this is accepted further changes will be submitted.