### PR TITLE
Default IMAP_SENTFOLDER folder was incorrect

### DIFF
--- a/conf/zpush/backend_imap.php
+++ b/conf/zpush/backend_imap.php
@@ -29,7 +29,7 @@ define('IMAP_FROM_LDAP_FROM', '#givenname #sn <#mail>');
 
 
 // copy outgoing mail to this folder. If not set z-push will try the default folders
-define('IMAP_SENTFOLDER', '');
+define('IMAP_SENTFOLDER', 'Sent Messages');
 define('IMAP_INLINE_FORWARD', true);
 define('IMAP_EXCLUDED_FOLDERS', '');
 define('IMAP_SMTP_METHOD', 'sendmail');


### PR DESCRIPTION
I noticing that I was getting this error in /var/log/z-push/z-push-error.log:

BackendIMAP->saveSentMessage(): The email could not be saved to Sent Items folder. Check your configuration.

And sure enough, email wasn't being saved in the 'Sent Messages' Dovecot folder when sent via Z-push. Does not require restarting any service after applied.