### PR TITLE
Network harden (sysctl.conf & host.conf)

### DIFF
--- a/setup/mail-dovecot.sh
+++ b/setup/mail-dovecot.sh
@@ -46,8 +46,45 @@ tools/editconf.py /etc/dovecot/conf.d/10-master.conf \
 # See http://www.dovecot.org/pipermail/dovecot/2013-March/088834.html.
 # A reboot is required for this to take effect (which we don't do as
 # as a part of setup). Test with `cat /proc/sys/fs/inotify/max_user_instances`.
+# Added IP Spoofing detection and other settings to harden network 
+# by preventing source routing of incoming packets and log malformed IP's 
 tools/editconf.py /etc/sysctl.conf \
 	fs.inotify.max_user_instances=1024
+	# IP Spoofing protection
+	net.ipv4.conf.all.rp_filter = 1
+	net.ipv4.conf.default.rp_filter = 1
+
+	# Ignore ICMP broadcast requests
+	net.ipv4.icmp_echo_ignore_broadcasts = 1
+
+	# Disable source packet routing
+	net.ipv4.conf.all.accept_source_route = 0
+	net.ipv6.conf.all.accept_source_route = 0 
+	net.ipv4.conf.default.accept_source_route = 0
+	net.ipv6.conf.default.accept_source_route = 0
+
+	# Ignore send redirects
+	net.ipv4.conf.all.send_redirects = 0
+	net.ipv4.conf.default.send_redirects = 0
+	
+	# Block SYN attacks
+	net.ipv4.tcp_syncookies = 1
+	net.ipv4.tcp_max_syn_backlog = 2048
+	net.ipv4.tcp_synack_retries = 2
+	net.ipv4.tcp_syn_retries = 5
+
+	# Log Martians
+	net.ipv4.conf.all.log_martians = 1
+	net.ipv4.icmp_ignore_bogus_error_responses = 1
+
+	# Ignore ICMP redirects
+	net.ipv4.conf.all.accept_redirects = 0
+	net.ipv6.conf.all.accept_redirects = 0
+	net.ipv4.conf.default.accept_redirects = 0 
+	net.ipv6.conf.default.accept_redirects = 0
+
+	# Ignore Directed pings
+	net.ipv4.icmp_echo_ignore_all = 1
 
 # Set the location where we'll store user mailboxes. '%d' is the domain name and '%n' is the
 # username part of the user's email address. We'll ensure that no bad domains or email addresses

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -319,3 +319,7 @@ cp -f conf/fail2ban/filter.d/* /etc/fail2ban/filter.d/
 # scripts will ensure the files exist and then fail2ban is given another
 # restart at the very end of setup.
 restart_service fail2ban
+
+# Guard against IP Spoofing in the host.conf file
+# see http://www.tldp.org/LDP/nag/node82.html
+grep -q -F 'nospoof on' host.conf || echo 'nospoof on' >> host.conf


### PR DESCRIPTION
While researching and setting up some servers I was taught some additional tips to harden Ubuntu. Hopefully these can be of use to the project. If I am wrong please let me know, if it can be improved please let me know how. 
So basically in host.conf I added the ability to stop IP spoofing per http://www.tldp.org/LDP/nag/node82.html 

While in the sysctl.conf I added/changed various options for some network hardening.

I hope this is of any use to the overall project.