### PR TITLE
Fixing issue making it impossible to send mail from Z-Push

### DIFF
--- a/conf/zpush/backend_imap.php
+++ b/conf/zpush/backend_imap.php
@@ -41,6 +41,7 @@ define('IMAP_FROM_LDAP_QUERY', '(mail=#username@#domain)');
 define('IMAP_FROM_LDAP_FIELDS', serialize(array('givenname', 'sn', 'mail')));
 define('IMAP_FROM_LDAP_FROM', '#givenname #sn <#mail>');
 
+define('IMAP_SMTP_METHOD', 'sendmail');
 
 global $imap_smtp_params;
 $imap_smtp_params = array('host' => 'ssl://localhost', 'port' => 587, 'auth' => true, 'username' => 'imap_username', 'password' => 'imap_password');


### PR DESCRIPTION
 * added IMAP_SMTP_METHOD to z_push/backend_imap
 * reverting that line accidentally deleted in commit 5055ef060dee908f5e98ad55fe5c380675a465c9
 * cf pull request GH-580 that commit is part of

because of this missing line, Z-Push reverted to the PHP `mail()` method, that couldn't work because it did not have the `sendmail` path set in php-fpm's `www.conf`. Setting this up, makes Z-Push directly connect to the SMTP server, without relying on PHP's `mail()`.