### PR TITLE
Switch from running backup via cron.daily to cron.d at 3am

### DIFF
--- a/setup/management.sh
+++ b/setup/management.sh
@@ -31,13 +31,12 @@ ln -s $(pwd)/conf/management-initscript /etc/init.d/mailinabox
 hide_output update-rc.d mailinabox defaults
 
 # Perform a daily backup.
-cat > /etc/cron.daily/mailinabox-backup << EOF;
-#!/bin/bash
-# Mail-in-a-Box --- Do not edit / will be overwritten on update.
-# Perform a backup.
-$(pwd)/management/backup.py
+cat > /etc/cron.d/mailinabox-backup << EOF;
+# /etc/cron.d/mailinabox-backup: crontab fragment to run maininabox-backup
+#  This executes mailinabox-backup at 3am.
+
+0 3 * * *	root	$(pwd)/management/backup.py
 EOF
-chmod +x /etc/cron.daily/mailinabox-backup
 
 # Perform daily status checks. Compare each day to the previous
 # for changes and mail the changes to the administrator.

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -30,6 +30,12 @@ rm -f /etc/init.d/mailinabox
 ln -s $(pwd)/conf/management-initscript /etc/init.d/mailinabox
 hide_output update-rc.d mailinabox defaults
 
+# Set time zone to something convenient for the user
+# Backup will be set for 3am localtime so choice is important depending
+# on user locations.
+
+dpkg-reconfigure tzdata
+
 # Perform a daily backup.
 if [ -f /etc/cron.daily/mailinabox-backup ]; then
   rm /etc/cron.daily/mailinabox-backup

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -31,9 +31,12 @@ ln -s $(pwd)/conf/management-initscript /etc/init.d/mailinabox
 hide_output update-rc.d mailinabox defaults
 
 # Perform a daily backup.
+if [ -f /etc/cron.daily/mailinabox-backup ]; then
+  rm /etc/cron.daily/mailinabox-backup
+fi
 cat > /etc/cron.d/mailinabox-backup << EOF;
 # /etc/cron.d/mailinabox-backup: crontab fragment to run maininabox-backup
-#  This executes mailinabox-backup at 3am.
+#  This executes $(pwd)/management/backup.py at 3am.
 
 0 3 * * *	root	$(pwd)/management/backup.py
 EOF


### PR DESCRIPTION
Create /etc/cron.d/mailinabox-backup instead of /etc/cron.daily/mailinabox-backup.  Delete /etc/cron.daily/mailinabox-backup if it exists.

Still to be decided whether to change TZ to local TZ or to keep UTC and note local TZ in /etc/mailinabox.conf and adjust startup time for backup accordingly.