### PR TITLE
Removes border and rounded corners from navbar

### DIFF
--- a/management/templates/index.html
+++ b/management/templates/index.html
@@ -70,7 +70,7 @@
     <!--[if lt IE 8]><p>Internet Explorer version 8 or any modern web browser is required to use this website, sorry.<![endif]-->
     <!--[if gt IE 7]><!-->
 
-    <div class="navbar navbar-inverse" role="navigation">
+    <div class="navbar navbar-inverse navbar-static-top" role="navigation">
       <div class="container">
         <div class="navbar-header">
           <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target=".navbar-collapse">


### PR DESCRIPTION
A subtle difference but I'd say it looks better without the ronded corners and border.

Before:
![screenshot 2016-01-14 15 48 16](https://cloud.githubusercontent.com/assets/76424/12327349/4e5e9c70-bad6-11e5-9a45-b133e9018cef.png)

After:
![screenshot 2016-01-14 15 47 48](https://cloud.githubusercontent.com/assets/76424/12327348/4e5ca10e-bad6-11e5-8cde-c58ef5545291.png)
