### PR TITLE
set ssh ciphers, macs

### DIFF
--- a/setup/system.sh
+++ b/setup/system.sh
@@ -219,6 +219,11 @@ APT::Periodic::Unattended-Upgrade "1";
 APT::Periodic::Verbose "1";
 EOF
 
+# Harden SSH and disable weak ciphers
+echo "Ciphers aes128-ctr,aes192-ctr,aes256-ctr,arcfour256,arcfour128" >> /etc/ssh/sshd_config
+echo "MACs hmac-sha1,umac-64@openssh.com,hmac-ripemd160" >> /etc/ssh/sshd_config
+
+
 # ### Firewall
 
 # Various virtualized environments like Docker and some VPSs don't provide #NODOC
@@ -298,3 +303,4 @@ cat conf/fail2ban/jail.local \
 cp conf/fail2ban/dovecotimap.conf /etc/fail2ban/filter.d/dovecotimap.conf
 
 restart_service fail2ban
+

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -220,9 +220,9 @@ APT::Periodic::Verbose "1";
 EOF
 
 # Harden SSH and disable weak ciphers
-echo "Ciphers aes128-ctr,aes192-ctr,aes256-ctr,arcfour256,arcfour128" >> /etc/ssh/sshd_config
-echo "MACs hmac-sha1,umac-64@openssh.com,hmac-ripemd160" >> /etc/ssh/sshd_config
-
+grep -q -F "Ciphers aes128-ctr,aes192-ctr,aes256-ctr,arcfour256,arcfour128 \
+MACs hmac-sha1,umac-64@openssh.com,hmac-ripemd160" /etc/ssh/sshd_config || echo "Ciphers aes128-ctr,aes192-ctr,aes256-ctr,arcfour256,arcfour128 \
+MACs hmac-sha1,umac-64@openssh.com,hmac-ripemd160" >> /etc/ssh/ssh_config
 
 # ### Firewall
 

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -220,9 +220,12 @@ APT::Periodic::Verbose "1";
 EOF
 
 # Harden SSH and disable weak ciphers
-grep -q -F "Ciphers aes128-ctr,aes192-ctr,aes256-ctr,arcfour256,arcfour128 \
-MACs hmac-sha1,umac-64@openssh.com,hmac-ripemd160" /etc/ssh/sshd_config || echo "Ciphers aes128-ctr,aes192-ctr,aes256-ctr,arcfour256,arcfour128 \
-MACs hmac-sha1,umac-64@openssh.com,hmac-ripemd160" >> /etc/ssh/ssh_config
+echo "disabling weak SSH ciphers"
+tools/editconf.py /etc/ssh/sshd_config -s \
+	Ciphers aes128-ctr,aes192-ctr,aes256-ctr,arcfour256,arcfour128 \
+	MACs hmac-sha1,umac-64@openssh.com,hmac-ripemd160
+	
+restart_service ssh
 
 # ### Firewall
 


### PR DESCRIPTION
Added this after it was revealed via OpenVAS. 
I was playing with a new OpenVAS server I deployed, which revealed the SSH ciphers could be stronger. Would like to know if anyone thinks this is an issue, or not. However I have pushed these small changes to my own mailinabox along with the changes from a couple other pull requests
Also currently doing the same for SSL/TLS right now for Mailinabox if I can find the issue revealed by OpenVAS
