### PR TITLE
fix LTDs using multiple digests for DS record

### DIFF
--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -499,6 +499,13 @@ def check_dnssec(domain, env, output, dns_zonefiles, is_checking_primary=False):
 
 	# Query public DNS for the DS record at the registrar.
 	ds = query_dns(domain, "DS", nxdomain=None)
+	# Some registars return multiple DS records using different digest function
+	# we are only interested in digest function 2
+	multi_ds = ds.split("; ")
+	for single_ds in multi_ds:
+		if len(single_ds.split(" ")) == 4 and single_ds.split(" ")[2] == "2":
+			ds = single_ds
+
 	ds_looks_valid = ds and len(ds.split(" ")) == 4
 	if ds_looks_valid: ds = ds.split(" ")
 	if ds_looks_valid and ds[0] == ds_keytag and ds[1] == ds_alg and ds[3] == digests.get(ds[2]):


### PR DESCRIPTION
Some LTDs like .be use both digest functions 1 and 2 resulting in 2 DS records. This eventuality was not taken into account by the script resulting in a false warning.

This quick fix does not address the problem caused if multiple DNSSEC keys are configured.
This should be addressed as it could be used to migrate users smoothly to a new DNSSEC algorithm, or to rotate the keys as suggested by the DNSSEC specifications.