### PR TITLE
Change password min-length to 8 characters

### DIFF
--- a/management/mailconfig.py
+++ b/management/mailconfig.py
@@ -599,8 +599,8 @@ def validate_password(pw):
 		raise ValueError("No password provided.")
 	if re.search(r"[\s]", pw):
 		raise ValueError("Passwords cannot contain spaces.")
-	if len(pw) < 4:
-		raise ValueError("Passwords must be at least four characters.")
+	if len(pw) < 8:
+		raise ValueError("Passwords must be at least eight characters.")
 
 
 if __name__ == "__main__":

--- a/management/templates/users.html
+++ b/management/templates/users.html
@@ -31,7 +31,7 @@
   <button type="submit" class="btn btn-primary">Add User</button>
 </form>
 <ul style="margin-top: 1em; padding-left: 1.5em; font-size: 90%;">
-  <li>Passwords must be at least four characters and may not contain spaces. For best results, <a href="#" onclick="return generate_random_password()">generate a random password</a>.</li>
+  <li>Passwords must be at least eight characters and may not contain spaces. For best results, <a href="#" onclick="return generate_random_password()">generate a random password</a>.</li>
   <li>Use <a href="#" onclick="return show_panel('aliases')">aliases</a> to create email addresses that forward to existing accounts.</li>
   <li>Administrators get access to this control panel.</li>
   <li>User accounts cannot contain any international (non-ASCII) characters, but <a href="#" onclick="return show_panel('aliases');">aliases</a> can.</li>
@@ -296,7 +296,7 @@ function mod_priv(elem, add_remove) {
 function generate_random_password() {
   var pw = "";
   var charset = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789"; // confusable characters skipped
-  for (var i = 0; i < 10; i++)
+  for (var i = 0; i < 12; i++)
     pw += charset.charAt(Math.floor(Math.random() * charset.length));
   show_modal_error("Random Password", "<p>Here, try this:</p> <p><code style='font-size: 110%'>" + pw + "</code></pr");
   return false; // cancel click

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -185,7 +185,7 @@ cp ${RCM_PLUGIN_DIR}/password/config.inc.php.dist \
 	${RCM_PLUGIN_DIR}/password/config.inc.php
 
 tools/editconf.py ${RCM_PLUGIN_DIR}/password/config.inc.php \
-	"\$config['password_minimum_length']=4;" \
+	"\$config['password_minimum_length']=8;" \
 	"\$config['password_db_dsn']='sqlite:///$STORAGE_ROOT/mail/users.sqlite';" \
 	"\$config['password_query']='UPDATE users SET password=%D WHERE email=%u';" \
 	"\$config['password_dovecotpw']='/usr/bin/doveadm pw';" \

--- a/tools/mail.py
+++ b/tools/mail.py
@@ -30,8 +30,8 @@ def mgmt(cmd, data=None, is_json=False):
 def read_password():
     while True:
         first = getpass.getpass('password: ')
-        if len(first) < 4:
-            print("Passwords must be at least four characters.")
+        if len(first) < 8:
+            print("Passwords must be at least eight characters.")
             continue
         if re.search(r'[\s]', first):
             print("Passwords cannot contain spaces.")


### PR DESCRIPTION
As there is a common practice to force stronger passwords, this pull request sets minimum password length to 8 characters. Additionally, random password generator provides stronger, 12-character passwords.