### PR TITLE
Hardening SSL per recommendations from OpenVAS

### DIFF
--- a/setup/mail-dovecot.sh
+++ b/setup/mail-dovecot.sh
@@ -71,12 +71,17 @@ tools/editconf.py /etc/dovecot/conf.d/10-auth.conf \
 
 # Enable SSL, specify the location of the SSL certificate and private key files.
 # Disable obsolete SSL protocols and allow only good ciphers per http://baldric.net/2013/12/07/tls-ciphers-in-postfix-and-dovecot/.
+# Updated by Alon "ChiefGyk" Ganon to reflect improvements to SSL here https://bettercrypto.org/static/applied-crypto-hardening.pdf
 tools/editconf.py /etc/dovecot/conf.d/10-ssl.conf \
 	ssl=required \
 	"ssl_cert=<$STORAGE_ROOT/ssl/ssl_certificate.pem" \
 	"ssl_key=<$STORAGE_ROOT/ssl/ssl_private_key.pem" \
 	"ssl_protocols=!SSLv3 !SSLv2" \
-	"ssl_cipher_list=TLSv1+HIGH !SSLv2 !RC4 !aNULL !eNULL !3DES @STRENGTH"
+	"ssl_cipher_list= EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA256:EECDH\
+\:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4\
+\:!SEED:!IDEA:!ECDSA:kEDH:CAMELLIA128-SHA:AES128-SHA"
+	"ssl_dh_parameters_length = 2048"
+	"ssl_prefer_server_ciphers = yes"
 
 # Disable in-the-clear IMAP/POP because there is no reason for a user to transmit
 # login credentials outside of an encrypted connection. Only the over-TLS versions

--- a/setup/mail-dovecot.sh
+++ b/setup/mail-dovecot.sh
@@ -77,11 +77,11 @@ tools/editconf.py /etc/dovecot/conf.d/10-ssl.conf \
 	"ssl_cert=<$STORAGE_ROOT/ssl/ssl_certificate.pem" \
 	"ssl_key=<$STORAGE_ROOT/ssl/ssl_private_key.pem" \
 	"ssl_protocols=!SSLv3 !SSLv2" \
-	"ssl_cipher_list= EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA256:EECDH\
+	"ssl_cipher_list=TLSv1+HIGH:EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA256:EECDH\
 \:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4\
 \:!SEED:!IDEA:!ECDSA:kEDH:CAMELLIA128-SHA:AES128-SHA"
-	"ssl_dh_parameters_length = 2048"
-	"ssl_prefer_server_ciphers = yes"
+	"ssl_dh_parameters_length=2048"
+	"ssl_prefer_server_ciphers=yes"
 
 # Disable in-the-clear IMAP/POP because there is no reason for a user to transmit
 # login credentials outside of an encrypted connection. Only the over-TLS versions


### PR DESCRIPTION
Using the tips from https://bettercrypto.org/static/applied-crypto-hardening.pdf
Now I am trying to figure out how to edit Postfix according to the bettercrypto guide to help harden it and may need some help figuring out exactly how I can adapt it without breaking it