### PR TITLE
Use the authoritative DNS server for PTR lookups

### DIFF
--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -421,7 +421,7 @@ def query_dns_ptr(qname):
 	rr = rrset[0]
 	if rr.rdtype != dns.rdatatype.SOA:
 		authority = rr.target
-		nameserver = resolver.query(authority).rrset[0].to_text()
+		nameserver = query_dns(authority, "A")
 
 	# Resolve the PTR record using the proper name server
 	return query_dns(qname, "PTR", at=nameserver)


### PR DESCRIPTION
For testing a possible solution to: https://github.com/mail-in-a-box/mailinabox/issues/628

This version will try to find the authoritative server for the address first and use that server to do the PTR lookup. After doing some reading on the matter I think this **might** solve the problem. It however doesn't happen al the time.

I would appreciate it if somebody could give this a try.