### PR TITLE
Configured Dovecot to log into its own logfile

### DIFF
--- a/conf/fail2ban/jail.local
+++ b/conf/fail2ban/jail.local
@@ -23,6 +23,7 @@ enabled = true
 filter  = dovecotimap
 findtime = 30
 maxretry = 20
+logpath  = /var/log/mail.log
 
 [recidive]
 enabled  = true

--- a/setup/mail-dovecot.sh
+++ b/setup/mail-dovecot.sh
@@ -39,7 +39,7 @@ apt_install \
 # machine has, so on a two-core machine that's 500 processes/100 users).
 tools/editconf.py /etc/dovecot/conf.d/10-master.conf \
 	default_process_limit=$(echo "`nproc` * 250" | bc) \
-	log_path = /var/log/mail.log
+	log_path=/var/log/mail.log
 
 # The inotify `max_user_instances` default is 128, which constrains
 # the total number of watched (IMAP IDLE push) folders by open connections.

--- a/setup/mail-dovecot.sh
+++ b/setup/mail-dovecot.sh
@@ -39,25 +39,7 @@ apt_install \
 # machine has, so on a two-core machine that's 500 processes/100 users).
 tools/editconf.py /etc/dovecot/conf.d/10-master.conf \
 	default_process_limit=$(echo "`nproc` * 250" | bc) \
-	log_path = /var/log/dovecot.log
-
-# Add logrotate entry for dovecot
-cat > /etc/logrotate.d/dovecot << EOF;
-/var/log/dovecot*.log {
-  missingok
-  notifempty
-  delaycompress
-  sharedscripts
-  postrotate
-      doveadm log reopen
-  endscript
-}
-EOF
-
-# Create base log files and set permissions
-touch /var/log/dovecot.log
-chown syslog:adm /var/log/dovecot.log
-chmod 640 /var/log/dovecot.log
+	log_path = /var/log/mail.log
 
 # The inotify `max_user_instances` default is 128, which constrains
 # the total number of watched (IMAP IDLE push) folders by open connections.

--- a/setup/mail-dovecot.sh
+++ b/setup/mail-dovecot.sh
@@ -42,7 +42,7 @@ tools/editconf.py /etc/dovecot/conf.d/10-master.conf \
 	log_path = /var/log/dovecot.log
 
 # Add logrotate entry for dovecot
-cat > /etc/dovecot/conf.d/90-plugin-fts.conf << EOF;
+cat > /etc/logrotate.d/dovecot << EOF;
 /var/log/dovecot*.log {
   missingok
   notifempty

--- a/setup/mail-dovecot.sh
+++ b/setup/mail-dovecot.sh
@@ -38,7 +38,26 @@ apt_install \
 # would be 20 users). Set it to 250 times the number of cores this
 # machine has, so on a two-core machine that's 500 processes/100 users).
 tools/editconf.py /etc/dovecot/conf.d/10-master.conf \
-	default_process_limit=$(echo "`nproc` * 250" | bc)
+	default_process_limit=$(echo "`nproc` * 250" | bc) \
+	log_path = /var/log/dovecot.log
+
+# Add logrotate entry for dovecot
+cat > /etc/dovecot/conf.d/90-plugin-fts.conf << EOF;
+/var/log/dovecot*.log {
+  missingok
+  notifempty
+  delaycompress
+  sharedscripts
+  postrotate
+      doveadm log reopen
+  endscript
+}
+EOF
+
+# Create base log files and set permissions
+touch /var/log/dovecot.log
+chown syslog:adm /var/log/dovecot.log
+chmod 640 /var/log/dovecot.log
 
 # The inotify `max_user_instances` default is 128, which constrains
 # the total number of watched (IMAP IDLE push) folders by open connections.


### PR DESCRIPTION
Added log path info into dovecot configuration file, added a config into logrotate.d folder, created a placeholder file in /var/log and set owner/permissions on the file.