### PR TITLE
Added the pear install command for enigma plugin

### DIFF
--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -39,6 +39,7 @@ HASH=81fbfba4683522f6e54006d0300a48e6da3f3bbd
 VACATION_SIEVE_VERSION=91ea6f52216390073d1f5b70b5f6bea0bfaee7e5
 PERSISTENT_LOGIN_VERSION=1e9d724476a370ce917a2fcd5b3217b0c306c24e
 HTML5_NOTIFIER_VERSION=4b370e3cd60dabd2f428a26f45b677ad1b7118d5
+TWOFACTOR_GAUTHENTICATOR_VERSION=2020378f8cfb8349614c72faf1a76f8896653cca
 UPDATE_KEY=$VERSION:$VACATION_SIEVE_VERSION:$PERSISTENT_LOGIN_VERSION:$HTML5_NOTIFIER_VERSION:a
 needs_update=0 #NODOC
 if [ ! -f /usr/local/lib/roundcubemail/version ]; then
@@ -68,6 +69,9 @@ if [ $needs_update == 1 ]; then
 	# install roundcube html5_notifier plugin
 	git_clone https://github.com/kitist/html5_notifier.git $HTML5_NOTIFIER_VERSION '' /usr/local/lib/roundcubemail/plugins/html5_notifier
 
+	# install required Crypt_GPG pear package for enigma plugin
+	pear install Crypt_GPG
+	
 	# record the version we've installed
 	echo $UPDATE_KEY > /usr/local/lib/roundcubemail/version
 fi


### PR DESCRIPTION
The enigma plugin ships with mailinabox, but when enabled an error is produced in /var/log/roundcubemail/errors that looks like `PHP Fatal error:  Call to undefined method Crypt_GPG_SubKey::usage() in /usr/local/lib/roundcubemail/plugins/enigma/lib/enigma_driver_gnupg.php on line 457` This is resolved by running `pear install Crypt_GPG` which should have happened at install.