### PR TITLE
Add HSTS to the control panel headers

### DIFF
--- a/conf/nginx-primaryonly.conf
+++ b/conf/nginx-primaryonly.conf
@@ -9,6 +9,7 @@
 		add_header X-Frame-Options "DENY";
 		add_header X-Content-Type-Options nosniff;
 		add_header Content-Security-Policy "frame-ancestors 'none';";
+		add_header Strict-Transport-Security max-age=31536000;
 	}
 
 	# ownCloud configuration.


### PR DESCRIPTION
This is for issue: https://github.com/mail-in-a-box/mailinabox/issues/878

After this fix, the header is returned:
```
curl -s -D- https://box.*/admin | grep Strict-Transport-Security
Strict-Transport-Security: max-age=31536000
```