### PR TITLE
Fix antispam-plugin config problem in #520

### DIFF
--- a/setup/spamassassin.sh
+++ b/setup/spamassassin.sh
@@ -94,6 +94,7 @@ cat > /etc/dovecot/conf.d/99-local-spampd.conf << EOF;
 plugin {
     antispam_backend = pipe
     antispam_spam_pattern_ignorecase = SPAM
+    antispam_trash_pattern_ignorecase = trash;Deleted *
     antispam_allow_append_to_spam = yes
     antispam_pipe_program_spam_args = /usr/local/bin/sa-learn-pipe.sh;--spam
     antispam_pipe_program_notspam_args = /usr/local/bin/sa-learn-pipe.sh;--ham


### PR DESCRIPTION
The antispam-plugin configuration is not ignoring deleted email (mail sent to a trash folder). This causes a big problem because if someone decides to "clean up" their Spam folder by deleting all of the emails, then sa-learn --ham is run on what is usually correctly caught spam messages. This causes big problems with the accuracy of the bayes scoring! It should really only be learning ham if someone drags the email to a non-Trash folder.

I ran "sa-learn --dbpath /home/user-data/mail/spamassassin --dump magic" before these changes and saw the nham counter increment with every message deleted from Spam.  With this new config sa-learn --ham is not run when email is deleted from Spam so the bayes database is not incorrectly trained.