### PR TITLE
Added 'Sent' folder when creating user.

### DIFF
--- a/management/mailconfig.py
+++ b/management/mailconfig.py
@@ -318,7 +318,7 @@ def add_mail_user(email, pw, privs, env):
 		conn.commit()
 		return ("Failed to initialize the user: " + e.output.decode("utf8"), 400)
 
-	for folder in ("INBOX", "Trash", "Spam", "Drafts"):
+	for folder in ("INBOX", "Sent", "Trash", "Spam", "Drafts"):
 		if folder not in existing_mboxes:
 			utils.shell('check_call', ["doveadm", "mailbox", "create", "-u", email, "-s", folder])
 


### PR DESCRIPTION
This will prevent some mail clients (such as Apple's OS X Mail app) from automatically creating non-standard folder names for sent email.

Please see [#571](https://github.com/mail-in-a-box/mailinabox/pull/571) and [#554](https://github.com/mail-in-a-box/mailinabox/issues/554) for more details.