### PR TITLE
Update z-push to 2.3.5 on the upstream repository of z-push.org

### DIFF
--- a/conf/zpush/autodiscover_config.php
+++ b/conf/zpush/autodiscover_config.php
@@ -5,11 +5,12 @@
 * Descr     :   Autodiscover configuration file
 ************************************************/
 
+define('TIMEZONE', '');
+
 // Defines the base path on the server
 define('BASE_PATH', dirname($_SERVER['SCRIPT_FILENAME']). '/');
 
-// The Z-Push server location for the autodiscover response
-define('SERVERURL', 'https://PRIMARY_HOSTNAME/Microsoft-Server-ActiveSync');
+define('ZPUSH_HOST', 'PRIMARY_HOSTNAME');
 
 define('USE_FULLEMAIL_FOR_LOGIN', true);
 
@@ -18,6 +19,7 @@ define('LOGFILE', LOGFILEDIR . 'autodiscover.log');
 define('LOGERRORFILE', LOGFILEDIR . 'autodiscover-error.log');
 define('LOGLEVEL', LOGLEVEL_INFO);
 define('LOGUSERLEVEL', LOGLEVEL);
+$specialLogUsers = array();
 
 // the backend data provider
 define('BACKEND_PROVIDER', 'BackendCombined');

--- a/conf/zpush/backend_imap.php
+++ b/conf/zpush/backend_imap.php
@@ -23,6 +23,9 @@ define('IMAP_FOLDER_TRASH', 'TRASH');
 define('IMAP_FOLDER_SPAM', 'SPAM');
 define('IMAP_FOLDER_ARCHIVE', 'ARCHIVE');
 
+define('IMAP_INLINE_FORWARD', true);
+define('IMAP_EXCLUDED_FOLDERS', '');
+
 define('IMAP_FROM_SQL_DSN', 'sqlite:STORAGE_ROOT/mail/roundcube/roundcube.sqlite');
 define('IMAP_FROM_SQL_USER', '');
 define('IMAP_FROM_SQL_PASSWORD', '');
@@ -49,5 +52,6 @@ global $imap_smtp_params;
 $imap_smtp_params = array('host' => 'ssl://127.0.0.1', 'port' => 587, 'auth' => true, 'username' => 'imap_username', 'password' => 'imap_password');
 
 define('MAIL_MIMEPART_CRLF', "\r\n");
+define('IMAP_MEETING_USE_CALDAV', true);
 
 ?>


### PR DESCRIPTION
This fixes the issues with z-push and Outlook 2016. The previews for email on iOS also work with this version.

I have tested mail, calendar and contacts on:

- iOS 10
- Windows 10 - Mail/Calendar/Contacts
- Windows 10 - Outlook 2016

Some testing by others would be appreciated. I think this should make z-push useable again. 