### PR TITLE
Update nginx-primaryonly.conf

### DIFF
--- a/conf/nginx-primaryonly.conf
+++ b/conf/nginx-primaryonly.conf
@@ -50,7 +50,7 @@
 	location ~ ^/((caldav|carddav|webdav).*)$ {
 		# Z-Push doesn't like getting a redirect, and a plain rewrite didn't work either.
 		# Properly proxying like this seems to work fine.
-		proxy_pass https://$HOSTNAME/cloud/remote.php/$1;
+		proxy_pass https://127.0.0.1/cloud/remote.php/$1;
 	}
 	rewrite ^/.well-known/host-meta /cloud/public.php?service=host-meta last;
 	rewrite ^/.well-known/host-meta.json /cloud/public.php?service=host-meta-json last;


### PR DESCRIPTION
Nginx should be connecting over the local interface, not to the IP the resolver gives it. Elsewhere in this file proxy_pass uses 127.0.0.1 as it should.