### PR TITLE
Support munin's cgi dynazoom

### DIFF
--- a/management/daemon.py
+++ b/management/daemon.py
@@ -514,33 +514,20 @@ def munin(filename=""):
 @authorized_personnel_only
 def munin_cgi(filename=""):
 	""" Relay munin cgi dynazoom requests
-
 	/usr/lib/munin/cgi/munin-cgi-graph is a perl cgi script in the munin package
 	that is responsible for generating binary png images _and_ associated HTTP
 	headers based on parameters in the requesting URL. All output is written
 	to stdout which munin_cgi splits into response headers and binary response
 	data.
-
-	munin-cgi-graph reads environment variables as well as passed input to determin
+	munin-cgi-graph reads environment variables as well as passed input to determine
 	what it should do. It expects a path to be in the env-var PATH_INFO, and a
 	querystring to be in the env-var QUERY_STRING as well as passed as input to the
 	command.
-
-	munin-cgi-graph has several failure modes. Some write HTTP 404 Status headers
-	and others return nonzero exit codes. munin_cgi has some basic handling, and
-	logs errors to app.logger.
-
-	= Reasoning =
+	munin-cgi-graph has several failure modes. Some write HTTP Status headers and
+	others return nonzero exit codes.
 	Situating munin_cgi between the user-agent and munin-cgi-graph enables keeping
 	the cgi script behind mailinabox's auth mechanisms and avoids additional
 	support infrastructure like spawn-fcgi.
-
-	= Configuration =
-	A single configuration change is all that is required to enable the
-	functionality of munin_cgi. In the munin.conf file (/etc/munin/munin.conf) add
-	the following line above your server listings:
-	`cgiurl_graph /admin/munin/cgi-graph`
-	This will tell munin to override the default path for dynazoom requests.
 	"""
 
 	COMMAND = 'su - munin --preserve-environment --shell=/bin/bash -c "/usr/lib/munin/cgi/munin-cgi-graph \'%s\'"'

--- a/setup/munin.sh
+++ b/setup/munin.sh
@@ -7,7 +7,8 @@ source /etc/mailinabox.conf # load global vars
 
 # install Munin
 echo "Installing Munin (system monitoring)..."
-apt_install munin munin-node
+apt_install munin munin-node libcgi-fast-perl
+# libcgi-fast-perl is needed by /usr/lib/munin/cgi/munin-cgi-graph
 
 # edit config
 cat > /etc/munin/munin.conf <<EOF;
@@ -31,6 +32,10 @@ contacts admin
 contact.admin.command mail -s "Munin notification ${var:host}" administrator@$PRIMARY_HOSTNAME
 contact.admin.always_send warning critical
 EOF
+
+# The Debian installer touches these files and chowns them to www-data:adm for use with spawn-fcgi
+chown munin. /var/log/munin/munin-cgi-html.log
+chown munin. /var/log/munin/munin-cgi-graph.log
 
 # ensure munin-node knows the name of this machine
 tools/editconf.py /etc/munin/munin-node.conf -s \

--- a/setup/munin.sh
+++ b/setup/munin.sh
@@ -19,6 +19,9 @@ tmpldir /etc/munin/templates
 
 includedir /etc/munin/munin-conf.d
 
+# path dynazoom uses for requests
+cgiurl_graph /admin/munin/cgi-graph
+
 # a simple host tree
 [$PRIMARY_HOSTNAME]
 address 127.0.0.1


### PR DESCRIPTION
Fixes #459 "Dynamic zooming of munin graphs doesn't work"

By adding a route to daemon.py and installing libcgi-fast-perl we can support munin's dynazoom and keep it behind mailinabox's auth mechanism.

 