### PR TITLE
If ufw isn't installed on the machine the status checks shouldn't fail

### DIFF
--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -169,6 +169,10 @@ def run_system_checks(rounded_values, env, output):
 	check_free_memory(rounded_values, env, output)
 
 def check_ufw(env, output):
+	if not os.path.isfile('/usr/sbin/ufw'):
+		output.print_warning("""The ufw program was not installed. If your system is able to run iptables, rerun the setup.""")
+		return
+
 	code, ufw = shell('check_output', ['ufw', 'status'], trap=True)
 
 	if code != 0:


### PR DESCRIPTION
For: https://github.com/mail-in-a-box/mailinabox/issues/987

It might be that the system doesn't support iptables and therefore ufw might not be installed. This PR makes the status checks more reliable.
