### PR TITLE
Update z-push to latest version

### DIFF
--- a/conf/zpush/backend_caldav.php
+++ b/conf/zpush/backend_caldav.php
@@ -5,10 +5,12 @@
 * Descr     :   CalDAV backend configuration file
 ************************************************/
 
-define('CALDAV_SERVER', 'https://localhost');
+define('CALDAV_PROTOCOL', 'https');
+define('CALDAV_SERVER', 'localhost');
 define('CALDAV_PORT', '443');
 define('CALDAV_PATH', '/caldav/calendars/%u/');
-define('CALDAV_PERSONAL', '');
+define('CALDAV_PERSONAL', 'PRINCIPAL');
 define('CALDAV_SUPPORTS_SYNC', true);
+define('CALDAV_MAX_SYNC_PERIOD', 2147483647);
 
 ?>

--- a/conf/zpush/backend_caldav.php
+++ b/conf/zpush/backend_caldav.php
@@ -10,7 +10,7 @@ define('CALDAV_SERVER', 'localhost');
 define('CALDAV_PORT', '443');
 define('CALDAV_PATH', '/caldav/calendars/%u/');
 define('CALDAV_PERSONAL', 'PRINCIPAL');
-define('CALDAV_SUPPORTS_SYNC', true);
+define('CALDAV_SUPPORTS_SYNC', false);
 define('CALDAV_MAX_SYNC_PERIOD', 2147483647);
 
 ?>

--- a/conf/zpush/backend_imap.php
+++ b/conf/zpush/backend_imap.php
@@ -10,26 +10,16 @@ define('IMAP_PORT', 993);
 define('IMAP_OPTIONS', '/ssl/norsh/novalidate-cert');
 define('IMAP_DEFAULTFROM', '');
 
-// for new commit
 define('SYSTEM_MIME_TYPES_MAPPING', '/etc/mime.types');
 define('IMAP_AUTOSEEN_ON_DELETE', false);
-
 define('IMAP_FOLDER_CONFIGURED', true);
-// Folder prefix is the common part in your names (3, 4)
 define('IMAP_FOLDER_PREFIX', '');
-// Inbox will have the preffix preppend (3 & 4 to true)
 define('IMAP_FOLDER_PREFIX_IN_INBOX', false);
-// Inbox folder name (case doesn't matter) - (empty in 4)
 define('IMAP_FOLDER_INBOX', 'INBOX');
-// Sent folder name (case doesn't matter)
 define('IMAP_FOLDER_SENT', 'SENT');
-// Draft folder name (case doesn't matter)
 define('IMAP_FOLDER_DRAFT', 'DRAFTS');
-// Trash folder name (case doesn't matter)
 define('IMAP_FOLDER_TRASH', 'TRASH');
-// Spam folder name (case doesn't matter). Only showed as special by iOS devices
 define('IMAP_FOLDER_SPAM', 'SPAM');
-// Archive folder name (case doesn't matter). Only showed as special by iOS devices
 define('IMAP_FOLDER_ARCHIVE', 'ARCHIVE');
 
 
@@ -50,12 +40,6 @@ define('IMAP_FROM_LDAP_QUERY', '(mail=#username@#domain)');
 define('IMAP_FROM_LDAP_FIELDS', serialize(array('givenname', 'sn', 'mail')));
 define('IMAP_FROM_LDAP_FROM', '#givenname #sn <#mail>');
 
-
-// copy outgoing mail to this folder. If not set z-push will try the default folders
-// define('IMAP_SENTFOLDER', '');
-// define('IMAP_INLINE_FORWARD', true);
-// define('IMAP_EXCLUDED_FOLDERS', '');
-// define('IMAP_SMTP_METHOD', 'sendmail');
 
 global $imap_smtp_params;
 $imap_smtp_params = array('host' => 'ssl://localhost', 'port' => 587, 'auth' => true, 'username' => 'imap_username', 'password' => 'imap_password');

--- a/conf/zpush/backend_imap.php
+++ b/conf/zpush/backend_imap.php
@@ -10,6 +10,29 @@ define('IMAP_PORT', 993);
 define('IMAP_OPTIONS', '/ssl/norsh/novalidate-cert');
 define('IMAP_DEFAULTFROM', '');
 
+// for new commit
+define('SYSTEM_MIME_TYPES_MAPPING', '/etc/mime.types');
+define('IMAP_AUTOSEEN_ON_DELETE', false);
+
+define('IMAP_FOLDER_CONFIGURED', true);
+// Folder prefix is the common part in your names (3, 4)
+define('IMAP_FOLDER_PREFIX', '');
+// Inbox will have the preffix preppend (3 & 4 to true)
+define('IMAP_FOLDER_PREFIX_IN_INBOX', false);
+// Inbox folder name (case doesn't matter) - (empty in 4)
+define('IMAP_FOLDER_INBOX', 'INBOX');
+// Sent folder name (case doesn't matter)
+define('IMAP_FOLDER_SENT', 'SENT');
+// Draft folder name (case doesn't matter)
+define('IMAP_FOLDER_DRAFT', 'DRAFTS');
+// Trash folder name (case doesn't matter)
+define('IMAP_FOLDER_TRASH', 'TRASH');
+// Spam folder name (case doesn't matter). Only showed as special by iOS devices
+define('IMAP_FOLDER_SPAM', 'SPAM');
+// Archive folder name (case doesn't matter). Only showed as special by iOS devices
+define('IMAP_FOLDER_ARCHIVE', 'ARCHIVE');
+
+
 // not used
 define('IMAP_FROM_SQL_DSN', '');
 define('IMAP_FROM_SQL_USER', '');
@@ -29,10 +52,10 @@ define('IMAP_FROM_LDAP_FROM', '#givenname #sn <#mail>');
 
 
 // copy outgoing mail to this folder. If not set z-push will try the default folders
-define('IMAP_SENTFOLDER', '');
-define('IMAP_INLINE_FORWARD', true);
-define('IMAP_EXCLUDED_FOLDERS', '');
-define('IMAP_SMTP_METHOD', 'sendmail');
+// define('IMAP_SENTFOLDER', '');
+// define('IMAP_INLINE_FORWARD', true);
+// define('IMAP_EXCLUDED_FOLDERS', '');
+// define('IMAP_SMTP_METHOD', 'sendmail');
 
 global $imap_smtp_params;
 $imap_smtp_params = array('host' => 'ssl://localhost', 'port' => 587, 'auth' => true, 'username' => 'imap_username', 'password' => 'imap_password');

--- a/setup/zpush.sh
+++ b/setup/zpush.sh
@@ -42,6 +42,7 @@ fi
 sed -i "s^define('TIMEZONE', .*^define('TIMEZONE', '$(cat /etc/timezone)');^" /usr/local/lib/z-push/config.php
 sed -i "s/define('BACKEND_PROVIDER', .*/define('BACKEND_PROVIDER', 'BackendCombined');/" /usr/local/lib/z-push/config.php
 sed -i "s/define('USE_FULLEMAIL_FOR_LOGIN', .*/define('USE_FULLEMAIL_FOR_LOGIN', true);/" /usr/local/lib/z-push/config.php
+sed -i "s/define('LOG_MEMORY_PROFILER', .*/define('LOG_MEMORY_PROFILER', false);/" /usr/local/lib/z-push/config.php
 
 # Configure BACKEND
 rm -f /usr/local/lib/z-push/backend/combined/config.php

--- a/setup/zpush.sh
+++ b/setup/zpush.sh
@@ -43,6 +43,7 @@ sed -i "s^define('TIMEZONE', .*^define('TIMEZONE', '$(cat /etc/timezone)');^" /u
 sed -i "s/define('BACKEND_PROVIDER', .*/define('BACKEND_PROVIDER', 'BackendCombined');/" /usr/local/lib/z-push/config.php
 sed -i "s/define('USE_FULLEMAIL_FOR_LOGIN', .*/define('USE_FULLEMAIL_FOR_LOGIN', true);/" /usr/local/lib/z-push/config.php
 sed -i "s/define('LOG_MEMORY_PROFILER', .*/define('LOG_MEMORY_PROFILER', false);/" /usr/local/lib/z-push/config.php
+sed -i "s/define('BUG68532FIXED', .*/define('BUG68532FIXED', false);/" /usr/local/lib/z-push/config.php
 
 # Configure BACKEND
 rm -f /usr/local/lib/z-push/backend/combined/config.php

--- a/setup/zpush.sh
+++ b/setup/zpush.sh
@@ -22,7 +22,7 @@ apt_install \
 php5enmod imap
 
 # Copy Z-Push into place.
-TARGETHASH=d0cd5a47c53afac5c3b287006dc8a48a1c4ffcd5
+TARGETHASH=80cbe53de4ab8dd598d1f2af6f0a23fa396c529a
 needs_update=0 #NODOC
 if [ ! -f /usr/local/lib/z-push/version ]; then
 	needs_update=1 #NODOC


### PR DESCRIPTION
This pull request updates z-push to the latest version from https://github.com/fmbiete/Z-Push-contrib/commit/80cbe53de4ab8dd598d1f2af6f0a23fa396c529a

This fixes https://github.com/mail-in-a-box/mailinabox/issues/576

Also has the following improvements (from contrib):

- Spam folder on iOS is treated as a special folder
- No more exceptions if you archive the message a little quickly after opening

Changes:

- setup/zpush.sh
  - Change target hash to latest commit
- conf/zpush/backend_caldav.php, conf/zpush/backend_imap.php
  - Modify settings to latest scheme from contrib
- setup/zpush.sh
  - Change default setting from contrib config.php to disable memory profiling

I have created a new droplet and domain name to test this. Installed from a cloned git repo. Made the changes to the live system and tested. After that I rerun the setup and confirmed that everything worked and deployed without errors.

I have tested on iOS 9 on an iPhone 6. Was able to sent and receive email. Send messages with CC's and archive email. While using the phone I tailed te log file on the box and checked for errors and warnings. (That triggered a few config changes) 
I also created a calendar appointment on ownCloud and on the iPhone. Both saw the changes. I did the same for contacts and that worked as well. 