### PR TITLE
Change ownership of roundcube DB after running migrations

### DIFF
--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -162,6 +162,7 @@ chmod 664 $STORAGE_ROOT/mail/users.sqlite
 
 # Run Roundcube database migration script (database is created if it does not exist)
 /usr/local/lib/roundcubemail/bin/updatedb.sh --dir /usr/local/lib/roundcubemail/SQL --package roundcube
+chown www-data:www-data $STORAGE_ROOT/mail/roundcube/roundcube.sqlite
 
 # Enable PHP modules.
 php5enmod mcrypt

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -163,6 +163,7 @@ chmod 664 $STORAGE_ROOT/mail/users.sqlite
 # Run Roundcube database migration script (database is created if it does not exist)
 /usr/local/lib/roundcubemail/bin/updatedb.sh --dir /usr/local/lib/roundcubemail/SQL --package roundcube
 chown www-data:www-data $STORAGE_ROOT/mail/roundcube/roundcube.sqlite
+chmod 664 $STORAGE_ROOT/mail/roundcube/roundcube.sqlite
 
 # Enable PHP modules.
 php5enmod mcrypt


### PR DESCRIPTION
Should fix #1023 by changing ownership of the Roundcube SQLite database to `www-data` after running migrations.

    chown www-data:www-data $STORAGE_ROOT/mail/roundcube/roundcube.sqlite