### PR TITLE
ownCloud 9

### DIFF
--- a/conf/ios-profile.xml
+++ b/conf/ios-profile.xml
@@ -19,7 +19,7 @@
       <key>CalDAVPort</key>
       <real>443</real>
       <key>CalDAVPrincipalURL</key>
-      <string>/cloud/remote.php/caldav/calendars/</string>
+      <string>/cloud/remote.php/dav/principals/users/</string>
       <key>CalDAVUseSSL</key>
       <true/>
       <key>PayloadDescription</key>
@@ -89,7 +89,7 @@
       <key>CardDAVPort</key>
       <integer>443</integer>
       <key>CardDAVPrincipalURL</key>
-      <string>/cloud/remote.php/carddav/addressbooks/</string>
+      <string>/cloud/remote.php/dav/principals/users/</string>
       <key>CardDAVUseSSL</key>
       <true/>
       <key>PayloadDescription</key>

--- a/conf/zpush/backend_caldav.php
+++ b/conf/zpush/backend_caldav.php
@@ -8,7 +8,7 @@
 define('CALDAV_PROTOCOL', 'https');
 define('CALDAV_SERVER', '127.0.0.1');
 define('CALDAV_PORT', '443');
-define('CALDAV_PATH', '/dav/principals/%u/');
+define('CALDAV_PATH', '/dav/principals/users/%u/');
 define('CALDAV_PERSONAL', 'PRINCIPAL');
 define('CALDAV_SUPPORTS_SYNC', false);
 define('CALDAV_MAX_SYNC_PERIOD', 2147483647);

--- a/conf/zpush/backend_caldav.php
+++ b/conf/zpush/backend_caldav.php
@@ -8,7 +8,7 @@
 define('CALDAV_PROTOCOL', 'https');
 define('CALDAV_SERVER', '127.0.0.1');
 define('CALDAV_PORT', '443');
-define('CALDAV_PATH', '/caldav/calendars/%u/');
+define('CALDAV_PATH', '/dav/principals/%u/');
 define('CALDAV_PERSONAL', 'PRINCIPAL');
 define('CALDAV_SUPPORTS_SYNC', false);
 define('CALDAV_MAX_SYNC_PERIOD', 2147483647);

--- a/conf/zpush/backend_carddav.php
+++ b/conf/zpush/backend_carddav.php
@@ -9,8 +9,8 @@
 define('CARDDAV_PROTOCOL', 'https'); /* http or https */
 define('CARDDAV_SERVER', '127.0.0.1');
 define('CARDDAV_PORT', '443');
-define('CARDDAV_PATH', '/carddav/addressbooks/%u/');
-define('CARDDAV_DEFAULT_PATH', '/carddav/addressbooks/%u/contacts/'); /* subdirectory of the main path */
+define('CARDDAV_PATH', '/dav/principals/users/%u/');
+define('CARDDAV_DEFAULT_PATH', '/dav/principals/users/%u/'); /* subdirectory of the main path */
 define('CARDDAV_GAL_PATH', ''); /* readonly, searchable, not syncd */
 define('CARDDAV_GAL_MIN_LENGTH', 5);
 define('CARDDAV_CONTACTS_FOLDER_NAME', '%u Addressbook');

--- a/setup/owncloud.sh
+++ b/setup/owncloud.sh
@@ -16,9 +16,11 @@ apt_install \
 
 apt-get purge -qq -y owncloud*
 
-# Install ownCloud from source of this version:
-owncloud_ver=8.2.3
-owncloud_hash=bfdf6166fbf6fc5438dc358600e7239d1c970613
+# Install ownCloud, calendar and contacts from source of this version:
+owncloud_ver=9.0.2
+owncloud_hash=72a3d15d09f58c06fa8bee48b9e60c9cd356f9c5
+contacts_hash=ada080e66757e79ebf1c241065115012cde25238 #v1.2.0.0
+calendar_hash=00e3ad1e01f8f9132e897e8b709ff050ab5d4291 #v1.2.2
 
 # Migrate <= v0.10 setups that stored the ownCloud config.php in /usr/local rather than
 # in STORAGE_ROOT. Move the file to STORAGE_ROOT.
@@ -52,8 +54,8 @@ if [ ! -d /usr/local/lib/owncloud/ ] \
 	# The two apps we actually want are not in ownCloud core. Clone them from
 	# their github repositories.
 	mkdir -p /usr/local/lib/owncloud/apps
-	git_clone https://github.com/owncloudarchive/contacts 9ba2e667ae8c7ea36d8c4a4c3413c374beb24b1b '' /usr/local/lib/owncloud/apps/contacts
-	git_clone https://github.com/owncloudarchive/calendar 2086e738a3b7b868ec59cd61f0f88b49c3f21dd1 '' /usr/local/lib/owncloud/apps/calendar
+	git_clone https://github.com/owncloud/contacts $contacts_hash '' /usr/local/lib/owncloud/apps/contacts
+	git_clone https://github.com/owncloud/calendar $calendar_hash '' /usr/local/lib/owncloud/apps/calendar
 
 	# Fix weird permissions.
 	chmod 750 /usr/local/lib/owncloud/{apps,config}


### PR DESCRIPTION
ownCloud 9 brings a new DAV-backend so we should test, whether everything is migrated well (contacts and calendar), and whether the ActiveSync and iOS-Profiles are still working 😅 

Known Problems:

- Contacts does not work, because it needs a builded package 😁 ...we must download the **.tar.gz** file from GitHub (https://github.com/owncloud/contacts/releases/download/v1.2.0.0/contacts.tar.gz) and unpack it into the /apps/ folder - I don't know how we should do that best.
