### PR TITLE
Allow sieve rules to be executed on spam messages

### DIFF
--- a/conf/sieve-spam.txt
+++ b/conf/sieve-spam.txt
@@ -2,6 +2,5 @@ require ["regex", "fileinto", "imap4flags"];
 
 if allof (header :regex "X-Spam-Status" "^Yes") {
   fileinto "Spam";
-  stop;
 }
 


### PR DESCRIPTION
This might be a matter of opinion so I'd like to open the discussion about this this way.

I have a bunch of messages which are incorrectly marked as spam which I'd like to move back to my inbox. I also have an alias which is receiving a lot of spam which I want to be marked as read inside my spam box so it's easier to filter out the remaining junk manually. Since sieve is instructed to stop filtering after moving junk mail to the Spam mailbox these actions can't be performed.

I'd argue that there is no issue in letting sieve continue filtering on spam messages. What do you think?