### PR TITLE
Check if release-upgrades configuration file is present before editing

### DIFF
--- a/setup/system.sh
+++ b/setup/system.sh
@@ -122,8 +122,10 @@ apt_install python3 python3-dev python3-pip \
 # ### Suppress Upgrade Prompts
 # Since Mail-in-a-Box might jump straight to 18.04 LTS, there's no need
 # to be reminded about 16.04 on every login.
-tools/editconf.py /etc/update-manager/release-upgrades Prompt=never
-rm -f /var/lib/ubuntu-release-upgrader/release-upgrade-available
+if [ -f /etc/update-manager/release-upgrades ]; then
+	tools/editconf.py /etc/update-manager/release-upgrades Prompt=never
+	rm -f /var/lib/ubuntu-release-upgrader/release-upgrade-available
+fi
 
 # ### Set the system timezone
 #


### PR DESCRIPTION
This PR: https://github.com/mail-in-a-box/mailinabox/pull/992 caused an issue on one of my machines. This machine doesn't have that configuration file and therefore shows the following message during the upgrade:

```
Installing system packages...
Traceback (most recent call last):
  File "tools/editconf.py", line 71, in <module>
    input_lines = list(open(filename))
FileNotFoundError: [Errno 2] No such file or directory: '/etc/update-manager/release-upgrades'
```

This PR checks if the config file is present before editing.