### PR TITLE
Adding a Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,48 @@
+# Mail-in-a-Box Code of Conduct
+
+Mail-in-a-Box is an open source community project about working, as a group, to empower ourselves and others to have control over our own digital communications. Just as we hope to increase technological diversity on the Internet through decentralization, we also believe that diverse viewpoints and voices among our community members foster innovation and creative solutions to the challenges we face.
+
+We are committed to providing a safe, welcoming, and harrassment-free space for collaboration, for everyone, without regard to age, disability, economic situation, ethnicity, gender identity and expression, language fluency, level of knowledge or experience, nationality, personal appearance, race, religion, sexual identity and orientation, or any other attribute. Community comes first. This policy supersedes all other project goals.
+
+The maintainers of Mail-in-a-Box share the dual responsibility of leading by example and enforcing these policies as necessary to maintain an open and welcoming environment.
+
+## Scope
+
+This Code of Conduct applies to all places where Mail-in-a-Box community activity is ocurring, including in on Github, in discussion forums, on Slack, on social media, and in real life. The Code of Conduct applies not only on websites/at events run by the Mail-in-a-Box community (e.g. our Github organization, our Slack team) but also at any other location where the Mail-in-a-Box community is present (e.g. in issues of other Github organizations where Mail-in-a-Box community members are discussing problems related to Mail-in-a-Box, or real-life professional conferences), or whenever a Mail-in-a-Box community member is representing Mail-in-a-Box to the public at large or acting on behalf of Mail-in-a-Box.
+
+This code does not apply to activity on a server running Mail-in-a-Box software, unless your server is hosting a service for the Mail-in-a-Box community at large.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Showing empathy towards other community members
+* Making room for new and quieter voices
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory/unwelcome comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Aggressive and micro-aggressive behavior, such as unconstructive criticism, providing corrections that do not improve the conversation (sometimes referred to as "well actually"s), repeatedly interrupting or talking over someone else, feigning surprise at someone's lack of knowledge or awareness about a topic, or subtle prejudice (for example, comments like "That's so easy my grandmother could do it.", which is prejudicial toward grandmothers).
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+* Retaliating against anyone who reports a violation of this code.
+
+We will not tolerate harassment. Harassment is any unwelcome or hostile behavior towards another person for any reason. This includes, but is not limited to, offensive verbal comments related to personal characteristics or choices, sexual images or comments, deliberate intimidation, bullying, stalking, following, harassing photography or recording, sustained disruption of discussion or events, nonconsensual publication of private comments, inappropriate physical contact, or unwelcome sexual attention. Conduct need not be intentional to be harassment.
+
+## Enforcement
+
+We will remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not consistent with this Code of Conduct. We may ban, temporarily or permanently, any contributor for violating this code, when appropriate.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project lead, [Joshua Tauberer](https://razor.occams.info/). All reports will be treated confidentially, impartially, consistently, and swiftly.
+
+Because the need for confidentiality for all parties involved in an enforcement action outweighs the goals of openness, limited information will be shared with the Mail-in-a-Box community regarding enforcement actions that have taken place.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant, version 1.4](http://contributor-covenant.org/version/1/4) and the code of conduct of [Code for DC](http://codefordc.org/resources/codeofconduct.html).
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,11 +4,11 @@ Mail-in-a-Box is an open source community project about working, as a group, to 
 
 We are committed to providing a safe, welcoming, and harrassment-free space for collaboration, for everyone, without regard to age, disability, economic situation, ethnicity, gender identity and expression, language fluency, level of knowledge or experience, nationality, personal appearance, race, religion, sexual identity and orientation, or any other attribute. Community comes first. This policy supersedes all other project goals.
 
-The maintainers of Mail-in-a-Box share the dual responsibility of leading by example and enforcing these policies as necessary to maintain an open and welcoming environment.
+The maintainers of Mail-in-a-Box share the dual responsibility of leading by example and enforcing these policies as necessary to maintain an open and welcoming environment. All community members should be excellent to each other.
 
 ## Scope
 
-This Code of Conduct applies to all places where Mail-in-a-Box community activity is ocurring, including in on Github, in discussion forums, on Slack, on social media, and in real life. The Code of Conduct applies not only on websites/at events run by the Mail-in-a-Box community (e.g. our Github organization, our Slack team) but also at any other location where the Mail-in-a-Box community is present (e.g. in issues of other Github organizations where Mail-in-a-Box community members are discussing problems related to Mail-in-a-Box, or real-life professional conferences), or whenever a Mail-in-a-Box community member is representing Mail-in-a-Box to the public at large or acting on behalf of Mail-in-a-Box.
+This Code of Conduct applies to all places where Mail-in-a-Box community activity is ocurring, including on GitHub, in discussion forums, on Slack, on social media, and in real life. The Code of Conduct applies not only on websites/at events run by the Mail-in-a-Box community (e.g. our GitHub organization, our Slack team) but also at any other location where the Mail-in-a-Box community is present (e.g. in issues of other GitHub organizations where Mail-in-a-Box community members are discussing problems related to Mail-in-a-Box, or real-life professional conferences), or whenever a Mail-in-a-Box community member is representing Mail-in-a-Box to the public at large or acting on behalf of Mail-in-a-Box.
 
 This code does not apply to activity on a server running Mail-in-a-Box software, unless your server is hosting a service for the Mail-in-a-Box community at large.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,7 @@ This project is in the public domain. Copyright and related rights in the work w
 All contributions to this project must be released under the same CC0 wavier. By submitting a pull request or patch, you are agreeing to comply with this waiver of copyright interest.
 
 [CC0]: http://creativecommons.org/publicdomain/zero/1.0/
+
+## Code of Conduct
+
+This project has a [Code of Conduct](CODE_OF_CONDUCT.md). Please review it when joining our community.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Mail-in-a-Box helps individuals take back control of their email by defining a o
 
 * * *
 
-I am trying to:
+Our goals are to:
 
 * Make deploying a good mail server easy.
 * Promote [decentralization](http://redecentralize.org/), innovation, and privacy on the web.
@@ -17,7 +17,7 @@ I am trying to:
 * **Not** make a totally unhackable, NSA-proof server.
 * **Not** make something customizable by power users.
 
-This setup is what has been powering my own personal email since September 2013.
+Additionally, this project has a [Code of Conduct](CODE_OF_CONDUCT.md), which supersedes the goals above. Please review it when joining our community.
 
 The Box
 -------


### PR DESCRIPTION
Hello all,

This pull request adds a Code of Conduct to this project. It is adapted primarily from the [Contributor Covenant](http://contributor-covenant.org).

I am open to feedback about this draft and what to put in a Code of Conduct.

But _not_ up for discussion is _whether_ to have a Code of Conduct: We will adopt a Code of Conduct.

This isn't in response to anything that has happened in the project so far. I have easily been the most difficult person in this community. But a Code of Conduct signals to would-be community members that we take community seriously and that I am prepared to enforce norms for acceptable behavior when necessary. Tech communities have been historically, and unfortunately too often still continue to be, unwelcoming to women and other groups, and we all have a responsibility to change that.

So please read the draft CoC in this pull request and share your thoughts. I have [cross-posted this on the discussion forum](https://discourse.mailinabox.email/t/adopting-a-code-of-conduct/1388) as well, and I will be watching both places for feedback.