### PR TITLE
add --replace-all argument to ssl_certificates.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ System:
 * Z-Push (Exchange/ActiveSync) logs now exclude warnings and are now rotated to save disk space.
 * Fix pip command that might have not installed all necessary Python packages.
 * The control panel and backup would not work on Google Compute Engine because they install a conflicting boto package.
+* Added a new command `management/backup.py --restore` to restore files from a backup to a target directory (command line arguments are passed to `duplicity restore`).
 
 v0.14 (November 4, 2015)
 ------------------------

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,6 +1,8 @@
 ## $HOSTNAME
 
-# Redirect all HTTP to HTTPS.
+# Redirect all HTTP to HTTPS *except* the ACME challenges (Let's Encrypt SSL certificate
+# domain validation challenges) path, which must be served over HTTP per the ACME spec
+# (due to some Apache vulnerability).
 server {
 	listen 80;
 	listen [::]:80;
@@ -12,10 +14,19 @@ server {
 	# error pages and in the "Server" HTTP-Header.
 	server_tokens off;
 
-	# Redirect using the 'return' directive and the built-in
-	# variable '$request_uri' to avoid any capturing, matching
-	# or evaluation of regular expressions.
-	return 301 https://$HOSTNAME$request_uri;
+	location / {
+		# Redirect using the 'return' directive and the built-in
+		# variable '$request_uri' to avoid any capturing, matching
+		# or evaluation of regular expressions.
+		return 301 https://$HOSTNAME$request_uri;
+	}
+
+	location /.well-known/acme-challenge/ {
+		# This path must be served over HTTP for ACME domain validation.
+		# We map this to a special path where our SSL cert provisioning
+		# tool knows to store challenge response files.
+		alias $STORAGE_ROOT/ssl/lets_encrypt/acme_challenges/;
+	}
 }
 
 # The secure HTTPS server.

--- a/management/backup.py
+++ b/management/backup.py
@@ -314,6 +314,18 @@ def run_duplicity_verification():
 		env["STORAGE_ROOT"],
 	], get_env(env))
 
+def run_duplicity_restore(args):
+	env = load_environment()
+	config = get_backup_config(env)
+	backup_cache_dir = os.path.join(env["STORAGE_ROOT"], 'backup', 'cache')
+	shell('check_call', [
+		"/usr/bin/duplicity",
+		"restore",
+		"--archive-dir", backup_cache_dir,
+		config["target"],
+		] + args,
+	get_env(env))
+
 def list_target_files(config):
 	import urllib.parse
 	try:
@@ -442,6 +454,11 @@ if __name__ == "__main__":
 		# Show backup status.
 		ret = backup_status(load_environment())
 		print(rtyaml.dump(ret["backups"]))
+
+	elif len(sys.argv) >= 2 and sys.argv[1] == "--restore":
+		# Run duplicity restore. Rest of command line passed as arguments
+		# to duplicity. The restore path should be specified.
+		run_duplicity_restore(sys.argv[2:])
 
 	else:
 		# Perform a backup. Add --full to force a full backup rather than

--- a/management/ssl_certificates.py
+++ b/management/ssl_certificates.py
@@ -182,10 +182,13 @@ def get_certificates_to_provision(env):
 			domains.add(domain)
 		else:
 			cert = cert["certificate_object"]
+			import sys
 			if cert.issuer == cert.subject:
 				# This is self-signed. Get a real one.
 				domains.add(domain)
-			
+			elif "--replace-all" in sys.argv:
+				domains.add(domain)
+
 			# Valid certificate today, but is it expiring soon?
 			elif cert.not_valid_after-now < datetime.timedelta(days=14):
 				domains.add(domain)

--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -262,22 +262,23 @@ def run_domain_checks(rounded_time, env, output, pool):
 	# Get the list of domains that we don't serve web for because of a custom CNAME/A record.
 	domains_with_a_records = get_domains_with_a_records(env)
 
-	ssl_certificates = get_ssl_certificates(env)
-
 	# Serial version:
 	#for domain in sort_domains(domains_to_check, env):
 	#	run_domain_checks_on_domain(domain, rounded_time, env, dns_domains, dns_zonefiles, mail_domains, web_domains)
 
 	# Parallelize the checks across a worker pool.
-	args = ((domain, rounded_time, env, dns_domains, dns_zonefiles, mail_domains, web_domains, domains_with_a_records, ssl_certificates)
+	args = ((domain, rounded_time, env, dns_domains, dns_zonefiles, mail_domains, web_domains, domains_with_a_records)
 		for domain in domains_to_check)
 	ret = pool.starmap(run_domain_checks_on_domain, args, chunksize=1)
 	ret = dict(ret) # (domain, output) => { domain: output }
 	for domain in sort_domains(ret, env):
 		ret[domain].playback(output)
 
-def run_domain_checks_on_domain(domain, rounded_time, env, dns_domains, dns_zonefiles, mail_domains, web_domains, domains_with_a_records, ssl_certificates):
+def run_domain_checks_on_domain(domain, rounded_time, env, dns_domains, dns_zonefiles, mail_domains, web_domains, domains_with_a_records):
 	output = BufferedOutput()
+
+	# we'd move this up, but this returns non-pickleable values
+	ssl_certificates = get_ssl_certificates(env)
 
 	# The domain is IDNA-encoded in the database, but for display use Unicode.
 	try:
@@ -640,45 +641,28 @@ def check_ssl_cert(domain, rounded_time, ssl_certificates, env, output):
 	if query_dns(domain, "A", None) not in (env['PUBLIC_IP'], None): return
 
 	# Where is the SSL stored?
-	x = get_domain_ssl_files(domain, ssl_certificates, env, allow_missing_cert=True)
-
-	if x is None:
+	tls_cert = get_domain_ssl_files(domain, ssl_certificates, env, allow_missing_cert=True)
+	if tls_cert is None:
 		output.print_warning("""No SSL certificate is installed for this domain. Visitors to a website on
 			this domain will get a security warning. If you are not serving a website on this domain, you do
 			not need to take any action. Use the SSL Certificates page in the control panel to install a
 			SSL certificate.""")
 		return
 
-	ssl_key, ssl_certificate, ssl_via = x
-
 	# Check that the certificate is good.
 
-	cert_status, cert_status_details = check_certificate(domain, ssl_certificate, ssl_key, rounded_time=rounded_time)
+	cert_status, cert_status_details = check_certificate(domain, tls_cert["certificate"], tls_cert["private-key"], rounded_time=rounded_time)
 
 	if cert_status == "OK":
 		# The certificate is ok. The details has expiry info.
-		output.print_ok("SSL certificate is signed & valid. %s %s" % (ssl_via if ssl_via else "", cert_status_details))
+		output.print_ok("SSL certificate is signed & valid. " + cert_status_details)
 
 	elif cert_status == "SELF-SIGNED":
 		# Offer instructions for purchasing a signed certificate.
-
-		fingerprint = shell('check_output', [
-			"openssl",
-			"x509",
-			"-in", ssl_certificate,
-			"-noout",
-			"-fingerprint"
-			])
-		fingerprint = re.sub(".*Fingerprint=", "", fingerprint).strip()
-
 		if domain == env['PRIMARY_HOSTNAME']:
 			output.print_error("""The SSL certificate for this domain is currently self-signed. You will get a security
 			warning when you check or send email and when visiting this domain in a web browser (for webmail or
-			static site hosting). Use the SSL Certificates page in the control panel to install a signed SSL certificate.
-			You may choose to leave the self-signed certificate in place and confirm the security exception, but check that
-			the certificate fingerprint matches the following:""")
-			output.print_line("")
-			output.print_line("   " + fingerprint, monospace=True)
+			static site hosting).""")
 		else:
 			output.print_error("""The SSL certificate for this domain is self-signed.""")
 
@@ -925,10 +909,10 @@ if __name__ == "__main__":
 		if query_dns(domain, "A") != env['PUBLIC_IP']:
 			sys.exit(1)
 		ssl_certificates = get_ssl_certificates(env)
-		ssl_key, ssl_certificate, ssl_via = get_domain_ssl_files(domain, ssl_certificates, env)
-		if not os.path.exists(ssl_certificate):
+		tls_cert = get_domain_ssl_files(domain, ssl_certificates, env)
+		if not os.path.exists(tls_cert["certificate"]):
 			sys.exit(1)
-		cert_status, cert_status_details = check_certificate(domain, ssl_certificate, ssl_key, warn_if_expiring_soon=False)
+		cert_status, cert_status_details = check_certificate(domain, tls_cert["certificate"], tls_cert["private-key"], warn_if_expiring_soon=False)
 		if cert_status != "OK":
 			sys.exit(1)
 		sys.exit(0)

--- a/setup/start.sh
+++ b/setup/start.sh
@@ -115,6 +115,9 @@ done
 tools/dns_update
 tools/web_update
 
+# If DNS is already working, try to provision TLS certficates from Let's Encrypt.
+management/ssl_certificates.py
+
 # If there aren't any mail users yet, create one.
 source setup/firstuser.sh
 


### PR DESCRIPTION
I manually installed LE certs and didn't want to wait two months until I could try the letsencrypt branch.  Now, if you see `No domains hosted on this box need a certificate at this time.`, just run:

    ./management/ssl_certificates.py --replace-all

This is the simplest thing I saw that would work.  Happy to make changes or ignore in favor of a better solution.

LE worked great.  Love this branch.