### PR TITLE
Changed UFW from Allow to Limit for inbound connection throttling

### DIFF
--- a/setup/functions.sh
+++ b/setup/functions.sh
@@ -132,6 +132,14 @@ function ufw_allow {
 	fi
 }
 
+# Adds a limit rule allowing 6 in 30 sec
+function ufw_limit {
+	if [ -z "$DISABLE_FIREWALL" ]; then
+		# ufw has completely unhelpful output
+		ufw limit $1 > /dev/null;
+	fi
+}
+
 function restart_service {
 	hide_output service $1 restart
 }

--- a/setup/mail-dovecot.sh
+++ b/setup/mail-dovecot.sh
@@ -200,11 +200,11 @@ mkdir -p $STORAGE_ROOT/mail/sieve/global_after
 chown -R mail.mail $STORAGE_ROOT/mail/sieve
 
 # Allow the IMAP/POP ports in the firewall.
-ufw_allow imaps
-ufw_allow pop3s
+ufw_limit imaps
+ufw_limit pop3s
 
 # Allow the Sieve port in the firewall.
-ufw_allow sieve
+ufw_limit sieve
 
 # Restart services.
 restart_service dovecot

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -229,7 +229,7 @@ if [ -z "$DISABLE_FIREWALL" ]; then
 	apt_install ufw
 
 	# Allow incoming connections to SSH.
-	ufw_allow ssh;
+	ufw_limit ssh;
 
 	# ssh might be running on an alternate port. Use sshd -T to dump sshd's #NODOC
 	# settings, find the port it is supposedly running on, and open that port #NODOC
@@ -239,7 +239,7 @@ if [ -z "$DISABLE_FIREWALL" ]; then
 	if [ "$SSH_PORT" != "22" ]; then
 
 	echo Opening alternate SSH port $SSH_PORT. #NODOC
-	ufw_allow $SSH_PORT #NODOC
+	ufw_limit $SSH_PORT #NODOC
 
 	fi
 	fi

--- a/setup/web.sh
+++ b/setup/web.sh
@@ -106,6 +106,6 @@ restart_service nginx
 restart_service php5-fpm
 
 # Open ports.
-ufw_allow http
-ufw_allow https
+ufw_limit http
+ufw_limit https
 


### PR DESCRIPTION
I have changed several files to use ufw limit which automatically adds rate limiting firewall rules that only allow inbound connections limit of 6 connections in 30 seconds.  I changed from allow to limit for ssh, http, https, imap, pop, and sieve.  I left smtp alone because I didn't know if it is expected to exceed the inbound connections limit.  May need to exclude imap and/or pop as well but definitely wouldn't expect inbound web traffic to be more than the limit...