### PR TITLE
fix status_checks.py free disk space reporting #932

### DIFF
--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -229,15 +229,15 @@ def check_free_disk_space(rounded_values, env, output):
 	st = os.statvfs(env['STORAGE_ROOT'])
 	bytes_total = st.f_blocks * st.f_frsize
 	bytes_free = st.f_bavail * st.f_frsize
-	if not rounded_values:
-		disk_msg = "The disk has %s GB space remaining." % str(round(bytes_free/1024.0/1024.0/1024.0*10.0)/10)
-	else:
-		disk_msg = "The disk has less than %s%% space left." % str(round(bytes_free/bytes_total/10 + .5)*10)
+	disk_msg = "The disk has %.2f GB space remaining." % (bytes_free/1024.0/1024.0/1024.0)
 	if bytes_free > .3 * bytes_total:
+		if rounded_values: disk_msg = "The disk has more than 30% free space."
 		output.print_ok(disk_msg)
 	elif bytes_free > .15 * bytes_total:
+		if rounded_values: disk_msg = "The disk has less than 30% free space."
 		output.print_warning(disk_msg)
 	else:
+		if rounded_values: disk_msg = "The disk has less than 15% free space."
 		output.print_error(disk_msg)
 
 def check_free_memory(rounded_values, env, output):
@@ -472,7 +472,7 @@ def check_dns_zone(domain, env, output, dns_zonefiles):
 				% (existing_ns, correct_ns) )
 
 	# Check that each custom secondary nameserver resolves the IP address.
-	
+
 	if custom_secondary_ns and not probably_external_dns:
 		for ns in custom_secondary_ns:
 			# We must first resolve the nameserver to an IP address so we can query it.
@@ -897,7 +897,7 @@ class FileOutput:
 class ConsoleOutput(FileOutput):
 	def __init__(self):
 		self.buf = sys.stdout
-		
+
 		# Do nice line-wrapping according to the size of the terminal.
 		# The 'stty' program queries standard input for terminal information.
 		if sys.stdin.isatty():


### PR DESCRIPTION
Fixes #932.

- Brought `check_free_disk_space` in line with `check_free_memory` logic.
- Print the GB value directly as a float (with rounding to 2 decimals).
- Editor removed some whitespace, because it loves trimming extra fat :)


### Testing

Created a 2G dummy file, taking available space to 17%.

```
# df -h | grep home
/dev/sdc         14G   12G  2.3G  83% /home

# ./status_checks.py --show-changes

System -- Previously:
=====================
✓  The disk has more than 30% free space.

System -- Currently:
====================
?  The disk has less than 30% free space.
```

Created another dummy file, taking available space to 9%.

```
# df -h | grep home
/dev/sdc         14G   13G  1.4G  91% /home

# ./status_checks.py --show-changes

System -- Previously:
=====================
?  The disk has less than 30% free space.

System -- Currently:
====================
✖  The disk has less than 15% free space.
```

Output from non-rounded values status-checks:

```
✓  The disk has 4.25 GB space remaining.
?  The disk has 2.30 GB space remaining.
✖  The disk has 1.32 GB space remaining.
```