### PR TITLE
Fix/rsync issues

### DIFF
--- a/management/backup.py
+++ b/management/backup.py
@@ -548,6 +548,12 @@ if __name__ == "__main__":
 		# are readable, and b) report if they are up to date.
 		run_duplicity_verification()
 
+	elif sys.argv[-1] == "--list":
+		# Run duplicity's verification command to check a) the backup files
+		# are readable, and b) report if they are up to date.
+		for fn, size in list_target_files(get_backup_config(load_environment())):
+			print("{}\t{}".format(fn, size))
+
 	elif sys.argv[-1] == "--status":
 		# Show backup status.
 		ret = backup_status(load_environment())


### PR DESCRIPTION
Fixing both #1019 and #1033.

- fixed the path splitting allowing for relative paths to be used
- added more meaningful verbose messages upon rsync failures
- added CLI command to list files (really useful for better testing the config)

It's also overlaping with #1035, but I thought it'd be easier to avoid a potential merge conflict by having both commits in one PR.