### PR TITLE
Add log rotation to z-push

### DIFF
--- a/setup/zpush.sh
+++ b/setup/zpush.sh
@@ -75,6 +75,19 @@ chmod 750 /var/lib/z-push
 chown www-data:www-data /var/log/z-push
 chown www-data:www-data /var/lib/z-push
 
+# Add log rotation
+
+cat > /etc/logrotate.d/z-push <<EOF;
+/var/log/z-push/*.log {
+	weekly
+	missingok
+	rotate 52
+	compress
+	delaycompress
+	notifempty
+}
+EOF
+
 # Restart service.
 
 restart_service php5-fpm


### PR DESCRIPTION
I have added log rotation for z-push. After a while the files will grow and will never get cleaned up. Any one want to comment on the defaults? I like leaving the level the same as it currently is in z-push. Z-push has some problems that often need investigating. 

(I am currently tracking and trying to assist in debugging a few bugs)