### PR TITLE
Change roundcube password min-length to four characters

### DIFF
--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -185,7 +185,7 @@ cp ${RCM_PLUGIN_DIR}/password/config.inc.php.dist \
 	${RCM_PLUGIN_DIR}/password/config.inc.php
 
 tools/editconf.py ${RCM_PLUGIN_DIR}/password/config.inc.php \
-	"\$config['password_minimum_length']=6;" \
+	"\$config['password_minimum_length']=4;" \
 	"\$config['password_db_dsn']='sqlite:///$STORAGE_ROOT/mail/users.sqlite';" \
 	"\$config['password_query']='UPDATE users SET password=%D WHERE email=%u';" \
 	"\$config['password_dovecotpw']='/usr/bin/doveadm pw';" \


### PR DESCRIPTION
in order to correlate with the management interface. Alternatively we can change https://github.com/mail-in-a-box/mailinabox/blob/d73d1c69002240bea6490d432853c849cc3eb55f/tools/mail.py#L33 to 6. 