### PR TITLE
Update jails.conf - SSH fail2ban jail

### DIFF
--- a/conf/fail2ban/jails.conf
+++ b/conf/fail2ban/jails.conf
@@ -73,6 +73,7 @@ action   = iptables-allports[name=recidive]
 enabled  = true
 
 [ssh]
+enabled = true
 maxretry = 7
 bantime = 3600
 


### PR DESCRIPTION
SSH fail2ban jail is not enabled by default and so the jail does not load. Inserted line to enable it by default.