### PR TITLE
Added a note about TXT record length limitations and how to construct the records to bypass the limitation

### DIFF
--- a/management/templates/external-dns.html
+++ b/management/templates/external-dns.html
@@ -34,6 +34,15 @@
 
 <p>If you do so, you are responsible for keeping your DNS entries up to date! If you previously enabled DNSSEC on your domain name by setting a DS record at your registrar, you will likely have to turn it off before changing nameservers.</p>
 
+
+<p class="alert" role="alert">
+	<span class="glyphicon glyphicon-info-sign"></span>
+	You may encounter zone file errors when attempting to create a TXT record with a long string.
+	<a href="http://tools.ietf.org/html/rfc4408#section-3.1.3">RFC 4408</a> states a TXT record is allowed to contain multiple strings, and this technique can be used to construct records that would exceed the 255-byte maximum length.
+	You may need to adopt this technique when adding DomainKeys. Use a tool like <code>named-checkzone</code> to validate your zone file.
+</p>
+
+
 <table id="external_dns_settings" class="table">
 	<thead>
 		<tr>


### PR DESCRIPTION
When I intially installed mailinabox, I was not aware of these limitations. This little bit of information would have been very helpful for me at the time.