### PR TITLE
Check if apc is disabled during ownCloud setup, if so enable it

### DIFF
--- a/setup/owncloud.sh
+++ b/setup/owncloud.sh
@@ -281,6 +281,12 @@ tools/editconf.py /etc/php5/fpm/php.ini -c ';' \
 	max_execution_time=600 \
 	short_open_tag=On
 
+# If apc is explicitly disabled we need to enable it
+if grep -q apc.enabled=0 /etc/php5/mods-available/apcu.ini; then
+	tools/editconf.py /etc/php5/mods-available/apcu.ini -c ';' \
+		apc.enabled=1
+fi
+
 # Set up a cron job for owncloud.
 cat > /etc/cron.hourly/mailinabox-owncloud << EOF;
 #!/bin/bash


### PR DESCRIPTION
I was able to reproduce the [issue](https://github.com/mail-in-a-box/mailinabox/pull/894#issuecomment-254712452) reported in the ownCloud 9.1.1 PR. If I change my config to disable apc, I get the same error message. Running the setup with this PR fixes the problem.

I check if it is explicitly disabled otherwise I do nothing, it might be enabled somewhere else.