### PR TITLE
adds optional vagrant-cachier if you have the plugin installed

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,12 @@ Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu14.04"
   config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
 
+  if Vagrant.has_plugin?("vagrant-cachier")
+    # Configure cached packages to be shared between instances of the same base box.
+    # More info on http://fgrehm.viewdocs.io/vagrant-cachier/usage
+    config.cache.scope = :box
+  end
+
   # Network config: Since it's a mail server, the machine must be connected
   # to the public web. However, we currently don't want to expose SSH since
   # the machine's box will let anyone log into it. So instead we'll put the


### PR DESCRIPTION
substantially improves the speed of `vagrant up` and `vagrant provision` the second time it's run and every time thereafter.