### PR TITLE
Revert two FAIL2BAN SSH jail changes

### DIFF
--- a/conf/fail2ban/jail.local
+++ b/conf/fail2ban/jail.local
@@ -4,7 +4,6 @@
 
 [ssh]
 maxretry = 7
-findtime = 120
 bantime = 3600
 
 [ssh-ddos]

--- a/conf/fail2ban/jail.local
+++ b/conf/fail2ban/jail.local
@@ -3,7 +3,6 @@
 # JAILS
 
 [ssh]
-enabled  = true
 maxretry = 7
 findtime = 120
 bantime = 3600


### PR DESCRIPTION
This PR fixes a config error in https://github.com/mail-in-a-box/mailinabox/pull/478 and proposes reverting the monitor period (FINDTIME) to default.