### PR TITLE
Add a preflight check for supported architecture

### DIFF
--- a/setup/preflight.sh
+++ b/setup/preflight.sh
@@ -46,3 +46,17 @@ if [ -e ~/.wgetrc ]; then
 	echo "Mail-in-a-Box expects no overrides to wget defaults, ~/.wgetrc exists"
 	exit
 fi
+
+# Check that we are running on x86_64, any other architecture is unsupported and
+# will fail later in the setup when we try to install the custom build lucene packages.
+#
+# Set ARM=1 to ignore this check if you have built the packages yourself. If you do this
+# you are on your own!
+ARCHITECTURE=$(uname -m)
+if [ "$ARCHITECTURE" != "x86_64" ]; then
+if [ -z "$ARM" ]; then
+	echo "Mail-in-a-Box only supports x86_64 and will not work on any architecture like ARM."
+	echo "Your architecture is $ARCHITECTURE"
+	exit
+fi
+fi

--- a/setup/preflight.sh
+++ b/setup/preflight.sh
@@ -55,7 +55,7 @@ fi
 ARCHITECTURE=$(uname -m)
 if [ "$ARCHITECTURE" != "x86_64" ]; then
 if [ -z "$ARM" ]; then
-	echo "Mail-in-a-Box only supports x86_64 and will not work on any architecture like ARM."
+	echo "Mail-in-a-Box only supports x86_64 and will not work on any other architecture, like ARM."
 	echo "Your architecture is $ARCHITECTURE"
 	exit
 fi


### PR DESCRIPTION
This adds a preflight check to prevent the installer from continuing on anything other than the x86_64  architecture.

This should prevent issues being raised with unclear error messages, like https://github.com/mail-in-a-box/mailinabox/issues/753. 

People are running this on ARM by building their own packages. I have added an override variable to the checks and mentioned them in the comments. So people can continue to do this. 

I have tested this on x86_64 and on ARM. 

Output on ARM:

> ~/mailinabox#` setup/start.sh
> Mail-in-a-Box only supports x86_64 and will not work on any other architecture, like ARM.
> Your architecture is armv7l