### PR TITLE
Added fail2ban alias as default for the box

### DIFF
--- a/management/mailconfig.py
+++ b/management/mailconfig.py
@@ -516,6 +516,9 @@ def get_required_aliases(env):
 
 	# The hostmaster alias is exposed in the DNS SOA for each zone.
 	aliases.add("hostmaster@" + env['PRIMARY_HOSTNAME'])
+	
+	# Always add the fail2ban alias to make sure, that messages from fail2ban can be delivered properly
+	aliases.add("fail2ban@" + env['PRIMARY_HOSTNAME'])
 
 	# Get a list of domains we serve mail for, except ones for which the only
 	# email on that domain are the required aliases or a catch-all/domain-forwarder.


### PR DESCRIPTION
Fixes mail delivery errors for fail2ban notices:

Mar 25 14:35:34 mail postfix/qmgr[1604]: AE02A2FF3D5: from=<fail2ban@HOSTNAME>, size=430, nrcpt=1 (queue active)
Mar 25 14:35:35 mail postfix/lmtp[4601]: A17A22FF19A: to=<fail2ban@HOSTNAME>, relay=127.0.0.1[127.0.0.1]:10025, delay=0.77, delays=0.41/0/0/0.36, dsn=5.1.1, status=bounced (host 127.0.0.1[127.0.0.1] said: 550 5.1.1 <fail2ban@HOSTNAME> User doesn't exist: fail2ban@HOSTNAME (in reply to RCPT TO command))