### PR TITLE
Add alias for abuse@

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Still In Development
 Mail:
 
 * Updated Roundcube to version 1.1.3.
+* Auto-create RFC2142 aliases for abuse@.
 
 Control panel:
 
@@ -392,7 +393,7 @@ v0.02 (September 21, 2014)
 * Better logic for determining when to take a full backup.
 * Reduce DNS TTL, not that it seems to really matter.
 * Add SSHFP DNS records.
-* Add an API for setting custom DNS records 
+* Add an API for setting custom DNS records
 * Update to ownCloud 7.0.2.
 * Some things were broken if the machine had an IPv6 address.
 * Use a dialogs library to ask users questions during setup.

--- a/management/templates/aliases.html
+++ b/management/templates/aliases.html
@@ -86,7 +86,7 @@
   </tbody>
 </table>
 
-<p style="margin-top: 1.5em"><small>hostmaster@, postmaster@, and admin@ email addresses are required on some domains.</small></p>
+<p style="margin-top: 1.5em"><small>hostmaster@, postmaster@, admin@ and abuse@ email addresses are required on some domains.</small></p>
 
 <div style="display: none">
   <table>


### PR DESCRIPTION
This adds mail alias abuse@ for domains (next to postmaster@ and admin@). 

Fixes #604 