### PR TITLE
Add check to preflight for exec on tmp

### DIFF
--- a/setup/preflight.sh
+++ b/setup/preflight.sh
@@ -34,10 +34,9 @@ if [ ! -d /vagrant ]; then
 fi
 fi
 
-# Check that tempfs is not mounted with noexec
+# Check that tempfs is mounted with exec
 MOUNTED_TMP_AS_NO_EXEC=$(grep "/tmp.*noexec" /proc/mounts)
 if [ -n "$MOUNTED_TMP_AS_NO_EXEC" ]; then
 	echo "Mail-in-a-Box has to have exec rights on /tmp, please mount /tmp with exec"
-
 	exit
 fi

--- a/setup/preflight.sh
+++ b/setup/preflight.sh
@@ -33,3 +33,11 @@ if [ ! -d /vagrant ]; then
 	exit
 fi
 fi
+
+# Check that tempfs is not mounted with noexec
+MOUNTED_TMP_AS_NO_EXEC=$(grep "/tmp.*noexec" /proc/mounts)
+if [ -n "$MOUNTED_TMP_AS_NO_EXEC" ]; then
+	echo "Mail-in-a-Box has to have exec rights on /tmp, please mount /tmp with exec"
+
+	exit
+fi

--- a/setup/start.sh
+++ b/setup/start.sh
@@ -5,7 +5,8 @@
 source setup/functions.sh # load our functions
 
 # Check system setup: Are we running as root on Ubuntu 14.04 on a
-# machine with enough memory? If not, this shows an error and exits.
+# machine with enough memory? Is /tmp mounted with exec.
+# If not, this shows an error and exits.
 source setup/preflight.sh
 
 # Ensure Python reads/writes files in UTF-8. If the machine


### PR DESCRIPTION
Should fix: https://github.com/mail-in-a-box/mailinabox/issues/609

I created a new DO droplet with a /tmp memory filesystem that was mounted with no exec. Starting the installation now fails with the message: "Mail-in-a-Box has to have exec rights on /tmp, please mount /tmp with exec"

Unmounting /tmp or remounting with exec continues the installation