### PR TITLE
Added more bantime and lowered max retry attempts

### DIFF
--- a/conf/fail2ban/jail.local
+++ b/conf/fail2ban/jail.local
@@ -8,6 +8,12 @@ maxretry = 20
 
 # JAILS
 
+[ssh]
+enabled  = true
+maxretry = 7
+findtime = 120
+bantime = 3600
+
 [ssh-ddos]
 enabled  = true
 


### PR DESCRIPTION
Ban time was too low for preventing ssh brute force attacks, this change also allows to keep the auth.log more clean and avoid wasting cpu and i/o on this. 

Bots eventually will flag your IP as secure and move along.