### PR TITLE
need valid domain for hostname for admin email address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ management/__pycache__/
 tools/__pycache__/
 externals/
 .env
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,7 @@ Vagrant.configure("2") do |config|
   # to the public web. However, we currently don't want to expose SSH since
   # the machine's box will let anyone log into it. So instead we'll put the
   # machine on a private network.
-  config.vm.hostname = "mailinabox"
+  config.vm.hostname = "mailinabox.lan"
   config.vm.network "private_network", ip: "192.168.50.4"
 
   config.vm.provision :shell, :inline => <<-SH


### PR DESCRIPTION
Changes the Vagrantfile hostname to be a domain with tld.

added the .vagrant directory to gitignore so it's not accidentally committed.