### PR TITLE
nginx should not serve certain roundcube paths

### DIFF
--- a/conf/nginx-alldomains.conf
+++ b/conf/nginx-alldomains.conf
@@ -26,9 +26,22 @@
 		index index.php;
 		alias /usr/local/lib/roundcubemail/;
 	}
-	location ~ /mail/config/.* {
-		# A ~-style location is needed to give this precedence over the next block.
-		return 403;
+	location ~ ^/mail/(config|temp|logs)/ {
+        	deny all;
+	}
+	location ~ ^/mail/(README|INSTALL|LICENSE|CHANGELOG|UPGRADING)$ {
+        	deny all;
+	}
+	location ~ ^/mail/(bin|SQL)/ {
+        	deny all;
+	}
+	location ~ ^/mail/(.+\.md)$ {
+        	deny all;
+	}
+	location ~ ^/mail/\. {
+        	deny all;
+        	access_log off;
+        	log_not_found off;
 	}
 	location ~ /mail/.*\.php {
 		# note: ~ has precendence over a regular location block

--- a/conf/nginx-alldomains.conf
+++ b/conf/nginx-alldomains.conf
@@ -26,16 +26,13 @@
 		index index.php;
 		alias /usr/local/lib/roundcubemail/;
 	}
-	location ~ ^/mail/(config|temp|logs)/ {
+	location ~ ^/mail/(config|temp|logs|bin|SQL)/ {
         	deny all;
 	}
 	location ~ ^/mail/(README|INSTALL|LICENSE|CHANGELOG|UPGRADING)$ {
         	deny all;
 	}
-	location ~ ^/mail/(bin|SQL)/ {
-        	deny all;
-	}
-	location ~ ^/mail/(.+\.md)$ {
+	location ~ ^/mail/(.+\.md|composer\.json.*|package\.xml|Dockerfile)$ {
         	deny all;
 	}
 	location ~ ^/mail/\. {


### PR DESCRIPTION
Additional denied nginx locations for Roundcube based on [Roundcube Documentation](https://github.com/roundcube/roundcubemail/wiki/Installation#protect-your-installation) and `.htaccess`.