### PR TITLE
sshfp records from nonstandard ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Control panel:
 
 * Remove recommendations for Certificate Providers
 * Status checks failed if the system doesn't support iptables
-* Add support for SSHFP records when sshd listens on no-standard ports
+* Add support for SSHFP records when sshd listens on non-standard ports
 
 v0.20 (September 23, 2016)
 --------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Control panel:
 
 * Remove recommendations for Certificate Providers
 * Status checks failed if the system doesn't support iptables
+* Add support for SSHFP records when sshd listens on no-standard ports
 
 v0.20 (September 23, 2016)
 --------------------------

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -348,7 +348,18 @@ def build_sshfp_records():
 	# like the known_hosts file: hostname, keytype, fingerprint. The order
 	# of the output is arbitrary, so sort it to prevent spurrious updates
 	# to the zone file (that trigger bumping the serial number).
-	keys = shell("check_output", ["ssh-keyscan", "localhost"])
+
+	# scan the sshd_config and find the ssh ports (port 22 may be closed)
+	with open('/etc/ssh/sshd_config', 'r') as f:
+		ports = []
+		t = f.readlines()
+		for line in t:
+			s = line.split()
+			if s != [] and s[0] == 'Port':
+				ports = ports + [s[1]]
+	# the keys are the same at each port, so we only need to get
+	# them at the first port found (may not be port 22)
+	keys = shell("check_output", ["ssh-keyscan", "-p", ports[0], "localhost"])
 	for key in sorted(keys.split("\n")):
 		if key.strip() == "" or key[0] == "#": continue
 		try:

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -355,7 +355,7 @@ def build_sshfp_records():
 		t = f.readlines()
 		for line in t:
 			s = line.split()
-			if s != [] and s[0] == 'Port':
+			if len(s) == 2 and s[0] == 'Port':
 				ports = ports + [s[1]]
 	# the keys are the same at each port, so we only need to get
 	# them at the first port found (may not be port 22)


### PR DESCRIPTION
If port 22 is not open, dns_update.py will not create SSHFP records
because it only scans port 22 for keys. This commit modifies
dns_update.py to parse the sshd_config file for open ports, and
then obtains keys from one of them (even if port 22 is not open).