### PR TITLE
Add generic login failed message

### DIFF
--- a/management/daemon.py
+++ b/management/daemon.py
@@ -43,7 +43,7 @@ def authorized_personnel_only(viewfunc):
 		except ValueError as e:
 			# Authentication failed.
 			privs = []
-			error = str(e)
+			error = "Incorrect username or password"
 
 		# Authorized to access an API view?
 		if "admin" in privs:
@@ -119,7 +119,7 @@ def me():
 	except ValueError as e:
 		return json_response({
 			"status": "invalid",
-			"reason": str(e),
+			"reason": "Incorrect username or password",
 			})
 
 	resp = {


### PR DESCRIPTION
As mentioned here: https://github.com/mail-in-a-box/mailinabox/issues/697 (Just spotted the issue, have been doing things from that list lately I see :smile:)

This will prevent an attacker from figuring out if a user is reregistered.