### PR TITLE
Change bayes_file_mode to world writable

### DIFF
--- a/setup/spamassassin.sh
+++ b/setup/spamassassin.sh
@@ -84,7 +84,7 @@ tools/editconf.py /etc/spamassassin/local.cf -s \
 
 tools/editconf.py /etc/spamassassin/local.cf -s \
 	bayes_path=$STORAGE_ROOT/mail/spamassassin/bayes \
-	bayes_file_mode=0660
+	bayes_file_mode=0666
 
 mkdir -p $STORAGE_ROOT/mail/spamassassin
 chown -R spampd:spampd $STORAGE_ROOT/mail/spamassassin


### PR DESCRIPTION
This fixes https://github.com/mail-in-a-box/mailinabox/issues/534

I have been testing this for weeks. Finally I saw the ownership change on the files and no errors appear in the mail.log. 

This makes the file world writable when ownership changes. I saw a few recommendations on the internet to make the file world writeable. 

I can't see any risk to doing it, it's just the database with spam signatures. Anybody think we shouldn't do this?