### PR TITLE
Fix DKIM validation and spamassassin DNS/Pyzor checks

### DIFF
--- a/setup/spamassassin.sh
+++ b/setup/spamassassin.sh
@@ -17,7 +17,8 @@ source setup/functions.sh # load our functions
 
 # Install packages.
 echo "Installing SpamAssassin..."
-apt_install spampd razor pyzor dovecot-antispam
+apt_install spampd razor pyzor dovecot-antispam libcrypt-openssl-bignum-perl \
+        libcrypt-openssl-rsa-perl libmail-dkim-perl libcrypt-openssl-random-perl
 
 # Allow spamassassin to download new rules.
 tools/editconf.py /etc/default/spamassassin \

--- a/setup/spamassassin.sh
+++ b/setup/spamassassin.sh
@@ -16,9 +16,14 @@ source setup/functions.sh # load our functions
 # ----------------------------------------
 
 # Install packages.
+# libmail-dkim-perl is needed to make the spamassassin DKIM module work.
+# For more information see Debian Bug #689414:
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=689414
+# libcrypt-openssl-bignum-perl and libcrypt-openssl-rsa-perl are
+# direct dependencies of libmail-dkim-perl.
 echo "Installing SpamAssassin..."
 apt_install spampd razor pyzor dovecot-antispam libcrypt-openssl-bignum-perl \
-        libcrypt-openssl-rsa-perl libmail-dkim-perl libcrypt-openssl-random-perl
+        libcrypt-openssl-rsa-perl libmail-dkim-perl
 
 # Allow spamassassin to download new rules.
 tools/editconf.py /etc/default/spamassassin \

--- a/setup/spamassassin.sh
+++ b/setup/spamassassin.sh
@@ -19,11 +19,8 @@ source setup/functions.sh # load our functions
 # libmail-dkim-perl is needed to make the spamassassin DKIM module work.
 # For more information see Debian Bug #689414:
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=689414
-# libcrypt-openssl-bignum-perl and libcrypt-openssl-rsa-perl are
-# direct dependencies of libmail-dkim-perl.
 echo "Installing SpamAssassin..."
-apt_install spampd razor pyzor dovecot-antispam libcrypt-openssl-bignum-perl \
-        libcrypt-openssl-rsa-perl libmail-dkim-perl
+apt_install spampd razor pyzor dovecot-antispam libmail-dkim-perl
 
 # Allow spamassassin to download new rules.
 tools/editconf.py /etc/default/spamassassin \

--- a/setup/spamassassin.sh
+++ b/setup/spamassassin.sh
@@ -42,9 +42,11 @@ echo "public.pyzor.org:24441" > /etc/spamassassin/pyzor/servers
 #   want to lose track of it. (We've configured Dovecot to listen on this port elsewhere.)
 # * Increase the maximum message size of scanned messages from the default of 64KB to 500KB, which
 #   is Spamassassin (spamc)'s own default. Specified in KBytes.
+# * Disable localmode so Pyzor, DKIM and DNS checks can be used.
 tools/editconf.py /etc/default/spampd \
 	DESTPORT=10026 \
-	ADDOPTS="\"--maxsize=500\""
+	ADDOPTS="\"--maxsize=500\"" \
+	LOCALONLY=0
 
 # Spamassassin normally wraps spam as an attachment inside a fresh
 # email with a report about the message. This also protects the user


### PR DESCRIPTION
DKIM validation was broken because some dependencies for the spamassassin DKIM module were missing and atleast on my box spampd localmode was enabled by default.
You can check that by looking at the `X-Spam-Status` header, it always contains `T_DKIM_INVALID`, even if DKIM is valid.

This PR fixes DKIM validation and also enables DNS and Pyzor checks in spampd.