### PR TITLE
Add swap space to the system

### DIFF
--- a/setup/system.sh
+++ b/setup/system.sh
@@ -38,7 +38,7 @@ if [ ! -e /swapfile ]; then
 
 	# Make sure the systeem keeps the file system inodes in
 	# memory as long as possible
-        hide_output sysctl vm.vfs_cache_pressure=50
+	hide_output sysctl vm.vfs_cache_pressure=50
 	tools/editconf.py /etc/sysctl.conf vm.vfs_cache_pressure=50
 fi
 fi

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -33,19 +33,13 @@ if [ ! -e /swapfile ]; then
 	echo "/swapfile   none    swap    sw    0   0" >> /etc/fstab
 
 	# Make sure the system only swaps as a last resort
-	SWAPPINESS=$(grep vm.swappiness /etc/sysctl.conf)
-	if [ -z "$SWAPPINESS" ]; then
-		hide_output sysctl vm.swappiness=10
-		echo "vm.swappiness=10" >> /etc/sysctl.conf
-	fi
+	hide_output sysctl vm.swappiness=10
+	tools/editconf.py /etc/sysctl.conf vm.swappiness=10
 
 	# Make sure the systeem keeps the file system inodes in
 	# memory as long as possible
-	PRESSURE=$(grep vm.vfs_cache_pressure /etc/sysctl.conf)
-        if [ -z "$PRESSURE" ]; then
-                hide_output sysctl vm.vfs_cache_pressure=50
-                echo "vm.vfs_cache_pressure=50" >> /etc/sysctl.conf
-        fi
+        hide_output sysctl vm.vfs_cache_pressure=50
+	tools/editconf.py /etc/sysctl.conf vm.vfs_cache_pressure=50
 fi
 fi
 fi

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -41,7 +41,8 @@ if
 then
 	echo "Adding swap to the system..."
 
-	# Allocate and activate the swap file
+	# Allocate and activate the swap file. Allocate in 1KB chuncks
+	# doing it in one go, could fail on low memory systems
 	dd if=/dev/zero of=/swapfile bs=1024 count=$[1024*1024] status=none
 	if [ -e /swapfile ]; then
 		chmod 600 /swapfile
@@ -50,7 +51,7 @@ then
 	fi
 
 	# Check if swap is mounted then activate on boot
-        if [ -n "$(swapon -s | grep "\/swapfile")" ]; then
+        if swapon -s | grep -q "\/swapfile"; then
 		echo "/swapfile   none    swap    sw    0   0" >> /etc/fstab
 	else
 		echo "ERROR: Swap allocation failed"

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -23,7 +23,7 @@ if [ -z "$SWAP_MOUNTED" ]; then
 if [ ! -e /swapfile ]; then
 	echo "Adding swap to the system..."
 
-	# Allocate and active the swap file
+	# Allocate and activate the swap file
 	fallocate -l 1G /swapfile
 	chmod 600 /swapfile
 	hide_output mkswap /swapfile

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -18,7 +18,7 @@ source setup/functions.sh # load our functions
 
 SWAP_MOUNTED=$(grep "swap" /proc/mounts)
 TOTAL_PHYSICAL_MEM=$(head -n 1 /proc/meminfo | awk '{print $2}')
-if [ $TOTAL_PHYSICAL_MEM -lt 19000000 ]; then
+if [ $TOTAL_PHYSICAL_MEM -lt 1900000 ]; then
 if [ -z "$SWAP_MOUNTED" ]; then
 if [ ! -e /swapfile ]; then
 	echo "Adding swap to the system..."

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -15,7 +15,7 @@ source setup/functions.sh # load our functions
 # than 5GB of disk space available
 
 # The following checks are performed:
-# - Check if swap is currently mountend by looking at /proc/mounts
+# - Check if swap is currently mountend by looking at /proc/swaps
 # - Check if the user intents to activate swap on next boot by checking fstab entries.
 # - Check if a swapfile already exists
 # - Check if the root file system is not btrfs, might be an incompatible version with
@@ -26,7 +26,7 @@ source setup/functions.sh # load our functions
 # See https://www.digitalocean.com/community/tutorials/how-to-add-swap-on-ubuntu-14-04
 # for reference
 
-SWAP_MOUNTED=$(grep "swap" /proc/mounts)
+SWAP_MOUNTED=$(cat /proc/swaps | tail -n+2)
 SWAP_IN_FSTAB=$(grep "swap" /etc/fstab)
 ROOT_IS_BTRFS=$(grep "\/ .*btrfs" /proc/mounts)
 TOTAL_PHYSICAL_MEM=$(head -n 1 /proc/meminfo | awk '{print $2}')

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -14,16 +14,27 @@ source setup/functions.sh # load our functions
 # and buffers for the system. We will only allocate this file if there is more
 # than 5GB of disk space available
 
+# The following checks are performed:
+# - Check if swap is currently mountend by looking at /proc/mounts
+# - Check if the user intents to activate swap on next boot by checking fstab entries.
+# - Check if a swapfile already exists
+# - Check the memory requirements
+# - Check available diskspace
+
 # See https://www.digitalocean.com/community/tutorials/how-to-add-swap-on-ubuntu-14-04
 # for reference
 
 SWAP_MOUNTED=$(grep "swap" /proc/mounts)
+SWAP_IN_FSTAB=$(grep "swap" /etc/fstab)
 TOTAL_PHYSICAL_MEM=$(head -n 1 /proc/meminfo | awk '{print $2}')
 AVAILABLE_DISK_SPACE=$(df / --output=avail | tail -n 1)
-if [ $TOTAL_PHYSICAL_MEM -lt 1900000 ]; then
-if [ -z "$SWAP_MOUNTED" ]; then
-if [ ! -e /swapfile ]; then
-if [ $AVAILABLE_DISK_SPACE -gt 5242880 ]; then
+if
+	[ -z "$SWAP_MOUNTED" ] &&
+	[ -z "$SWAP_IN_FSTAB" ] &&
+	[ ! -e /swapfile ] &&
+	[ $TOTAL_PHYSICAL_MEM -lt 1900000 ] &&
+	[ $AVAILABLE_DISK_SPACE -gt 5242880 ]
+then
 	echo "Adding swap to the system..."
 
 	# Allocate and activate the swap file
@@ -32,11 +43,11 @@ if [ $AVAILABLE_DISK_SPACE -gt 5242880 ]; then
 	hide_output mkswap /swapfile
 	swapon /swapfile
 
-	# Make sure swap is activated on boot
-	echo "/swapfile   none    swap    sw    0   0" >> /etc/fstab
-fi
-fi
-fi
+	# Check if swap is mounted then activate on boot
+	ACTIVATED_SWAP=$(swapon -s | grep "\/swapfile")
+	if [ -n "$ACTIVATED_SWAP" ]; then
+		echo "/swapfile   none    swap    sw    0   0" >> /etc/fstab
+	fi
 fi
 
 # ### Add Mail-in-a-Box's PPA.


### PR DESCRIPTION
If the physical memory of the system is below 2GB it is wise to create a swap file. This will make the system more resiliant to memory spikes and prevent for instance spam filtering from crashing.