### PR TITLE
Stop fail2ban recidive from sending emails, like all other jails

### DIFF
--- a/conf/fail2ban/jail.local
+++ b/conf/fail2ban/jail.local
@@ -27,3 +27,4 @@ maxretry = 20
 [recidive]
 enabled  = true
 maxretry = 10
+action   = iptables-allports[name=recidive]

--- a/conf/fail2ban/jail.local
+++ b/conf/fail2ban/jail.local
@@ -28,3 +28,13 @@ maxretry = 20
 enabled  = true
 maxretry = 10
 action   = iptables-allports[name=recidive]
+# In the recidive section of jail.conf the action contains:
+#
+# action   = iptables-allports[name=recidive]
+#            sendmail-whois-lines[name=recidive, logpath=/var/log/fail2ban.log]
+#
+# The last line on the action will sent an email to the configured address. This mail will
+# notify the administrator that someone has been repeatedly triggering one of the other jails.
+# By default we don't configure this address and no action is required from the admin anyway.
+# So the notification is ommited. This will prevent message appearing in the mail.log that mail
+# can't be delivered to fail2ban@$HOSTNAME.


### PR DESCRIPTION
The default config in jail.conf is to send an email when an ip is placed in recidive. This overrides that behavior.

See: https://github.com/mail-in-a-box/mailinabox/pull/770