### PR TITLE
Use Roundcube identity to populate Z-Push From: name

### DIFF
--- a/conf/zpush/backend_imap.php
+++ b/conf/zpush/backend_imap.php
@@ -8,7 +8,7 @@
 define('IMAP_SERVER', '127.0.0.1');
 define('IMAP_PORT', 993);
 define('IMAP_OPTIONS', '/ssl/norsh/novalidate-cert');
-define('IMAP_DEFAULTFROM', '');
+define('IMAP_DEFAULTFROM', 'sql');
 
 define('SYSTEM_MIME_TYPES_MAPPING', '/etc/mime.types');
 define('IMAP_AUTOSEEN_ON_DELETE', false);
@@ -23,15 +23,16 @@ define('IMAP_FOLDER_TRASH', 'TRASH');
 define('IMAP_FOLDER_SPAM', 'SPAM');
 define('IMAP_FOLDER_ARCHIVE', 'ARCHIVE');
 
-
-// not used
-define('IMAP_FROM_SQL_DSN', '');
+define('IMAP_FROM_SQL_DSN', 'sqlite:STORAGE_ROOT/mail/roundcube/roundcube.sqlite');
 define('IMAP_FROM_SQL_USER', '');
 define('IMAP_FROM_SQL_PASSWORD', '');
 define('IMAP_FROM_SQL_OPTIONS', serialize(array(PDO::ATTR_PERSISTENT => true)));
-define('IMAP_FROM_SQL_QUERY', "select first_name, last_name, mail_address from users where mail_address = '#username@#domain'");
-define('IMAP_FROM_SQL_FIELDS', serialize(array('first_name', 'last_name', 'mail_address')));
-define('IMAP_FROM_SQL_FROM', '#first_name #last_name <#mail_address>');
+define('IMAP_FROM_SQL_QUERY', "SELECT name, email FROM identities i INNER JOIN users u ON i.user_id = u.user_id WHERE u.username = '#username' AND i.standard = 1 AND i.del = 0 AND i.name <> ''");
+define('IMAP_FROM_SQL_FIELDS', serialize(array('name', 'email')));
+define('IMAP_FROM_SQL_FROM', '#name <#email>');
+define('IMAP_FROM_SQL_FULLNAME', '#name');
+
+// not used
 define('IMAP_FROM_LDAP_SERVER', '');
 define('IMAP_FROM_LDAP_SERVER_PORT', '389');
 define('IMAP_FROM_LDAP_USER', 'cn=zpush,ou=servers,dc=zpush,dc=org');
@@ -40,6 +41,7 @@ define('IMAP_FROM_LDAP_BASE', 'dc=zpush,dc=org');
 define('IMAP_FROM_LDAP_QUERY', '(mail=#username@#domain)');
 define('IMAP_FROM_LDAP_FIELDS', serialize(array('givenname', 'sn', 'mail')));
 define('IMAP_FROM_LDAP_FROM', '#givenname #sn <#mail>');
+define('IMAP_FROM_LDAP_FULLNAME', '#givenname #sn');
 
 define('IMAP_SMTP_METHOD', 'sendmail');
 

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -160,11 +160,8 @@ chmod 775 $STORAGE_ROOT/mail
 chown root.www-data $STORAGE_ROOT/mail/users.sqlite 
 chmod 664 $STORAGE_ROOT/mail/users.sqlite 
 
-# Run Roundcube database migration script, if the database exists (it's created by
-# Roundcube on first use).
-if [ -f $STORAGE_ROOT/mail/roundcube/roundcube.sqlite ]; then
-	/usr/local/lib/roundcubemail/bin/updatedb.sh --dir /usr/local/lib/roundcubemail/SQL --package roundcube
-fi
+# Run Roundcube database migration script (database is created if it does not exist)
+/usr/local/lib/roundcubemail/bin/updatedb.sh --dir /usr/local/lib/roundcubemail/SQL --package roundcube
 
 # Enable PHP modules.
 php5enmod mcrypt

--- a/setup/zpush.sh
+++ b/setup/zpush.sh
@@ -53,6 +53,7 @@ cp conf/zpush/backend_combined.php /usr/local/lib/z-push/backend/combined/config
 # Configure IMAP
 rm -f /usr/local/lib/z-push/backend/imap/config.php
 cp conf/zpush/backend_imap.php /usr/local/lib/z-push/backend/imap/config.php
+sed -i "s%STORAGE_ROOT%$STORAGE_ROOT%" /usr/local/lib/z-push/backend/imap/config.php
 
 # Configure CardDav
 rm -f /usr/local/lib/z-push/backend/carddav/config.php


### PR DESCRIPTION
This PR adjusts the Z-Push IMAP configuration to use the Roundcube identities table to populate the From: name when sending messages via Z-Push. This allows users to configure the name in the same interface as their webmail identity, and keeps the two in sync. It should resolve issue #255 

When constructing the From: name, Z-Push will query the Roundcube SQLite database and use the default identity for the user account. If that identity has no full name, or there is no default identity, Z-Push will fall back to using the email address as a From: name.

We also adjust a few setup scripts: `setup/zpush.sh` adds the STORAGE_ROOT to the sqlite DSN, and `setup/webmail.sh` removes the conditional around the Roundcube database migration script so that an empty database will be created on the first run.