### PR TITLE
Add TLSA to the list of allowed custom records

### DIFF
--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -755,7 +755,7 @@ def set_custom_dns_record(qname, rtype, value, action, env):
 				v = ipaddress.ip_address(value) # raises a ValueError if there's a problem
 				if rtype == "A" and not isinstance(v, ipaddress.IPv4Address): raise ValueError("That's an IPv6 address.")
 				if rtype == "AAAA" and not isinstance(v, ipaddress.IPv6Address): raise ValueError("That's an IPv4 address.")
-		elif rtype in ("CNAME", "TXT", "SRV", "MX"):
+		elif rtype in ("CNAME", "TXT", "SRV", "MX", "TLSA"):
 			# anything goes
 			pass
 		else:


### PR DESCRIPTION
This commit allows custom TLSA records to be added to the
managed domains. Since the criteria for the primary domain TLSA
record is 3 1 1 and the default key for all certificates is the
same one, the same TLSA record generated for the primary domain
will work for all managed domains.

Note that this commit does not modify the custom DNS configuration
page. It only permits TLSA records to be added. Currently the only
way to do that is by manually editing the custom.yaml file in
/home/user-data/dns.