### PR TITLE
Fix broken pip due to cryptography/setuptools/pip mismatch

### DIFF
--- a/setup/management.sh
+++ b/setup/management.sh
@@ -15,7 +15,19 @@ apt_install build-essential libssl-dev libffi-dev python3-dev
 # Install other Python 3 packages used by the management daemon.
 # The first line is the packages that Josh maintains himself!
 # NOTE: email_validator is repeated in setup/questions.sh, so please keep the versions synced.
-hide_output pip3 install --upgrade setuptools
+
+# the below fixes the issue with an older version of pip3 and setup tools
+# breaking pip3 via a race condition
+# see https://github.com/pypa/pip/issues/4253
+# and
+# https://github.com/mail-in-a-box/mailinabox/issues/1086
+
+# need to use hide output, because we have to re-install this.
+hide_output apt-get install -y --reinstall python-pkg-resources
+# ensure that we have a modern version of setuptools, distribute and pip3 first
+hide_output python3 -m pip install --upgrade setuptools
+hide_output python3 -m pip install --upgrade distribute
+hide_output python3 -m pip install --upgrade pip
 
 hide_output pip3 install --upgrade \
 	rtyaml "email_validator>=1.0.0" "free_tls_certificates>=0.1.3" "exclusiveprocess" \

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -15,9 +15,11 @@ apt_install build-essential libssl-dev libffi-dev python3-dev
 # Install other Python 3 packages used by the management daemon.
 # The first line is the packages that Josh maintains himself!
 # NOTE: email_validator is repeated in setup/questions.sh, so please keep the versions synced.
+hide_output pip3 install --upgrade setuptools
+
 hide_output pip3 install --upgrade \
 	rtyaml "email_validator>=1.0.0" "free_tls_certificates>=0.1.3" "exclusiveprocess" \
-	"idna>=2.0.0" "cryptography>=1.0.2" boto psutil setuptools
+	"idna>=2.0.0" "cryptography<=1.0.2" boto psutil
 
 # duplicity uses python 2 so we need to get the python 2 package of boto to have backups to S3.
 # boto from the Ubuntu package manager is too out-of-date -- it doesn't support the newer

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -17,7 +17,7 @@ apt_install build-essential libssl-dev libffi-dev python3-dev
 # NOTE: email_validator is repeated in setup/questions.sh, so please keep the versions synced.
 hide_output pip3 install --upgrade \
 	rtyaml "email_validator>=1.0.0" "free_tls_certificates>=0.1.3" "exclusiveprocess" \
-	"idna>=2.0.0" "cryptography>=1.0.2" boto psutil
+	"idna>=2.0.0" "cryptography>=1.0.2" boto psutil setuptools
 
 # duplicity uses python 2 so we need to get the python 2 package of boto to have backups to S3.
 # boto from the Ubuntu package manager is too out-of-date -- it doesn't support the newer

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -19,7 +19,7 @@ hide_output pip3 install --upgrade setuptools
 
 hide_output pip3 install --upgrade \
 	rtyaml "email_validator>=1.0.0" "free_tls_certificates>=0.1.3" "exclusiveprocess" \
-	"idna>=2.0.0" "cryptography<=1.0.2" boto psutil
+	"idna>=2.0.0" "cryptography>=1.7.1" boto psutil
 
 # duplicity uses python 2 so we need to get the python 2 package of boto to have backups to S3.
 # boto from the Ubuntu package manager is too out-of-date -- it doesn't support the newer


### PR DESCRIPTION
fixes #1081 and #1080

I was able to replicate and adding `setuptools` to the initial pip3 installation seemed to fix it.