### PR TITLE
Add support for adding a manual CAA record

### DIFF
--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -767,7 +767,7 @@ def set_custom_dns_record(qname, rtype, value, action, env):
 				v = ipaddress.ip_address(value) # raises a ValueError if there's a problem
 				if rtype == "A" and not isinstance(v, ipaddress.IPv4Address): raise ValueError("That's an IPv6 address.")
 				if rtype == "AAAA" and not isinstance(v, ipaddress.IPv6Address): raise ValueError("That's an IPv4 address.")
-		elif rtype in ("CNAME", "TXT", "SRV", "MX", "SSHFP"):
+		elif rtype in ("CNAME", "TXT", "SRV", "MX", "SSHFP", "CAA"):
 			# anything goes
 			pass
 		else:

--- a/management/templates/custom-dns.html
+++ b/management/templates/custom-dns.html
@@ -126,7 +126,7 @@
 <tr><td>email</td> <td>The email address of any administrative user here.</td></tr>
 <tr><td>password</td> <td>That user&rsquo;s password.</td></tr>
 <tr><td>qname</td> <td>The fully qualified domain name for the record you are trying to set. It must be one of the domain names or a subdomain of one of the domain names hosted on this box. (Add mail users or aliases to add new domains.)</td></tr>
-<tr><td>rtype</td> <td>The resource type. Defaults to <code>A</code> if omitted. Possible values: <code>A</code> (an IPv4 address), <code>AAAA</code> (an IPv6 address), <code>TXT</code> (a text string), <code>CNAME</code> (an alias, which is a fully qualified domain name &mdash; don&rsquo;t forget the final period), <code>MX</code>, <code>SRV</code>, or <code>SSHFP</code>, or <code>CAA</code>.</td></tr>
+<tr><td>rtype</td> <td>The resource type. Defaults to <code>A</code> if omitted. Possible values: <code>A</code> (an IPv4 address), <code>AAAA</code> (an IPv6 address), <code>TXT</code> (a text string), <code>CNAME</code> (an alias, which is a fully qualified domain name &mdash; don&rsquo;t forget the final period), <code>MX</code>, <code>SRV</code>, <code>SSHFP</code> or <code>CAA</code>.</td></tr>
 <tr><td>value</td> <td>For PUT, POST, and DELETE, the record&rsquo;s value. If the <code>rtype</code> is <code>A</code> or <code>AAAA</code> and <code>value</code> is empty or omitted, the IPv4 or IPv6 address of the remote host is used (be sure to use the <code>-4</code> or <code>-6</code> options to curl). This is handy for dynamic DNS!</td></tr>
 </table>
 

--- a/management/templates/custom-dns.html
+++ b/management/templates/custom-dns.html
@@ -33,6 +33,7 @@
       <select id="customdnsType" class="form-control" style="max-width: 400px" onchange="show_customdns_rtype_hint()">
         <option value="A" data-hint="Enter an IPv4 address (i.e. a dotted quad, such as 123.456.789.012).">A (IPv4 address)</option>
         <option value="AAAA" data-hint="Enter an IPv6 address.">AAAA (IPv6 address)</option>
+        <option value="CAA" data-hint="Enter a CA that can issue certificates for this domain in the form of FLAG TAG VALUE. (0 issuewild &quot;letsencrypt.org&quot;)">CAA (Certificate Authority Authorization)</option>
         <option value="CNAME" data-hint="Enter another domain name followed by a period at the end (e.g. mypage.github.io.).">CNAME (DNS forwarding)</option>
         <option value="TXT" data-hint="Enter arbitrary text.">TXT (text record)</option>
         <option value="MX" data-hint="Enter record in the form of PRIORITY DOMAIN., including trailing period (e.g. 20 mx.example.com.).">MX (mail exchanger)</option>
@@ -125,7 +126,7 @@
 <tr><td>email</td> <td>The email address of any administrative user here.</td></tr>
 <tr><td>password</td> <td>That user&rsquo;s password.</td></tr>
 <tr><td>qname</td> <td>The fully qualified domain name for the record you are trying to set. It must be one of the domain names or a subdomain of one of the domain names hosted on this box. (Add mail users or aliases to add new domains.)</td></tr>
-<tr><td>rtype</td> <td>The resource type. Defaults to <code>A</code> if omitted. Possible values: <code>A</code> (an IPv4 address), <code>AAAA</code> (an IPv6 address), <code>TXT</code> (a text string), <code>CNAME</code> (an alias, which is a fully qualified domain name &mdash; don&rsquo;t forget the final period), <code>MX</code>, <code>SRV</code>, or <code>SSHFP</code>.</td></tr>
+<tr><td>rtype</td> <td>The resource type. Defaults to <code>A</code> if omitted. Possible values: <code>A</code> (an IPv4 address), <code>AAAA</code> (an IPv6 address), <code>TXT</code> (a text string), <code>CNAME</code> (an alias, which is a fully qualified domain name &mdash; don&rsquo;t forget the final period), <code>MX</code>, <code>SRV</code>, or <code>SSHFP</code>, or <code>CAA</code>.</td></tr>
 <tr><td>value</td> <td>For PUT, POST, and DELETE, the record&rsquo;s value. If the <code>rtype</code> is <code>A</code> or <code>AAAA</code> and <code>value</code> is empty or omitted, the IPv4 or IPv6 address of the remote host is used (be sure to use the <code>-4</code> or <code>-6</code> options to curl). This is handy for dynamic DNS!</td></tr>
 </table>
 


### PR DESCRIPTION
For https://github.com/mail-in-a-box/mailinabox/issues/1154 and [discourse topic](https://discourse.mailinabox.email/t/caa-dns-record-checking-now-mandatory/2081)

This PR allows a user to add a CAA record manually.

<img width="909" alt="schermafbeelding 2017-04-12 om 14 38 29" src="https://cloud.githubusercontent.com/assets/5643940/24957931/dc0b1d2e-1f8d-11e7-9352-f59867d9eb0e.png">

This results in:
```
dig @ns1.box.test.domain test.domain CAA

; <<>> DiG 9.11.0-P3 <<>> @ns1.box.test.domain test.domain CAA
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 18331
;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 2, ADDITIONAL: 5
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;test.domain.			IN	CAA

;; ANSWER SECTION:
test.domain.		1800	IN	CAA	0 issuewild "letsencrypt.org"

;; AUTHORITY SECTION:
test.domain.		1800	IN	NS	ns1.box.test.domain.
test.domain.		1800	IN	NS	ns2.box.test.domain.

;; ADDITIONAL SECTION:
ns1.box.test.domain.	1800	IN	A	xx
ns2.box.test.domain.	1800	IN	A	xx
ns1.box.test.domain.	1800	IN	AAAA	xx
ns2.box.test.domain.	1800	IN	AAAA	xx

;; Query time: 24 msec
;; SERVER: xx#53(xx)
;; WHEN: Wed Apr 12 14:24:28 CEST 2017
;; MSG SIZE  rcvd: 206

```

Maybe in the future we could make this automatic when we request certificates from lets encrypt.
