### PR TITLE
Quota implementation

### DIFF
--- a/management/daemon.py
+++ b/management/daemon.py
@@ -6,7 +6,7 @@ from functools import wraps
 from flask import Flask, request, render_template, abort, Response, send_from_directory, make_response
 
 import auth, utils, multiprocessing.pool
-from mailconfig import get_mail_users, get_mail_users_ex, get_admins, add_mail_user, set_mail_password, remove_mail_user
+from mailconfig import get_mail_users, get_mail_users_ex, get_admins, add_mail_user, set_mail_password, set_mail_quota, remove_mail_user
 from mailconfig import get_mail_user_privileges, add_remove_mail_user_privilege
 from mailconfig import get_mail_aliases, get_mail_aliases_ex, get_mail_domains, add_mail_alias, remove_mail_alias
 
@@ -154,7 +154,11 @@ def mail_users():
 @authorized_personnel_only
 def mail_users_add():
 	try:
-		return add_mail_user(request.form.get('email', ''), request.form.get('password', ''), request.form.get('privileges', ''), env)
+		return add_mail_user(
+			request.form.get('email', ''),
+			request.form.get('password', ''),
+			request.form.get('privileges', ''),
+			request.form.get('quota', ''), env)
 	except ValueError as e:
 		return (str(e), 400)
 
@@ -163,6 +167,14 @@ def mail_users_add():
 def mail_users_password():
 	try:
 		return set_mail_password(request.form.get('email', ''), request.form.get('password', ''), env)
+	except ValueError as e:
+		return (str(e), 400)
+
+@app.route('/mail/users/quota', methods=['POST'])
+@authorized_personnel_only
+def mail_users_quota():
+	try:
+		return set_mail_quota(request.form.get('email', ''), request.form.get('quota', ''), env)
 	except ValueError as e:
 		return (str(e), 400)
 

--- a/management/templates/users.html
+++ b/management/templates/users.html
@@ -23,6 +23,10 @@
     <input type="password" class="form-control" id="adduserPassword" placeholder="Password">
   </div>
   <div class="form-group">
+    <label class="sr-only" for="adduserQuota">Quota (MB)</label>
+    <input type="text" class="form-control" id="adduserQuota" placeholder="Quota (MB)">
+  </div>
+  <div class="form-group">
     <select class="form-control" id="adduserPrivs">
       <option value="">Normal User</option>
       <option value="admin">Administrator</option>
@@ -31,6 +35,7 @@
   <button type="submit" class="btn btn-primary">Add User</button>
 </form>
 <ul style="margin-top: 1em; padding-left: 1.5em; font-size: 90%;">
+  <li>Enter blank or 0 for no quota (unlimited) accounts.</li>
   <li>Passwords must be at least eight characters and may not contain spaces. For best results, <a href="#" onclick="return generate_random_password()">generate a random password</a>.</li>
   <li>Use <a href="#" onclick="return show_panel('aliases')">aliases</a> to create email addresses that forward to existing accounts.</li>
   <li>Administrators get access to this control panel.</li>
@@ -44,6 +49,7 @@
       <th width="50%">Email Address</th>
       <th>Actions</th>
       <th>Mailbox Size</th>
+      <th>Mailbox Quota</th>
     </tr>
   </thead>
   <tbody>
@@ -66,6 +72,13 @@
           |
         </span>
 
+        <span class="if_active">
+          <a href="#" onclick="users_set_quota(this); return false;" class='setquota' title="Set Quota">
+            set quota
+          </a>
+          |
+        </span>
+
         <span class='add-privs'>
         </span>
 
@@ -74,6 +87,8 @@
         </a>
     </td>
     <td class='mailboxsize'>
+    </td>
+    <td class='mailboxquota'>
     </td>
   </tr>
   <tr id="user-extra-template" class="if_inactive">
@@ -157,6 +172,7 @@ function show_users() {
           n.attr('data-email', user.email);
           n.find('.address').text(user.email)
           n.find('.mailboxsize').text(nice_size(user.mailbox_size))
+          n.find('.mailboxquota').text(''+user.quota + " MB")
           n2.find('.restore_info tt').text(user.mailbox);
 
           if (user.status == 'inactive') continue;
@@ -185,13 +201,15 @@ function do_add_user() {
   var email = $("#adduserEmail").val();
   var pw = $("#adduserPassword").val();
   var privs = $("#adduserPrivs").val();
+  var quota = $("#adduserQuota").val();
   api(
     "/mail/users/add",
     "POST",
     {
       email: email,
       password: pw,
-      privileges: privs
+      privileges: privs,
+      quota: quota
     },
     function(r) {
       // Responses are multiple lines of pre-formatted text.
@@ -229,6 +247,33 @@ function users_set_password(elem) {
         },
         function(r) {
           show_modal_error("Set Password", r);
+        });
+    });
+}
+
+function users_set_quota(elem) {
+  var email = $(elem).parents('tr').attr('data-email');
+
+  var quota = "";
+
+  show_modal_confirm(
+    "User Quota",
+    $("<p>Set a new quota for <b>" + email + "</b>?</p> <p><label for='quota_value' style='display: block; font-weight: normal'>New Quota (MB):</label><input type='text' id='quota_value'></p><p><small>Quota must be positive integer. Enter 0 or blank for no quota.</small></p>"),
+    "Set Quota",
+    function() {
+      api(
+        "/mail/users/quota",
+        "POST",
+        {
+          email: email,
+          quota: $('#quota_value').val()
+        },
+        function(r) {
+          // Responses are multiple lines of pre-formatted text.
+          show_modal_error("Set Quota", $("<pre/>").text(r));
+        },
+        function(r) {
+          show_modal_error("Set Quota", r);
         });
     });
 }

--- a/setup/mail-postfix.sh
+++ b/setup/mail-postfix.sh
@@ -200,7 +200,7 @@ tools/editconf.py /etc/postfix/main.cf virtual_transport=lmtp:[127.0.0.1]:10025
 # "450 4.7.1 Client host rejected: Service unavailable". This is a retry code, so the mail doesn't properly bounce. #NODOC
 tools/editconf.py /etc/postfix/main.cf \
 	smtpd_sender_restrictions="reject_non_fqdn_sender,reject_unknown_sender_domain,reject_authenticated_sender_login_mismatch,reject_rhsbl_sender dbl.spamhaus.org" \
-	smtpd_recipient_restrictions=permit_sasl_authenticated,permit_mynetworks,"reject_rbl_client zen.spamhaus.org",reject_unlisted_recipient,"check_policy_service inet:127.0.0.1:10023"
+	smtpd_recipient_restrictions=permit_sasl_authenticated,permit_mynetworks,"reject_rbl_client zen.spamhaus.org",reject_unlisted_recipient,"check_policy_service inet:127.0.0.1:10023","check_policy_service inet:127.0.0.1:12340"
 
 # Postfix connects to Postgrey on the 127.0.0.1 interface specifically. Ensure that
 # Postgrey listens on the same interface (and not IPv6, for instance).

--- a/setup/mail-users.sh
+++ b/setup/mail-users.sh
@@ -20,7 +20,7 @@ db_path=$STORAGE_ROOT/mail/users.sqlite
 # Create an empty database if it doesn't yet exist.
 if [ ! -f $db_path ]; then
 	echo Creating new user database: $db_path;
-	echo "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, email TEXT NOT NULL UNIQUE, password TEXT NOT NULL, extra, privileges TEXT NOT NULL DEFAULT '');" | sqlite3 $db_path;
+	echo "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, email TEXT NOT NULL UNIQUE, password TEXT NOT NULL, quota NUMERIC NOT NULL DEFAULT 0, extra, privileges TEXT NOT NULL DEFAULT '');" | sqlite3 $db_path;
 	echo "CREATE TABLE aliases (id INTEGER PRIMARY KEY AUTOINCREMENT, source TEXT NOT NULL UNIQUE, destination TEXT NOT NULL, permitted_senders TEXT);" | sqlite3 $db_path;
 fi
 
@@ -40,6 +40,7 @@ passdb {
 userdb {
   driver = sql
   args = /etc/dovecot/dovecot-sql.conf.ext
+  default_fields = uid=mail gid=mail home=$STORAGE_ROOT/mail/mailboxes/%d/%n
 }
 EOF
 
@@ -48,6 +49,7 @@ cat > /etc/dovecot/dovecot-sql.conf.ext << EOF;
 driver = sqlite
 connect = $db_path
 default_pass_scheme = SHA512-CRYPT
+user_query = SELECT '*:storage=' || quota || 'M' AS quota_rule FROM users WHERE email='%u';
 password_query = SELECT email as user, password FROM users WHERE email='%u';
 user_query = SELECT email AS user, "mail" as uid, "mail" as gid, "$STORAGE_ROOT/mail/mailboxes/%d/%n" as home FROM users WHERE email='%u';
 iterate_query = SELECT email AS user FROM users;
@@ -148,5 +150,3 @@ EOF
 
 restart_service postfix
 restart_service dovecot
-
-

--- a/setup/migrate.py
+++ b/setup/migrate.py
@@ -148,6 +148,12 @@ def migration_11(env):
 		# meh
 		pass
 
+def migration_12(env):
+	# Add quota column to `users` table for quota implementation per user.
+	# Note that the numeric value represents megabyte. 0 is unlimited.
+	db = os.path.join(env["STORAGE_ROOT"], 'mail/users.sqlite')
+	shell("check_call", ["sqlite3", db, "ALTER TABLE users ADD quota NUMERIC NOT NULL DEFAULT 0"])
+
 def get_current_migration():
 	ver = 0
 	while True:
@@ -225,4 +231,3 @@ if __name__ == "__main__":
 	elif sys.argv[-1] == "--migrate":
 		# Perform migrations.
 		run_migrations()
-


### PR DESCRIPTION
As solution for #58, I have a very simple quota implementation. :)

In terms of code, I kept the common structures & conventions as close as possible. But I do suggest some refactor and cleanups (eg. frontend) on maybe major releases. I followed a bunch of guides for dovecot quota, mainly these:
- http://wiki2.dovecot.org/Quota/Configuration
- https://sys4.de/en/blog/2013/04/08/postfix-dovecot-mailbox-quota/

The best implementation seems to be for dovecot to serve as service for postfix to avoid backscattering. The quota can probably be later be expanded to other mailboxes such as index, sent, etc or graces, but that's TBD.

I added a new column to `users` called `quota`, which contains `NUMERIC` that represents MB. It can probably be bytes, but I feel like MB is simpler and straightforward. Please suggest if otherwise.

I noticed that we already have `check_policy_service`  for `smtpd_recipient_restrictions`. I needed to add another one for quota, so I did, but I'm not sure if that's the way to do it (in terms of adding multiple entries of `check_policy_service`), so someone needs to verify that.

In any case, please review. Merge if like, close if not. I tested it on my own mail server and it seems to work OK.
