### PR TITLE
Gandi tells me that .be TLD only supports algorithms 8 and 10 for DNSSEC

### DIFF
--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -502,11 +502,12 @@ zone:
 
 def dnssec_choose_algo(domain, env):
 	if '.' in domain and domain.rsplit('.')[-1] in \
-		("email", "guide", "fund"):
+		("email", "guide", "fund", "be"):
 		# At GoDaddy, RSASHA256 is the only algorithm supported
 		# for .email and .guide.
 		# A variety of algorithms are supported for .fund. This
 		# is preferred.
+		# Gandi tells me that .be does not support RSASHA1-NSEC3-SHA1
 		return "RSASHA256"
 
 	# For any domain we were able to sign before, don't change the algorithm


### PR DESCRIPTION
I wasn’t able to set the DNSSEC for my .be domain.
It failed without specifying why.
I contacted Gandi and they told me that .be don't support RSASHA1-NSEC3-SHA1.

this change makes .be websites use RSASHA256 instead.