### PR TITLE
suppress Ubuntu's upgrade prompts

### DIFF
--- a/setup/system.sh
+++ b/setup/system.sh
@@ -119,6 +119,12 @@ apt_install python3 python3-dev python3-pip \
 	haveged pollinate \
 	unattended-upgrades cron ntp fail2ban
 
+# ### Suppress Upgrade Prompts
+# Since Mail-in-a-Box might jump straight to 18.04 LTS, there's no need
+# to be reminded about 16.04 on every login.
+tools/editconf.py /etc/update-manager/release-upgrades Prompt=never
+rm -f /var/lib/ubuntu-release-upgrader/release-upgrade-available
+
 # ### Set the system timezone
 #
 # Some systems are missing /etc/timezone, which we cat into the configs for


### PR DESCRIPTION
On every login we're notified:

    New release '16.04.1 LTS' available.
    Run 'do-release-upgrade' to upgrade to it.

It might be worth disabling this so an eager yet inattentive admin doesn't accidentally follow these instructions.

The `rm -rf` can be safely removed if desired.  It clears the cache so that the prompt goes away in a matter of seconds (one or two logout/login cycles), instead of days.

