### PR TITLE
Upgrade ownCloud to 9.1.4 to address security vulnerabilities, refs #1111

### DIFF
--- a/setup/owncloud.sh
+++ b/setup/owncloud.sh
@@ -29,12 +29,13 @@ if [ ! -f $STORAGE_ROOT/owncloud/config.php ] \
 fi
 
 InstallOwncloud() {
-	echo
-	echo "Upgrading to ownCloud version $1"
-	echo
 
-        version=$1
-        hash=$2
+	version=$1
+	hash=$2
+
+	echo
+	echo "Upgrading to ownCloud version $version"
+	echo
 
 	# Remove the current owncloud
 	rm -rf /usr/local/lib/owncloud

--- a/setup/owncloud.sh
+++ b/setup/owncloud.sh
@@ -86,7 +86,8 @@ InstallOwncloud() {
 	fi
 }
 
-owncloud_ver=9.1.2
+owncloud_ver=9.1.4
+owncloud_hash=e637cab7b2ca3346164f3506b1a0eb812b4e841a
 
 # Check if ownCloud dir exist, and check if version matches owncloud_ver (if either doesn't - install/upgrade)
 if [ ! -d /usr/local/lib/owncloud/ ] \
@@ -153,7 +154,7 @@ EOF
 		fi
 	fi
 
-	InstallOwncloud $owncloud_ver ba9b1cdb681b8a3607d928cbe56f52e3888d9296
+	InstallOwncloud $owncloud_ver $owncloud_hash
 fi
 
 # ### Configuring ownCloud


### PR DESCRIPTION
There's a new scanning tool from the folks at Nextcloud (see #1111) which unearthed a few security vulnerabilities currently present in our ownCloud version. Therefore, we should upgrade ownCloud.

This PR moves the [scan.nextcloud.com](https://scan.nextcloud.com) score from an E to an A.