### PR TITLE
Use one imap-login process for all logins

### DIFF
--- a/setup/mail-dovecot.sh
+++ b/setup/mail-dovecot.sh
@@ -39,6 +39,14 @@ apt_install \
 # machine has, so on a two-core machine that's 500 processes/100 users).
 tools/editconf.py /etc/dovecot/conf.d/10-master.conf \
 	default_process_limit=$(echo "`nproc` * 250" | bc)
+	
+# Configure dovecot to use one imap-login process that is always available 
+# for all logins to improve performance.
+# This should have no security implications as we already use only one system 
+# user for all of our virtual mailboxes.
+tools/editconf.py /etc/dovecot/conf.d/10-master.conf \
+	service_count=0 \
+	process_min_avail=1
 
 # The inotify `max_user_instances` default is 128, which constrains
 # the total number of watched (IMAP IDLE push) folders by open connections.


### PR DESCRIPTION
As already mentioned in https://github.com/mail-in-a-box/mailinabox/issues/535.

Configure dovecot to use one imap-login process that is always available for all logins instead of one imap-login process for every login. AFAIK that should have no security implications as mentioned in http://wiki.dovecot.org/LoginProcess as we already use one system user for all of our virtual mailboxes.

The default vsz_limit of 256M should suffice, but I think it would be good if some contributors could verify that. 