### PR TITLE
Fix Munin Setup `use_node_name yes` in favor of #474

### DIFF
--- a/setup/munin.sh
+++ b/setup/munin.sh
@@ -21,6 +21,7 @@ includedir /etc/munin/munin-conf.d
 # a simple host tree
 [$PRIMARY_HOSTNAME]
 address 127.0.0.1
+use_node_name yes
 
 # send alerts to the following address
 contacts admin


### PR DESCRIPTION
needs for environments with ipv4 and ipv6 enabled