### PR TITLE
Move from ownCloud to Nextcloud 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It is a one-click email appliance. There are no user-configurable setup options.
 
 The components installed are:
 
-* SMTP ([postfix](http://www.postfix.org/)), IMAP ([dovecot](http://dovecot.org/)), CardDAV/CalDAV ([ownCloud](https://owncloud.org/)), Exchange ActiveSync ([z-push](https://github.com/fmbiete/Z-Push-contrib))
+* SMTP ([postfix](http://www.postfix.org/)), IMAP ([dovecot](http://dovecot.org/)), CardDAV/CalDAV ([Nextcloud](https://nextcloud.com/)), Exchange ActiveSync ([z-push](https://github.com/fmbiete/Z-Push-contrib))
 * Webmail ([Roundcube](http://roundcube.net/)), static website hosting ([nginx](http://nginx.org/))
 * Spam filtering ([spamassassin](https://spamassassin.apache.org/)), greylisting ([postgrey](http://postgrey.schweikert.ch/))
 * DNS ([nsd4](https://www.nlnetlabs.nl/projects/nsd/)) with [SPF](https://en.wikipedia.org/wiki/Sender_Policy_Framework), DKIM ([OpenDKIM](http://www.opendkim.org/)), [DMARC](https://en.wikipedia.org/wiki/DMARC), [DNSSEC](https://en.wikipedia.org/wiki/DNSSEC), [DANE TLSA](https://en.wikipedia.org/wiki/DNS-based_Authentication_of_Named_Entities), and [SSHFP](https://tools.ietf.org/html/rfc4255) records automatically set

--- a/conf/fail2ban/jails.conf
+++ b/conf/fail2ban/jails.conf
@@ -34,7 +34,7 @@ findtime = 30
 enabled  = true
 port     = http,https
 filter   = miab-owncloud
-logpath  = STORAGE_ROOT/owncloud/owncloud.log
+logpath  = STORAGE_ROOT/owncloud/nextcloud.log
 maxretry = 20
 findtime = 120
 

--- a/conf/nginx-alldomains.conf
+++ b/conf/nginx-alldomains.conf
@@ -70,7 +70,7 @@
 	# takes precedence over all non-regex matches and only regex matches that
 	# come after it (i.e. none of those, since this is the last one.) That means
 	# we're blocking dotfiles in the static hosted sites but not the FastCGI-
-	# handled locations for ownCloud (which serves user-uploaded files that might
+	# handled locations for Nextcloud (which serves user-uploaded files that might
 	# have this pattern, see #414) or some of the other services.
 	location ~ /\.(ht|svn|git|hg|bzr) {
 		log_not_found off;

--- a/conf/nginx-primaryonly.conf
+++ b/conf/nginx-primaryonly.conf
@@ -12,7 +12,7 @@
 		add_header Strict-Transport-Security max-age=31536000;
 	}
 
-	# ownCloud configuration.
+	# Nextcloud configuration.
 	rewrite ^/cloud$ /cloud/ redirect;
 	rewrite ^/cloud/$ /cloud/index.php;
 	rewrite ^/cloud/(contacts|calendar|files)$ /cloud/index.php/apps/$1/ redirect;
@@ -47,7 +47,7 @@
 		fastcgi_buffers 64 4K;
 	}
 	location ^~ /owncloud-xaccel/ {
-		# This directory is for MOD_X_ACCEL_REDIRECT_ENABLED. ownCloud sends the full file
+		# This directory is for MOD_X_ACCEL_REDIRECT_ENABLED. Nextcloud sends the full file
 		# path on disk as a subdirectory under this virtual path.
 		# We must only allow 'internal' redirects within nginx so that the filesystem
 		# is not exposed to the world.

--- a/conf/zpush/backend_carddav.php
+++ b/conf/zpush/backend_carddav.php
@@ -17,7 +17,7 @@ define('CARDDAV_CONTACTS_FOLDER_NAME', '%u Addressbook');
 define('CARDDAV_SUPPORTS_SYNC', false);
 
 // If the CardDAV server supports the FN attribute for searches
-// DAViCal supports it, but SabreDav, Owncloud and SOGo don't
+// DAViCal supports it, but SabreDav, Nextcloud and SOGo don't
 // Setting this to true will search by FN. If false will search by sn, givenName and email
 // It's safe to leave it as false
 define('CARDDAV_SUPPORTS_FN_SEARCH', false);

--- a/security.md
+++ b/security.md
@@ -73,7 +73,7 @@ If DNSSEC is enabled at the box's domain name's registrar, the SSHFP record that
 
 `fail2ban` provides some protection from brute-force login attacks (repeated logins that guess account passwords) by blocking offending IP addresses at the network level.
 
-The following services are protected: SSH, IMAP (dovecot), SMTP submission (postfix), webmail (roundcube), ownCloud/CalDAV/CardDAV (over HTTP), and the Mail-in-a-Box control panel & munin (over HTTP).
+The following services are protected: SSH, IMAP (dovecot), SMTP submission (postfix), webmail (roundcube), Nextcloud/CalDAV/CardDAV (over HTTP), and the Mail-in-a-Box control panel & munin (over HTTP).
 
 Some other services running on the box may be missing fail2ban filters.
 

--- a/tools/owncloud-restore.sh
+++ b/tools/owncloud-restore.sh
@@ -28,9 +28,9 @@ fi
 echo "Restoring backup from $1"
 service php5-fpm stop
 
-# remove the current owncloud installation
+# remove the current ownCloud/Nextcloud installation
 rm -rf /usr/local/lib/owncloud/
-# restore the current owncloud application
+# restore the current ownCloud/Nextcloud application
 cp -r  "$1/owncloud-install" /usr/local/lib/owncloud
 
 # restore access rights

--- a/tools/owncloud-unlockadmin.sh
+++ b/tools/owncloud-unlockadmin.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# This script will give you administrative access to the ownCloud
+# This script will give you administrative access to the Nextcloud
 # instance running here.
 #
 # Run this at your own risk. This is for testing & experimentation
@@ -13,8 +13,8 @@ test -z "$1" || ADMIN=$1
 
 echo I am going to unlock admin features for $ADMIN.
 echo You can provide another user to unlock as the first argument of this script.
-echo 
-echo WARNING: you could break mail-in-a-box when fiddling around with owncloud\'s admin interface
+echo
+echo WARNING: you could break mail-in-a-box when fiddling around with Nextcloud\'s admin interface
 echo If in doubt, press CTRL-C to cancel.
 echo 
 echo Press enter to continue.


### PR DESCRIPTION
This pull request moves MIAB from ownCloud to Nextcloud. (I know, I know. Let me explain!)

I have been following the discussions in #514 and #894 closely and I also think that MIAB will be better off moving to something more light-weight and controllable in the long term.

However, #514 has shown that we don't have consensus (yet) about a proper replacement for ownCloud in MIAB. All options have pros and cons and migration seems to be the biggest hurdle at the moment. Since a move like this has to be planned carefully it's certainly not something that's going to happen short-term. However, the longer we keep (outdated versions of) ownCloud running on MIAB, the more we will expose ourselves to the associated attack vectors.

I think that an *interim* move to Nextcloud would be a wise decision for the time being.

Looking at the development of the two [ownC|Nextc]loud projects since the fork, Nextcloud seems to be the more active and open/libre contender. It's been initiated by the project's original founder Frank Karlitschek and it's supported by many of the former contributors. To me it seems that Nextcloud represents a direct continuation of the ownCloud project while ownCloud itself is merely the former "business partners" trying to keep an abandoned code base up and running. Last but not least, the people at Nextcloud seem to [take security more seriously](https://nextcloud.com/secure/).

<off-topic>There's a [podcast interview](https://www.radiotux.de/index.php?/archives/8015-RadioTux-Sendung-Juni-2016.html) about the fork with Frank for those who understand German.</off-topc>

This PR is designed to be very small and simple, so that it can be reviewed and hopefully merged without much friction. It mainly re-uses the upgrade/migration logic which @yodax built in #894 and adds an internal `flavor` argument that changes the download URLs for `wget`.

It follows the migration path recommended by Nextcloud and will move from ownCloud 9.1.x (status quo in stable MIAB) to Nextcloud 10.0.4. All previous migration steps up to 9.1.x are still carried out, so the upgrade should be just as safe as moving from any older MIAB release to the current one (before this PR) + the move to Nextcloud itself which is considered safe by the Nextcloud community.

I have been maintaining a few ownCloud installations outside of MIAB and I have migrated them all successfully to Nextcloud. The Nextcloud team did some solid work there, so we shouldn't expect too many issues with this last step of the migration chain.

I was going to upgrade all the way to Nextcloud 11. Unfortunately that requires at least PHP 5.6 while we're still at PHP 5.5 (see #827), so Nextcloud 10 it is for now. That's fine though as 10.x still seems to be getting updates even though Nextcloud [has not made any EOL promises](https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule) as of yet.

This PR was manually tested with direct upgrades from:

- v0.19b (ownCloud 8.2.7)
- v0.21  (ownCloud 9.1.1)
- v0.21c (ownCloud 9.1.2)
- a fresh Ubuntu 14.04 box

I've also tested any migrated boxes using the `tests/fail2ban.py`script as @yodax pointed out in #1111 and fail2ban has been configured to read from the new `nextcloud.log`.

The PR does not yet rename any of the internal files and folders, neither within the MIAB code nor on the target boxes. Everything is still called `owncloud...` internally. This was intentional to make this PR as small and self-contained as possible. I'd be happy to do house-keeping in subsequent commits.

Any feedback would be greatly appreciated. Thanks!
