### PR TITLE
During the backup you will get login failures which will confuse iOS

### DIFF
--- a/management/backup.py
+++ b/management/backup.py
@@ -220,9 +220,9 @@ def perform_backup(full_backup):
 	full_backup = full_backup or should_force_full(env)
 
 	# Stop services.
-	shell('check_call', ["/usr/sbin/service", "dovecot", "stop"])
-	shell('check_call', ["/usr/sbin/service", "postfix", "stop"])
 	shell('check_call', ["/usr/sbin/service", "php5-fpm", "stop"])
+	shell('check_call', ["/usr/sbin/service", "postfix", "stop"])
+	shell('check_call', ["/usr/sbin/service", "dovecot", "stop"])
 
 	# Run a backup of STORAGE_ROOT (but excluding the backups themselves!).
 	# --allow-source-mismatch is needed in case the box's hostname is changed

--- a/management/backup.py
+++ b/management/backup.py
@@ -222,6 +222,7 @@ def perform_backup(full_backup):
 	# Stop services.
 	shell('check_call', ["/usr/sbin/service", "dovecot", "stop"])
 	shell('check_call', ["/usr/sbin/service", "postfix", "stop"])
+	shell('check_call', ["/usr/sbin/service", "php5-fpm", "stop"])
 
 	# Run a backup of STORAGE_ROOT (but excluding the backups themselves!).
 	# --allow-source-mismatch is needed in case the box's hostname is changed
@@ -243,6 +244,7 @@ def perform_backup(full_backup):
 		# Start services again.
 		shell('check_call', ["/usr/sbin/service", "dovecot", "start"])
 		shell('check_call', ["/usr/sbin/service", "postfix", "start"])
+		shell('check_call', ["/usr/sbin/service", "php5-fpm", "start"])
 
 	# Once the migrated backup is included in a new backup, it can be deleted.
 	if os.path.isdir(migrated_unencrypted_backup_dir):


### PR DESCRIPTION
During a backup z-push can't authenticate or fetch email. This will result in a client error which iOS doesn't recover from until you reenter your password.It is better to stop z-push as well during a backup, this will be treated as a connectivity issue and it should recover. 

This change will stop the services before the backup and start them afterwards.

I will test this for a few days on my main machine to see if it breaks anything else. 

I would like to be able to configure the backup time as well, shall I have a look into that? I know you are checking for an appropriate time in the logs, but for me configuring it would make more sense. 