### PR TITLE
set default_process_limit to a simple value

### DIFF
--- a/setup/mail-dovecot.sh
+++ b/setup/mail-dovecot.sh
@@ -38,7 +38,7 @@ apt_install \
 # would be 20 users). Set it to 250 times the number of cores this
 # machine has, so on a two-core machine that's 500 processes/100 users).
 tools/editconf.py /etc/dovecot/conf.d/10-master.conf \
-	default_process_limit=$(echo "`nproc` * 250" | bc)
+	default_process_limit=1024
 
 # The inotify `max_user_instances` default is 128, which constrains
 # the total number of watched (IMAP IDLE push) folders by open connections.


### PR DESCRIPTION
This is the simplest way to unbreak `readable_bash.py`.  With this change, readable_bash runs to completion and generates usable docs.

I don't think this value is even being used...?  By my reading of the docs, `default_process_limit` is only used when `process_limit` is set to 0: http://wiki2.dovecot.org/Services#Service_limits.  And, since mail-in-a-box never sets `process_limit`, it remains at its default of 1024.  Therefore, `default_process_limit` is never used.  (right?)

Related dovecot mailing list message: http://dovecot.org/pipermail/dovecot/2012-January/080627.html

And the settings on my stock MIAB:

```
root@int:/etc# grep -r process_limit .
./dovecot/conf.d/10-master.conf:#default_process_limit = 100
./dovecot/conf.d/10-master.conf:default_process_limit=500
./dovecot/conf.d/10-master.conf:  #process_limit = 1024
./dovecot/conf.d/10-master.conf:  #process_limit = 1024
./dovecot/conf.d/20-managesieve.conf:  #process_limit = 1024
```

So, maybe the proper fix is just to delete `default_process_limit` entirely.

If you do want to keep the computation, I can try to figure out how to make modgrammar happy with the `$(...)` construct.  But it's going to take quite a bit longer.