### PR TITLE
#1161 Move the config line for mail_domain to always reset the PRIMARY_HOST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ Control Panel/Management:
 * Fix an error in the control panel related to IPv6 addresses.
 * TLS certificates for internationalized domain names can now be provisioned from Let's Encrypt automatically.
 
+v0.22a (April 24, 2017)
+---------------------
+Installation:
+
+* Fixed an error in Owncloud/Nextcloud setup not updating domain when changing hostname.
+
+
 v0.22 (April 2, 2017)
 ---------------------
 
@@ -160,7 +167,7 @@ v0.18 (May 15, 2016)
 
 ownCloud:
 
-* Updated to ownCloud to 8.2.3 
+* Updated to ownCloud to 8.2.3
 
 Mail:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,18 +12,13 @@ Mail:
 ownCloud (now Nextcloud):
 
 * ownCloud is replaced with Nextcloud 10.0.5.
+* Fixed an error in Owncloud/Nextcloud setup not updating domain when changing hostname.
 
 Control Panel/Management:
 
 * Fix an error in the control panel showing rsync backup status.
 * Fix an error in the control panel related to IPv6 addresses.
 * TLS certificates for internationalized domain names can now be provisioned from Let's Encrypt automatically.
-
-v0.22a (April 24, 2017)
----------------------
-Installation:
-
-* Fixed an error in Owncloud/Nextcloud setup not updating domain when changing hostname.
 
 
 v0.22 (April 2, 2017)

--- a/setup/owncloud.sh
+++ b/setup/owncloud.sh
@@ -221,7 +221,6 @@ if [ ! -f $STORAGE_ROOT/owncloud/owncloud.db ]; then
   'mail_smtpname' => '',
   'mail_smtppassword' => '',
   'mail_from_address' => 'owncloud',
-  'mail_domain' => '$PRIMARY_HOSTNAME',
 );
 ?>
 EOF
@@ -277,6 +276,8 @@ include("$STORAGE_ROOT/owncloud/config.php");
 
 \$CONFIG['logtimezone'] = '$TIMEZONE';
 \$CONFIG['logdateformat'] = 'Y-m-d H:i:s';
+
+\$CONFIG['mail_domain'] => '$PRIMARY_HOSTNAME',
 
 echo "<?php\n\\\$CONFIG = ";
 var_export(\$CONFIG);

--- a/setup/owncloud.sh
+++ b/setup/owncloud.sh
@@ -261,6 +261,8 @@ fi
 # * We need to set the timezone to the system timezone to allow fail2ban to ban
 #   users within the proper timeframe
 # * We need to set the logdateformat to something that will work correctly with fail2ban
+# * mail_domain' needs to be set every time we run the setup. Making sure we are setting 
+#   the correct domain name if the domain is being change from the previous setup.
 # Use PHP to read the settings file, modify it, and write out the new settings array.
 TIMEZONE=$(cat /etc/timezone)
 CONFIG_TEMP=$(/bin/mktemp)


### PR DESCRIPTION
 Cant we just move the line when the $PRIMARY_HOST is set down a few lines? That way its set regardless of the file already being present.