### PR TITLE
Added X-Frame-Options protection for nginx

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -43,5 +43,8 @@ server {
 	ssl_certificate $SSL_CERTIFICATE;
 	ssl_certificate_key $SSL_KEY;
 
+	# Add protection against clickjacking attacks by adding an X-Frame-Options
+	add_header X-Frame-Options "SAMEORIGIN";
+
 	# ADDITIONAL DIRECTIVES HERE
 }


### PR DESCRIPTION
Per the discussion on Issue 697 I have added the X-Frame-Option to the Nginx config file to protect against click-jacking attacks.  More information can be found [https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options?redirectlocale=en-US&redirectslug=The_X-FRAME-OPTIONS_response_header](url)