### PR TITLE
Prevent click jacking of the management interface

### DIFF
--- a/conf/nginx-primaryonly.conf
+++ b/conf/nginx-primaryonly.conf
@@ -6,7 +6,9 @@
 	location /admin/ {
 		proxy_pass http://127.0.0.1:10222/;
 		proxy_set_header X-Forwarded-For $remote_addr;
-		add_header X-Frame-Options "SAMEORIGIN";
+		add_header X-Frame-Options "DENY";
+		add_header X-Content-Type-Options nosniff;
+		add_header Content-Security-Policy "frame-ancestors 'none';";
 	}
 
 	# ownCloud configuration.

--- a/conf/nginx-primaryonly.conf
+++ b/conf/nginx-primaryonly.conf
@@ -6,6 +6,7 @@
 	location /admin/ {
 		proxy_pass http://127.0.0.1:10222/;
 		proxy_set_header X-Forwarded-For $remote_addr;
+		add_header X-Frame-Options "SAMEORIGIN";
 	}
 
 	# ownCloud configuration.


### PR DESCRIPTION
This prevents [click jacking](https://en.wikipedia.org/wiki/Clickjacking) of the management interface. We aren't running a public site so for each individual it has to be a targeted attack. So it is a low risk to begin with, but a trivial fix to add.

Before:
<img width="435" alt="schermafbeelding 2016-03-13 om 18 22 16" src="https://cloud.githubusercontent.com/assets/5643940/13730302/fec531ac-e94b-11e5-88d9-4f5e21f85651.png">

After:
<img width="434" alt="schermafbeelding 2016-03-13 om 18 22 39" src="https://cloud.githubusercontent.com/assets/5643940/13730213/44fef804-e949-11e5-911f-26bc8e4de44f.png">

I have also set the nosniff option, see: https://msdn.microsoft.com/en-us/library/gg622941(v=vs.85).aspx

Still runs in a normal browser and I have tested the pages in the management interface, own cloud and webmail. The last two shouldn't be affected. We might also consider adding the headers to these two sub sites.

