### PR TITLE
Update Z-Push to 2.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ In Development
 Mail:
 
 * The default theme for Roundcube was changed to the nicer Larry theme.
-* Exchange/ActiveSync support has been replaced with z-push 2.3.5 from z-push.org (rather than z-push-contrib).
+* Exchange/ActiveSync support has been replaced with z-push 2.3.6 from z-push.org (rather than z-push-contrib).
 
 ownCloud (now Nextcloud):
 

--- a/setup/zpush.sh
+++ b/setup/zpush.sh
@@ -22,8 +22,8 @@ apt_install \
 php5enmod imap
 
 # Copy Z-Push into place.
-TARGETHASH=3ce78c23e02198bffe80c983ce247350c27590bd
-VERSION=2.3.5
+TARGETHASH=131229a8feda09782dfd06449adce3d5a219183f
+VERSION=2.3.6
 needs_update=0 #NODOC
 if [ ! -f /usr/local/lib/z-push/version ]; then
 	needs_update=1 #NODOC


### PR DESCRIPTION
This is an update to the latest version of z-push. This is just a bug fix release. A few are interesting (at least to me)

- https://jira.z-hub.io/browse/ZP-1155 REVERT: [IMAP] iOS mail with z-push preview show raw html
- https://jira.z-hub.io/browse/ZP-1167 [IMAP] Some new messages are outdated and lost when sync

This was tested with iOS 10.

Full changelog:

```
Hi all,

we have just released Z-Push 2.3.6 (tag 2.3.6, commit ca1e816ee03c6c3ba4ed8d439ad7478b69f5404f).

This is a maintenence release without major features, but several important fixes. 
Thanks to our contributor Roel we got updated licenses for some pear classes used in the IMAP backend that will make it possible to get Z-Push into Debian.
Roel also contributed some man pages for the z-push CLI tools.
Yano contributed some other changes for the IMAP backend, improving the sync of messages.
Thanks guys! 
This version also contains a few fixes for the Kopano backend and KOE.

Changes since 2.3.5 final:

Tickets merged to final and released as 2.3.5+5 via repositories (also included in this version):
https://jira.z-hub.io/browse/ZP-1155 REVERT: [IMAP] iOS mail with z-push preview show raw html
https://jira.z-hub.io/browse/ZP-1179 folderid not mapped when deleting
https://jira.z-hub.io/browse/ZP-1191 Z-Push 2.3.5 breaks CentOS updates / libawl invalid dependency

Improvements
https://jira.z-hub.io/browse/ZP-1135 Update licenses of forked PEAR classes to be compatible with Debian (includes ZP-1152, ZP-1187, ZP-1189, ZP-1193) (thanks to Roel for achieving this!)
https://jira.z-hub.io/browse/ZP-1168 Log wait time in INFO level
https://jira.z-hub.io/browse/ZP-1178 Use PR_SEARCH_KEY in cases the GAB entry of a recipient is not available
https://jira.z-hub.io/browse/ZP-1190 Missing manpages for installed binaries (thanks to Roel for contributing)
https://jira.z-hub.io/browse/ZP-1195 Expose WebserviceDevice->GetDeviceDetails() for a single device

Bugs
https://jira.z-hub.io/browse/ZP-1163 Warning when install z-push-common on a new system
https://jira.z-hub.io/browse/ZP-1167 [IMAP] Some new messages are outdated and lost when sync
https://jira.z-hub.io/browse/ZP-1169 Kopano MAPI_E_UNCONFIGURED (0x8004011C) causes a folder resync
https://jira.z-hub.io/browse/ZP-1172 [IMAP] Some mails bodies or headers in Japanese may be decoded in wrong encoding
https://jira.z-hub.io/browse/ZP-1180 Implement plain streams for CalDav and CardDav backends
https://jira.z-hub.io/browse/ZP-1182 WARN messages doesn't log into z-push-error.log
https://jira.z-hub.io/browse/ZP-1185 Messages in error log are duplicated
https://jira.z-hub.io/browse/ZP-1186 Folder created under root in Outlook is not synced
https://jira.z-hub.io/browse/ZP-1188 Check if OOF expired and disabled it if needed


Code changes since Z-Push 2.3.5: https://stash.z-hub.io/projects/ZP/repos/z-push/compare/diff?targetBranch=refs%2Ftags%2F2.3.5&sourceBranch=refs%2Ftags%2F2.3.6

Install Z-Push 2.3.6 from the final repositories (recommended): https://wiki.z-hub.io/display/ZP/Installation

The tarball is available here (not recommended): http://download.z-push.org/final/2.3/z-push-2.3.6.tar.gz

Please share your experiences and give feedback!

Greetings,
Sebastian
Z-Push dev team
```