### PR TITLE
don't install bind9-host when setting hostname

### DIFF
--- a/setup/questions.sh
+++ b/setup/questions.sh
@@ -207,8 +207,6 @@ if [ "$PUBLIC_IPV6" = "auto" ]; then
 	PUBLIC_IPV6=$(get_publicip_from_web_service 6 || get_default_privateip 6)
 fi
 if [ "$PRIMARY_HOSTNAME" = "auto" ]; then
-	# Use reverse DNS to get this machine's hostname. Install bind9-host early.
-	hide_output apt-get -y install bind9-host
 	PRIMARY_HOSTNAME=$(get_default_hostname)
 elif [ "$PRIMARY_HOSTNAME" = "auto-easy" ]; then
 	# Generate a probably-unique subdomain under our justtesting.email domain.


### PR DESCRIPTION
also remove an incorrect comment.

https://github.com/mail-in-a-box/mailinabox/commit/5edaeb8c7baa69bec952b97a9dbb5c77ced32e90#commitcomment-14778339

Tell me if there's more cleanup that can be done.