### PR TITLE
Fix status checks for ufw when the system doesn't support iptables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ In Development
 Control panel:
 
 * Remove recommendations for Certificate Providers
+* Status checks failed if the system doesn't support iptables
 
 v0.20 (September 23, 2016)
 --------------------------

--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -173,8 +173,8 @@ def check_ufw(env, output):
 
 	if code != 0:
 		# The command failed, it's safe to say the firewall is disabled
-		output.print_warning("""The firewall is probably disabled on this machine. An error was received
-					while trying to check the firewall.""")
+		output.print_warning("""The firewall is not working on this machine. An error was received
+					while trying to check the firewall. To investigate run 'sudo ufw status'.""")
 		return
 
 	ufw = ufw.splitlines()

--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -169,8 +169,15 @@ def run_system_checks(rounded_values, env, output):
 	check_free_memory(rounded_values, env, output)
 
 def check_ufw(env, output):
-	ufw = shell('check_output', ['ufw', 'status']).splitlines()
+	code, ufw = shell('check_output', ['ufw', 'status'], trap=True)
 
+	if code != 0:
+		# The command failed, it's safe to say the firewall is disabled
+		output.print_warning("""The firewall is probably disabled on this machine. An error was received
+					while trying to check the firewall.""")
+		return
+
+	ufw = ufw.splitlines()
 	if ufw[0] == "Status: active":
 		not_allowed_ports = 0
 		for service in get_services():


### PR DESCRIPTION
Fix for a separate issue reported here: https://github.com/mail-in-a-box/mailinabox/issues/327#issuecomment-250951339 

If the system doesn't support iptables, the status checks fail.

If the call to ufw fails this change will report this error:

```
The firewall is probably disabled on this machine. An error was received while trying to check the firewall.
```

@JoshData would you mind checking the phrasing/content of the message?