### PR TITLE
target to blank for munin link in tempalte

### DIFF
--- a/management/templates/index.html
+++ b/management/templates/index.html
@@ -93,7 +93,7 @@
                 <li class="dropdown-header">Advanced Pages</li>
                 <li><a href="#custom_dns" onclick="return show_panel(this);">Custom DNS</a></li>
                 <li><a href="#external_dns" onclick="return show_panel(this);">External DNS</a></li>
-                <li><a href="/admin/munin">Munin Monitoring</a></li>
+                <li><a href="/admin/munin" target="_blank">Munin Monitoring</a></li>
               </ul>
             </li>
             <li class="dropdown">


### PR DESCRIPTION
adding :
target="_blank"
to 
<li><a href="/admin/munin">Munin Monitoring</a></li> on line 96
Why ?
Because when you click on munin link, and follow links, you lose your index, or click back many times...
So i propose my pull request.
Et voilà ^^