### PR TITLE
Add favicon, sourced from mailinabox.email

### DIFF
--- a/management/templates/index.html
+++ b/management/templates/index.html
@@ -9,6 +9,9 @@
 
         <meta name="robots" content="noindex, nofollow">
 
+        <link rel="icon" type="image/png" href="https://mailinabox.email/static/logo_small.png">
+        <link rel="apple-touch-icon" type="image/png" href="https://mailinabox.email/static/logo_small.png">
+
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.0/css/bootstrap.min.css">
         <style>
             @import url(https://fonts.googleapis.com/css?family=Raleway:400,700);


### PR DESCRIPTION
I would have included the favicon as a static asset but the management daemon
isn't set up to support them.

Perhaps Josh would rather that mailinabox.email did not receive the traffic
this would add.

Perhaps hotlinking like this is untenable because users may be concerned about
referencing external resources unnecessarily.

Perhaps this is bad because deployed boxes should not make assumptions about
the location and availability of external resources. But a change of location/
availability of the favicon wouldn't make things any worse than they currently
are - and it is only a favicon.

If none of the above are issues, the web UI does look better with a favicon,
and this is a pretty quick way of adding one.