### PR TITLE
Secure shared memory in /etc/fstab on setup

### DIFF
--- a/setup/preflight.sh
+++ b/setup/preflight.sh
@@ -47,6 +47,9 @@ if [ -n "$MOUNTED_TMP_AS_NO_EXEC" ]; then
 	exit
 fi
 
+#make sure that shared memory is secured
+grep -q -F 'tmpfs     /run/shm     tmpfs     defaults,noexec,nosuid     0     0' /etc/fstab || echo 'tmpfs     /run/shm     tmpfs     defaults,noexec,nosuid     0     0' >> /etc/fstab
+
 # Check that no .wgetrc exists
 if [ -e ~/.wgetrc ]; then
 	echo "Mail-in-a-Box expects no overrides to wget defaults, ~/.wgetrc exists"


### PR DESCRIPTION
During my research a practice I was taught was to secure the shared memory on Ubuntu. 
I was taught that in /etc/fstab you should add the option, so I had it search for the line on preflight, and if not found it will add it. 
`tmpfs     /run/shm     tmpfs     defaults,noexec,nosuid     0     0`
It seems like a simple tweak, to add a bit more security. I am probably going to have some other code changes I am making, as I am using this as a learning experience for myself. If this helps at all, or needs further tweaks please do let me know. I am quite happy to learn