### PR TITLE
Remove Certificate Providers / Fix #950

### DIFF
--- a/management/templates/ssl.html
+++ b/management/templates/ssl.html
@@ -55,7 +55,7 @@
 
 <h3 id="ssl_install_header">Install certificate</h3>
 
-<p>There are many other places where you can get a free or cheap certificate. If you don't want to use our automatic Let's Encrypt integration, you can give <a href="https://www.namecheap.com/security/ssl-certificates/domain-validation.aspx">Namecheap&rsquo;s $9 certificate</a>, <a href="https://www.startssl.com/">StartSSL&rsquo;s free express lane</a>, <a href="https://buy.wosign.com/free/">WoSign&rsquo;s free TLS</a></a> or any other certificate provider a try.</p>
+<p>If you don't want to use our automatic Let's Encrypt integration, you can give any other certificate provider a try. You can generate the needed CSR below.</p>
 
 <p>Which domain are you getting a certificate for?</p>
 
@@ -108,7 +108,7 @@ function show_tls(keep_provisioning_shown) {
       $('#ssl_provision_p').toggle(res.can_provision.length > 0);
       if (res.can_provision.length > 0)
           $('#ssl_provision_p span').text(res.can_provision.join(", "));
-      
+
       $('#ssl_provision_problems_div').toggle(res.cant_provision.length > 0);
       $('#ssl_provision_problems tbody').text("");
       for (var i = 0; i < res.cant_provision.length; i++) {
@@ -260,7 +260,7 @@ function provision_tls_cert() {
             }
           }
           ready_to_finish();
-          
+
           // don't re-enable the Provision button -- user must use the Retry button when it becomes enabled
           may_reenable_provision_button = false;
 
@@ -268,7 +268,7 @@ function provision_tls_cert() {
           n.find("p").addClass("text-success").text("The TLS certificate was provisioned and installed.");
           setTimeout("show_tls(true)", 1); // update main table of certificate statuses, call with arg keep_provisioning_shown true so that we don't clear what we just outputted
         }
-        
+
         // display the detailed log info in case of problems
         var trace = $("<div class='small text-muted' style='margin-top: 1.5em'>Log:</div>");
         n.append(trace);


### PR DESCRIPTION
This will remove all Certificate Providers. The original request was to remove **WoSign** and **StartSSL** because of their problems with Mozilla ... Since we are using Lets Encrypt we not longer need to use another provider. User wanting to use another one are "advanced" enough to select the provider themselves 😜 

cc @yodax @JoshData 