### PR TITLE
For a new user create the archive folder

### DIFF
--- a/conf/dovecot-mailboxes.conf
+++ b/conf/dovecot-mailboxes.conf
@@ -41,6 +41,10 @@ namespace inbox {
     special_use = \Trash
     auto = subscribe
   }
+  mailbox Archive {
+    special_use = \Archive
+    auto = subscribe
+  }
 
   # dovevot's standard mailboxes configuration file marks two sent folders
   # with the \Sent attribute, just in case clients don't agree about which

--- a/setup/mail-dovecot.sh
+++ b/setup/mail-dovecot.sh
@@ -56,7 +56,7 @@ tools/editconf.py /etc/dovecot/conf.d/10-mail.conf \
 	mail_privileged_group=mail \
 	first_valid_uid=0
 
-# Create, subscribe, and mark as special folders: INBOX, Drafts, Sent, Trash, and Spam.
+# Create, subscribe, and mark as special folders: INBOX, Drafts, Sent, Trash, Spam and Archive.
 cp conf/dovecot-mailboxes.conf /etc/dovecot/conf.d/15-mailboxes.conf
 
 # ### IMAP/POP


### PR DESCRIPTION
For new users it might be wise to create the Archive folder. 

I created a new droplet to test this on the latest dev branch. Everything sets-up fine and the default user got an Archive folder. I also created a new user. This user also got the Archive folder. 

Together with https://github.com/mail-in-a-box/mailinabox/pull/580 this makes z-push work out of the box. 