### PR TITLE
Add special folder Archives to map to Archive

### DIFF
--- a/conf/dovecot-mailboxes.conf
+++ b/conf/dovecot-mailboxes.conf
@@ -50,6 +50,9 @@ namespace inbox {
   # with the \Sent attribute, just in case clients don't agree about which
   # they're using. We'll keep that, plus add Junk as an alterative for Spam.
   # These are not auto-created.
+  mailbox "Archives" {
+    special_use = \Archive
+  }
   mailbox "Sent Messages" {
     special_use = \Sent
   }


### PR DESCRIPTION
These are the changes to add a special folder Archives which maps to Archive to support Thunderbird.

This is for the problems Josh reported with Thunderbird regarding this pull request: https://github.com/mail-in-a-box/mailinabox/pull/581 See the last few comments regarding this issue. 

I tested this with:
+ Apple Mail
+ iOS Mail
+ Thunderbird
+ Roundcube

It seems that mail clients are a bit finicky about the folders. 

Perhaps this is the best middle ground?