### PR TITLE
Postfix mail queue time

### DIFF
--- a/setup/mail-postfix.sh
+++ b/setup/mail-postfix.sh
@@ -60,13 +60,18 @@ apt_install postfix postfix-pcre postgrey ca-certificates
 # * Set our name (the Debian default seems to be "localhost" but make it our hostname).
 # * Set the name of the local machine to localhost, which means xxx@localhost is delivered locally, although we don't use it.
 # * Set the SMTP banner (which must have the hostname first, then anything).
-# * Set the delay_warning_time to 1 day. Informs users that their e-mail delivery is delayed.
+# * Set the delay_warning_time to 3 hours to inform users that their e-mail delivery is delayed.
+# * The bounce_queue_lifetime refers to MAILER-DAEMON messages. Should be short and has no effect on regular mail.
+# * Set maximal_queue_lifetime to 2 days. Server will try to send an undeliverable e-mail for the maximum of 2 days.
+
 tools/editconf.py /etc/postfix/main.cf \
 	inet_interfaces=all \
 	myhostname=$PRIMARY_HOSTNAME\
 	smtpd_banner="\$myhostname ESMTP Hi, I'm a Mail-in-a-Box (Ubuntu/Postfix; see https://mailinabox.email/)" \
 	mydestination=localhost
-	delay_warning_time=1d
+	delay_warning_time=3h
+	maximal_queue_lifetime=2d 
+	bounce_queue_lifetime=1d
 
 # ### Outgoing Mail
 

--- a/setup/mail-postfix.sh
+++ b/setup/mail-postfix.sh
@@ -66,11 +66,11 @@ apt_install postfix postfix-pcre postgrey ca-certificates
 
 tools/editconf.py /etc/postfix/main.cf \
 	inet_interfaces=all \
-	myhostname=$PRIMARY_HOSTNAME\
+	myhostname=$PRIMARY_HOSTNAME \
 	smtpd_banner="\$myhostname ESMTP Hi, I'm a Mail-in-a-Box (Ubuntu/Postfix; see https://mailinabox.email/)" \
-	mydestination=localhost
-	delay_warning_time=3h
-	maximal_queue_lifetime=2d 
+	mydestination=localhost \
+	delay_warning_time=3h \
+	maximal_queue_lifetime=2d \
 	bounce_queue_lifetime=1d
 
 # ### Outgoing Mail

--- a/setup/mail-postfix.sh
+++ b/setup/mail-postfix.sh
@@ -60,14 +60,13 @@ apt_install postfix postfix-pcre postgrey ca-certificates
 # * Set our name (the Debian default seems to be "localhost" but make it our hostname).
 # * Set the name of the local machine to localhost, which means xxx@localhost is delivered locally, although we don't use it.
 # * Set the SMTP banner (which must have the hostname first, then anything).
-# * Set the default timeout for undeliverable e-mail to 1 day. The default is 5.
+# * Set the delay_warning_time to 1 day. Informs users that their e-mail delivery is delayed.
 tools/editconf.py /etc/postfix/main.cf \
 	inet_interfaces=all \
 	myhostname=$PRIMARY_HOSTNAME\
 	smtpd_banner="\$myhostname ESMTP Hi, I'm a Mail-in-a-Box (Ubuntu/Postfix; see https://mailinabox.email/)" \
 	mydestination=localhost
-	maximal_queue_lifetime=1d
-	bounce_queue_lifetime=1d
+	delay_warning_time=1d
 
 # ### Outgoing Mail
 

--- a/setup/mail-postfix.sh
+++ b/setup/mail-postfix.sh
@@ -60,11 +60,14 @@ apt_install postfix postfix-pcre postgrey ca-certificates
 # * Set our name (the Debian default seems to be "localhost" but make it our hostname).
 # * Set the name of the local machine to localhost, which means xxx@localhost is delivered locally, although we don't use it.
 # * Set the SMTP banner (which must have the hostname first, then anything).
+# * Set the default timeout for undeliverable e-mail to 1 day. The default is 5.
 tools/editconf.py /etc/postfix/main.cf \
 	inet_interfaces=all \
 	myhostname=$PRIMARY_HOSTNAME\
 	smtpd_banner="\$myhostname ESMTP Hi, I'm a Mail-in-a-Box (Ubuntu/Postfix; see https://mailinabox.email/)" \
 	mydestination=localhost
+	maximal_queue_lifetime=1d
+	bounce_queue_lifetime=1d
 
 # ### Outgoing Mail
 


### PR DESCRIPTION
The default timeout for Postfix's maximal_queue_lifetime and bounce_queue_lifetime is 5 days. 
This is way too long if you expect someone to have an answer and after 5 days you'll get the message that it's not delivered, it disrupts communication. 
Users could be It would be more responsive if the user got the 'can't deliver' error after 24 hours so appropriate action can be taken on time.