### PR TITLE
When previous panel was login, move to system_status

### DIFF
--- a/management/templates/login.html
+++ b/management/templates/login.html
@@ -117,7 +117,7 @@ function do_login() {
       // Open the next panel the user wants to go to. Do this after the XHR response
       // is over so that we don't start a new XHR request while this one is finishing,
       // which confuses the loading indicator.
-      setTimeout(function() { show_panel(!switch_back_to_panel ? 'system_status' : switch_back_to_panel) }, 300);
+      setTimeout(function() { show_panel(!switch_back_to_panel || switch_back_to_panel == "login" ? 'system_status' : switch_back_to_panel) }, 300);
     }
   })
 }


### PR DESCRIPTION
Should fix https://github.com/mail-in-a-box/mailinabox/issues/704 

Tested it a couple of times. Doesn't occur on my test devices anymore, but I couldn't always consistently reproduce it on them either. I will test this for the coming days and will report back if it keeps working and otherwise try and fix it.