### PR TITLE
Fix for putty Line Drawing issues

### DIFF
--- a/setup/start.sh
+++ b/setup/start.sh
@@ -24,6 +24,8 @@ export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
 export LC_TYPE=en_US.UTF-8
 
+# Fix for putty Line Drawing characters to be shown correctly
+export NCURSES_NO_UTF8_ACS=1
 # Recall the last settings used if we're running this a second time.
 if [ -f /etc/mailinabox.conf ]; then
 	# Run any system migrations before proceeding. Since this is a second run,


### PR DESCRIPTION
Fix for putty (Windows) Line Drawing characters to be shown correctly.