### PR TITLE
Make backups more configurable

### DIFF
--- a/management/backup.py
+++ b/management/backup.py
@@ -293,7 +293,6 @@ def run_duplicity_verification():
 	env = load_environment()
 	config = get_backup_config()
 	backup_cache_dir = os.path.join(backup_root, 'cache')
-	backup_dir = os.path.join(backup_root, 'encrypted')
 
 	shell('check_call', [
 		"/usr/bin/duplicity",

--- a/management/backup.py
+++ b/management/backup.py
@@ -31,7 +31,11 @@ def backup_status(env):
 	# Use the number of volumes to estimate the size.
 	config = get_backup_config()
 	now = datetime.datetime.now(dateutil.tz.tzlocal())
-	
+
+	backups = { }
+	backup_dir = os.path.join(backup_root, 'encrypted')
+	backup_cache_dir = os.path.join(backup_root, 'cache')
+
 	def reldate(date, ref, clip):
 		if ref < date: return clip
 		rd = dateutil.relativedelta.relativedelta(ref, date)
@@ -57,16 +61,13 @@ def backup_status(env):
 	shell('check_call', [
 		"/usr/bin/duplicity",
 		"collection-status",
+		"--archive-dir", backup_cache_dir,
 		"--log-file", os.path.join(backup_root, "duplicity_status"),
 		"--gpg-options", "--cipher-algo=AES256",
 		config["target"],
 		],
 		get_env())
-		
 
-	backups = { }
-	backup_dir = os.path.join(backup_root, 'encrypted')
-	
 	# Parse backup data from status file
 	with open(os.path.join(backup_root, "duplicity_status"),'r') as status_file:
 		for line in status_file:

--- a/management/backup.py
+++ b/management/backup.py
@@ -227,6 +227,7 @@ def perform_backup(full_backup):
 			"/usr/bin/duplicity",
 			"full" if full_backup else "incr",
 			"--archive-dir", backup_cache_dir,
+			"--asynchronous-upload",
 			"--exclude", backup_root,
 			"--volsize", "250",
 			"--gpg-options", "--cipher-algo=AES256",

--- a/management/daemon.py
+++ b/management/daemon.py
@@ -416,7 +416,7 @@ def backup_set_custom():
 		request.form.get('target', ''),
 		request.form.get('target_user', ''),
 		request.form.get('target_pass', ''),
-		request.form.get('max_age', '')
+		request.form.get('min_age', '')
 	))
 
 # MUNIN

--- a/management/daemon.py
+++ b/management/daemon.py
@@ -402,13 +402,13 @@ def backup_status():
 	from backup import backup_status
 	return json_response(backup_status(env))
 
-@app.route('/system/backup/get-custom')
+@app.route('/system/backup/config', methods=["GET"])
 @authorized_personnel_only
 def backup_get_custom():
 	from backup import get_backup_config
 	return json_response(get_backup_config())
 
-@app.route('/system/backup/set-custom', methods=["POST"])
+@app.route('/system/backup/config', methods=["POST"])
 @authorized_personnel_only
 def backup_set_custom():
 	from backup import backup_set_custom

--- a/management/daemon.py
+++ b/management/daemon.py
@@ -416,7 +416,6 @@ def backup_set_custom():
 		request.form.get('target', ''),
 		request.form.get('target_user', ''),
 		request.form.get('target_pass', ''),
-		request.form.get('target_type', ''),
 		request.form.get('max_age', '')
 	))
 

--- a/management/daemon.py
+++ b/management/daemon.py
@@ -402,6 +402,24 @@ def backup_status():
 	from backup import backup_status
 	return json_response(backup_status(env))
 
+@app.route('/system/backup/get-custom')
+@authorized_personnel_only
+def backup_get_custom():
+	from backup import get_backup_config
+	return json_response(get_backup_config())
+
+@app.route('/system/backup/set-custom', methods=["POST"])
+@authorized_personnel_only
+def backup_set_custom():
+	from backup import backup_set_custom
+	return json_response(backup_set_custom(
+		request.form.get('target', ''),
+		request.form.get('target_user', ''),
+		request.form.get('target_pass', ''),
+		request.form.get('target_type', ''),
+		request.form.get('max_age', '')
+	))
+
 # MUNIN
 
 @app.route('/munin/')
@@ -432,4 +450,3 @@ if __name__ == '__main__':
 
 	# Start the application server. Listens on 127.0.0.1 (IPv4 only).
 	app.run(port=10222)
-

--- a/management/daemon.py
+++ b/management/daemon.py
@@ -4,7 +4,7 @@ import os, os.path, re, json
 
 from functools import wraps
 
-from flask import Flask, request, render_template, abort, Response, send_from_directory
+from flask import Flask, request, render_template, abort, Response, send_from_directory, jsonify
 
 import auth, utils
 from mailconfig import get_mail_users, get_mail_users_ex, get_admins, add_mail_user, set_mail_password, remove_mail_user
@@ -399,14 +399,14 @@ def do_updates():
 @app.route('/system/backup/status')
 @authorized_personnel_only
 def backup_status():
-	from backup import backup_status
-	return json_response(backup_status(env))
+	from backup import backup_status, get_backup_log
+	return jsonify(backups=backup_status(env), log=get_backup_log())
 
 @app.route('/system/backup/config', methods=["GET"])
 @authorized_personnel_only
 def backup_get_custom():
 	from backup import get_backup_config
-	return json_response(get_backup_config())
+	return jsonify(get_backup_config())
 
 @app.route('/system/backup/config', methods=["POST"])
 @authorized_personnel_only

--- a/management/templates/system-backup.html
+++ b/management/templates/system-backup.html
@@ -26,7 +26,7 @@
   <div class="form-group">
     <label for="target" class="col-sm-2 control-label">Maximum time to keep old backups (in days)</label>
     <div class="col-sm-8">
-      <input type="number" class="form-control" rows="1" id="max-age"></input>
+      <input type="number" class="form-control" rows="1" id="min-age"></input>
     </div>
   </div>
   <div class="form-group form-advanced">
@@ -147,7 +147,7 @@ function show_custom_backup() {
         $("#target-type").val(target_type);
         $("#target-user").val(r.target_user);
         $("#target-pass").val(r.target_pass);
-        $("#max-age").val(r.max_age_in_days);
+        $("#min-age").val(r.min_age_in_days);
         toggle_form()
       })
 }
@@ -157,7 +157,7 @@ function set_custom_backup() {
   var target_type = $("#target-type").val();
   var target_user = $("#target-user").val();
   var target_pass = $("#target-pass").val();
-  var max_age = $("#max-age").val();
+  var min_age = $("#min-age").val();
   api(
     "/system/backup/custom",
     "POST",
@@ -165,7 +165,7 @@ function set_custom_backup() {
       target: target,
       target_user: target_user,
       target_pass: target_pass,
-      max_age: max_age
+      min_age: min_age
     },
     function(r) {
       // Responses are multiple lines of pre-formatted text.

--- a/management/templates/system-backup.html
+++ b/management/templates/system-backup.html
@@ -142,8 +142,9 @@ function show_custom_backup() {
       "GET",
       { },
       function(r) {
+        var target_type = r.target.split(':')[0]
         $("#target").val(r.target);
-        $("#target-type").val(r.target_type);
+        $("#target-type").val(target_type);
         $("#target-user").val(r.target_user);
         $("#target-pass").val(r.target_pass);
         $("#max-age").val(r.max_age_in_days);
@@ -162,7 +163,6 @@ function set_custom_backup() {
     "POST",
     {
       target: target,
-      target_type: target_type,
       target_user: target_user,
       target_pass: target_pass,
       max_age: max_age

--- a/management/templates/system-backup.html
+++ b/management/templates/system-backup.html
@@ -138,7 +138,7 @@ function show_system_backup() {
 
 function show_custom_backup() {
     api(
-      "/system/backup/custom",
+      "/system/backup/config",
       "GET",
       { },
       function(r) {
@@ -159,7 +159,7 @@ function set_custom_backup() {
   var target_pass = $("#target-pass").val();
   var min_age = $("#min-age").val();
   api(
-    "/system/backup/custom",
+    "/system/backup/config",
     "POST",
     {
       target: target,

--- a/management/templates/system-backup.html
+++ b/management/templates/system-backup.html
@@ -68,6 +68,11 @@
   <tbody>
   </tbody>
 </table>
+
+<h3>Backup logs</h3>
+<pre id="backup-log"></pre>
+
+
 <script>
 
 function toggle_form() {
@@ -104,22 +109,24 @@ function show_system_backup() {
     "GET",
     { },
     function(r) {
-      $('#backup-location').text(r.directory);
-      $('#backup-encpassword-file').text(r.encpwfile);
+      var status = r.backups;
+      var log = r.log;
+      $('#backup-location').text(status.directory);
+      $('#backup-encpassword-file').text(status.encpwfile);
 
       $('#backup-status tbody').html("");
       var total_disk_size = 0;
 
-      if (r.backups.length == 0) {
+      if (status.backups.length == 0) {
         var tr = $('<tr><td colspan="3">No backups have been made yet.</td></tr>');
         $('#backup-status tbody').append(tr);
       }
 
-      for (var i = 0; i < r.backups.length; i++) {
-        var b = r.backups[i];
+      for (var i = 0; i < status.backups.length; i++) {
+        var b = status.backups[i];
         var tr = $('<tr/>');
         if (b.full) tr.addClass("full-backup");
-        tr.append( $('<td/>').text(b.date_str + " " + r.tz) );
+        tr.append( $('<td/>').text(b.date_str + " " + status.tz) );
         tr.append( $('<td/>').text(b.date_delta + " ago") );
         tr.append( $('<td/>').text(b.full ? "full" : "increment") );
         tr.append( $('<td style="text-align: right"/>').text( nice_size(b.size)) );
@@ -133,6 +140,8 @@ function show_system_backup() {
       }
 
       $('#backup-total-size').text(nice_size(total_disk_size));
+      
+      $('#backup-log').text(log || 'No backup logs yet');
     })
 }
 

--- a/management/templates/system-backup.html
+++ b/management/templates/system-backup.html
@@ -7,11 +7,52 @@
 
 <h3>Copying Backup Files</h3>
 
-<p>The box makes an incremental backup each night. The backup is stored on the machine itself. You are responsible for copying the backup files off of the machine.</p>
-
-<p>Many cloud providers make this easy by allowing you to take snapshots of the machine's disk.</p>
+<p>The box makes an incremental backup each night. By default the backup is stored on the machine itself, but you can also have it stored on Amazon S3</p>
 
 <p>You can also use SFTP (FTP over SSH) to copy files from <tt id="backup-location"></tt>. These files are encrypted, so they are safe to store anywhere. Copy the encryption password from <tt id="backup-encpassword-file"></tt> also but keep it in a safe location.</p>
+
+<h3>Backup Configuration</h3>
+
+<form class="form-horizontal" role="form" onsubmit="set_custom_backup(); return false;">
+  <div class="form-group">
+    <label for="target" class="col-sm-2 control-label">Backup target</label>
+    <div class="col-sm-2">
+      <select class="form-control" rows="1" id="target-type" onchange="toggle_form()">
+        <option value="file">Store locally</option>
+        <option value="s3">Amazon S3</option>
+      </select>
+    </div>
+  </div>
+  <div class="form-group">
+    <label for="target" class="col-sm-2 control-label">Maximum time to keep old backups (in days)</label>
+    <div class="col-sm-8">
+      <input type="number" class="form-control" rows="1" id="max-age"></input>
+    </div>
+  </div>
+  <div class="form-group form-advanced">
+    <label for="target" class="col-sm-2 control-label">S3 URL</label>
+    <div class="col-sm-8">
+      <textarea class="form-control" rows="1" id="target"></textarea>
+    </div>
+  </div>
+  <div class="form-group form-advanced">
+    <label for="target-user" class="col-sm-2 control-label">S3&nbsp;Key</label>
+    <div class="col-sm-8">
+      <textarea class="form-control" rows="1" id="target-user"></textarea>
+    </div>
+  </div>
+  <div class="form-group form-advanced">
+    <label for="target-pass" class="col-sm-2 control-label">S3&nbsp;Secret</label>
+    <div class="col-sm-8">
+      <textarea class="form-control" rows="1" id="target-pass"></textarea>
+    </div>
+  </div>
+  <div class="form-group">
+    <div class="col-sm-offset-2 col-sm-11">
+      <button id="set-s3-backup-button" type="submit" class="btn btn-primary">Save</button>
+    </div>
+  </div>
+</form>
 
 <h3>Current Backups</h3>
 
@@ -27,8 +68,17 @@
   <tbody>
   </tbody>
 </table>
-
 <script>
+
+function toggle_form() {
+  var target_type = $("#target-type").val();
+  if (target_type == 'file') {
+    $(".form-advanced").hide();
+  } else {
+    $(".form-advanced").show();
+  }
+}
+
 function nice_size(bytes) {
   var powers = ['bytes', 'KB', 'MB', 'GB', 'TB'];
   while (true) {
@@ -46,6 +96,8 @@ function nice_size(bytes) {
 }
 
 function show_system_backup() {
+  show_custom_backup()
+  
   $('#backup-status tbody').html("<tr><td colspan='2' class='text-muted'>Loading...</td></tr>")
   api(
     "/system/backup/status",
@@ -82,5 +134,46 @@ function show_system_backup() {
 
       $('#backup-total-size').text(nice_size(total_disk_size));
     })
+}
+
+function show_custom_backup() {
+    api(
+      "/system/backup/get-custom",
+      "GET",
+      { },
+      function(r) {
+        $("#target").val(r.target);
+        $("#target-type").val(r.target_type);
+        $("#target-user").val(r.target_user);
+        $("#target-pass").val(r.target_pass);
+        $("#max-age").val(r.max_age_in_days);
+        toggle_form()
+      })
+}
+
+function set_custom_backup() {
+  var target = $("#target").val();
+  var target_type = $("#target-type").val();
+  var target_user = $("#target-user").val();
+  var target_pass = $("#target-pass").val();
+  var max_age = $("#max-age").val();
+  api(
+    "/system/backup/set-custom",
+    "POST",
+    {
+      target: target,
+      target_type: target_type,
+      target_user: target_user,
+      target_pass: target_pass,
+      max_age: max_age
+    },
+    function(r) {
+      // Responses are multiple lines of pre-formatted text.
+      show_modal_error("Backup configuration", $("<pre/>").text(r));
+    },
+    function(r) {
+      show_modal_error("Backup configuration (error)", r);
+    });
+  return false;
 }
 </script>

--- a/management/templates/system-backup.html
+++ b/management/templates/system-backup.html
@@ -138,7 +138,7 @@ function show_system_backup() {
 
 function show_custom_backup() {
     api(
-      "/system/backup/get-custom",
+      "/system/backup/custom",
       "GET",
       { },
       function(r) {
@@ -158,7 +158,7 @@ function set_custom_backup() {
   var target_pass = $("#target-pass").val();
   var max_age = $("#max-age").val();
   api(
-    "/system/backup/set-custom",
+    "/system/backup/custom",
     "POST",
     {
       target: target,

--- a/management/templates/system-backup.html
+++ b/management/templates/system-backup.html
@@ -32,19 +32,19 @@
   <div class="form-group form-advanced">
     <label for="target" class="col-sm-2 control-label">S3 URL</label>
     <div class="col-sm-8">
-      <textarea class="form-control" rows="1" id="target"></textarea>
+      <input type="text" placeholder="s3://s3-eu-central-1.amazonaws.com/bucket-name" class="form-control" rows="1" id="target"></textarea>
     </div>
   </div>
   <div class="form-group form-advanced">
     <label for="target-user" class="col-sm-2 control-label">S3&nbsp;Key</label>
     <div class="col-sm-8">
-      <textarea class="form-control" rows="1" id="target-user"></textarea>
+      <input type="text" class="form-control" rows="1" id="target-user"></input>
     </div>
   </div>
   <div class="form-group form-advanced">
     <label for="target-pass" class="col-sm-2 control-label">S3&nbsp;Secret</label>
     <div class="col-sm-8">
-      <textarea class="form-control" rows="1" id="target-pass"></textarea>
+      <input type="text" class="form-control" rows="1" id="target-pass"></input>
     </div>
   </div>
   <div class="form-group">

--- a/management/templates/system-backup.html
+++ b/management/templates/system-backup.html
@@ -24,7 +24,7 @@
     </div>
   </div>
   <div class="form-group">
-    <label for="target" class="col-sm-2 control-label">Maximum time to keep old backups (in days)</label>
+    <label for="target" class="col-sm-2 control-label">How many days should backups be kept?</label>
     <div class="col-sm-8">
       <input type="number" class="form-control" rows="1" id="min-age"></input>
     </div>

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -4,8 +4,9 @@ source setup/functions.sh
 
 # build-essential libssl-dev libffi-dev python3-dev: Required to pip install cryptography.
 apt_install python3-flask links duplicity libyaml-dev python3-dnspython python3-dateutil \
-	build-essential libssl-dev libffi-dev python3-dev
-hide_output pip3 install --upgrade rtyaml email_validator idna cryptography
+	build-essential libssl-dev libffi-dev python3-dev python-pip
+hide_output pip3 install --upgrade rtyaml email_validator idna cryptography boto
+hide_output pip install --upgrade boto
 	# email_validator is repeated in setup/questions.sh
 
 # Create a backup directory and a random key for encrypting backups.

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -6,8 +6,11 @@ source setup/functions.sh
 apt_install python3-flask links duplicity libyaml-dev python3-dnspython python3-dateutil \
 	build-essential libssl-dev libffi-dev python3-dev python-pip
 hide_output pip3 install --upgrade rtyaml email_validator idna cryptography boto
+
+# duplicity uses python 2 so we need to use the python 2 package of boto
 hide_output pip install --upgrade boto
-	# email_validator is repeated in setup/questions.sh
+
+# email_validator is repeated in setup/questions.sh
 
 # Create a backup directory and a random key for encrypting backups.
 mkdir -p $STORAGE_ROOT/backup


### PR DESCRIPTION
Backup location and maximum age can now be configured in the admin panel.
For now only S3 is supported, but adding other duplicity supported backends is easy now.

I had to change the way how backup_status works, as naively walking through the file system doesn't work when using a remote storage. It now queries  `duplicity collection-status` for the necessary info.