### PR TITLE
Support DSA and ED25519 SSHFP record types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ In Development
 * Allow larger messages to be checked by SpamAssassin.
 * Made nightly re-provisioning of TLS certificates less noisy.
 * Fixed bugs in rsync backup method.
+* Added support for DSA and ED25519 SSHFP records.
 
 v0.21b (December 4, 2016)
 -------------------------

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -342,6 +342,7 @@ def build_sshfp_records():
 		"ssh-rsa": 1,
 		"ssh-dss": 2,
 		"ecdsa-sha2-nistp256": 3,
+		"ssh-ed25519": 4,
 	}
 
 	# Get our local fingerprints by running ssh-keyscan. The output looks
@@ -359,7 +360,7 @@ def build_sshfp_records():
 				ports = ports + [s[1]]
 	# the keys are the same at each port, so we only need to get
 	# them at the first port found (may not be port 22)
-	keys = shell("check_output", ["ssh-keyscan", "-p", ports[0], "localhost"])
+	keys = shell("check_output", ["ssh-keyscan", "-t", "rsa,dsa,ecdsa,ed25519", "-p", ports[0], "localhost"])
 	for key in sorted(keys.split("\n")):
 		if key.strip() == "" or key[0] == "#": continue
 		try:


### PR DESCRIPTION
By default ssh-keyscan only looks for RSA and ECDSA key types. The `-t` parameter is needed to make it scan for all the SSH key types supported by MIAB.

I have this on my box already, try `$> dig SSHFP mail.seanwatson.io`