### PR TITLE
Fix Munin Setup in favor of #474

### DIFF
--- a/setup/munin.sh
+++ b/setup/munin.sh
@@ -21,6 +21,7 @@ includedir /etc/munin/munin-conf.d
 # a simple host tree
 [$PRIMARY_HOSTNAME]
 address 127.0.0.1
+host_name `hostname`
 
 # send alerts to the following address
 contacts admin

--- a/setup/munin.sh
+++ b/setup/munin.sh
@@ -21,7 +21,7 @@ includedir /etc/munin/munin-conf.d
 # a simple host tree
 [$PRIMARY_HOSTNAME]
 address 127.0.0.1
-host_name `hostname`
+host_name `hostname --fqdn`
 
 # send alerts to the following address
 contacts admin


### PR DESCRIPTION
needs for environments with ipv4 and ipv6 enabled.

`hostname` could be differnt to `$PRIMARY_HOSTNAME`

For me 
hostname : vservername.providername.tld
$PRIMARY_HOSTNAME : box.vservername.providername.tld
(notice the missing `box.`)

Munin needs that the hostname fits to the `/etc/hostname`.