### PR TITLE
Activate FAIL2BAN recidive jail

### DIFF
--- a/conf/fail2ban/jail.local
+++ b/conf/fail2ban/jail.local
@@ -13,3 +13,7 @@ enabled = true
 filter  = dovecotimap
 findtime = 30
 maxretry = 20
+
+[recidive]
+enabled  = true
+maxretry = 10


### PR DESCRIPTION
Recidive can be thought of as FAIL2BAN checking itself. This setup will monitor the FAIL2BAN log and if 10 bans are seen within one day activate a week long ban and email the mail in a box admin that it has been applied . These bans survive FAIL2BAN service restarts so are much stronger which obviously means we need to be careful with them.

Our current settings are relatively safe and definitely not easy to trigger by mistake e.g to activate a recidive IP jail by failed SSH logins a user would have to fail logging into SSH 6 times in 10 minutes, get banned, wait for the ban to expire and then repeat this process 9 further times within a 24 hour period.

The default maxretry of 5 is much saner but that can be applied once users are happy with this jail. I have been running a stronger version of this for months and it does a very good job of ejecting persistent abusers.