### PR TITLE
Download jQuery and Bootstrap to local box (#1167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Control Panel/Management:
 * Fix an error in the control panel showing rsync backup status.
 * Fix an error in the control panel related to IPv6 addresses.
 * TLS certificates for internationalized domain names can now be provisioned from Let's Encrypt automatically.
+* Download management web assets (jQuery/Bootstrap) to the static web root directory.
 
 v0.22 (April 2, 2017)
 ---------------------
@@ -160,7 +161,7 @@ v0.18 (May 15, 2016)
 
 ownCloud:
 
-* Updated to ownCloud to 8.2.3 
+* Updated to ownCloud to 8.2.3
 
 Mail:
 

--- a/management/templates/index.html
+++ b/management/templates/index.html
@@ -9,7 +9,7 @@
 
         <meta name="robots" content="noindex, nofollow">
 
-        <link rel="stylesheet" href="/assets/css/lib/bootstrap.min.css">
+        <link rel="stylesheet" href="/assets/bootstrap.min.css">
         <style>
 	    body {
 		overflow-y: scroll;
@@ -63,7 +63,7 @@
 	       margin-bottom: 1em;
 	    }
         </style>
-        <link rel="stylesheet" href="/assets/css/lib/bootstrap-theme.min.css">
+        <link rel="stylesheet" href="/assets/bootstrap-theme.min.css">
     </head>
     <body>
 
@@ -191,8 +191,8 @@
           </div>
         </div>
 
-        <script src="/assets/js/lib/jquery.min.js"></script>
-        <script src="/assets/js/lib/bootstrap.min.js"></script>
+        <script src="/assets/jquery.min.js"></script>
+        <script src="/assets/bootstrap.min.js"></script>
 
         <script>
 var global_modal_state = null;

--- a/management/templates/index.html
+++ b/management/templates/index.html
@@ -9,7 +9,7 @@
 
         <meta name="robots" content="noindex, nofollow">
 
-        <link rel="stylesheet" href="/admin/static/assets/css/lib/bootstrap.min.css">
+        <link rel="stylesheet" href="/assets/css/lib/bootstrap.min.css">
         <style>
 	    body {
 		overflow-y: scroll;
@@ -63,7 +63,7 @@
 	       margin-bottom: 1em;
 	    }
         </style>
-        <link rel="stylesheet" href="/admin/static/assets/css/lib/bootstrap-theme.min.css">
+        <link rel="stylesheet" href="/assets/css/lib/bootstrap-theme.min.css">
     </head>
     <body>
 
@@ -191,8 +191,8 @@
           </div>
         </div>
 
-        <script src="/admin/static/assets/js/lib/jquery.min.js"></script>
-        <script src="/admin/static/assets/js/lib/bootstrap.min.js"></script>
+        <script src="/assets/js/lib/jquery.min.js"></script>
+        <script src="/assets/js/lib/bootstrap.min.js"></script>
 
         <script>
 var global_modal_state = null;

--- a/management/templates/index.html
+++ b/management/templates/index.html
@@ -9,7 +9,7 @@
 
         <meta name="robots" content="noindex, nofollow">
 
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+        <link rel="stylesheet" href="/admin/static/assets/css/lib/bootstrap.min.css">
         <style>
 	    body {
 		overflow-y: scroll;
@@ -63,7 +63,7 @@
 	       margin-bottom: 1em;
 	    }
         </style>
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+        <link rel="stylesheet" href="/admin/static/assets/css/lib/bootstrap-theme.min.css">
     </head>
     <body>
 
@@ -191,8 +191,8 @@
           </div>
         </div>
 
-        <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js" integrity="sha256-rsPUGdUPBXgalvIj4YKJrrUlmLXbOb6Cp7cdxn1qeUc=" crossorigin="anonymous"></script>
-        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+        <script src="/admin/static/assets/js/lib/jquery.min.js"></script>
+        <script src="/admin/static/assets/js/lib/bootstrap.min.js"></script>
 
         <script>
 var global_modal_state = null;
@@ -218,7 +218,7 @@ $(function() {
     if (global_modal_state == null) global_modal_state = 1; // cancel if the user hit ESC or clicked outside of the modal
     if (global_modal_funcs && global_modal_funcs[global_modal_state])
       global_modal_funcs[global_modal_state]();
-  })  
+  })
 })
 
 function show_modal_error(title, message, callback) {
@@ -281,7 +281,7 @@ function ajax_with_indicator(options) {
   };
   options.error = function(jqxhr) {
     hide_loading_indicator();
-    if (!old_error) 
+    if (!old_error)
       show_modal_error("Error", "Something went wrong, sorry.")
     else
       old_error(jqxhr.responseText, jqxhr);

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -72,15 +72,15 @@ mkdir -p $assets_dir
 jquery_version=2.1.4
 jquery_url=https://code.jquery.com
 
-# Get the Javascript files
+# Get jQuery
 wget_verify $jquery_url/jquery-$jquery_version.min.js 43dc554608df885a59ddeece1598c6ace434d747 $assets_dir/jquery.min.js
-wget_verify $bootstrap_url/js/bootstrap.min.js 430a443d74830fe9be26efca431f448c1b3740f9 $assets_dir/bootstrap.min.js
 
 # Bootstrap CDN URL
 bootstrap_version=3.3.7
 bootstrap_url=https://maxcdn.bootstrapcdn.com/bootstrap/$bootstrap_version
 
-# Get the CSS/Map files
+# Get Bootstrap
+wget_verify $bootstrap_url/js/bootstrap.min.js 430a443d74830fe9be26efca431f448c1b3740f9 $assets_dir/bootstrap.min.js
 wget_verify $bootstrap_url/css/bootstrap-theme.min.css 8256575374f430476bdcd49de98c77990229ce31 $assets_dir/bootstrap-theme.min.css
 wget_verify $bootstrap_url/css/bootstrap-theme.min.css.map 87f7dfd79d77051ac2eca7d093d961fbd1c8f6eb $assets_dir/bootstrap-theme.min.css.map
 wget_verify $bootstrap_url/css/bootstrap.min.css 6527d8bf3e1e9368bab8c7b60f56bc01fa3afd68 $assets_dir/bootstrap.min.css

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -65,9 +65,6 @@ fi
 # Download jQuery and Bootstrap local files
 echo "Installing Mail-in-a-Box system management web assets..."
 
-js_lib=$STORAGE_ROOT/www/default/assets/js/lib
-css_lib=$STORAGE_ROOT/www/default/assets/css/lib
-
 # jQuery CDN URL
 jquery_version=2.1.4
 jquery_url=https://code.jquery.com
@@ -76,24 +73,27 @@ jquery_url=https://code.jquery.com
 bootstrap_version=3.3.7
 bootstrap_url=https://maxcdn.bootstrapcdn.com/bootstrap/$bootstrap_version
 
-# Get the Javascript files
+js_lib=$STORAGE_ROOT/www/default/assets/js/lib
+css_lib=$STORAGE_ROOT/www/default/assets/css/lib
+
+# Make sure we have the directories to save to.
 if [ ! -d $js_lib ]; then
 	mkdir -p $js_lib
-
-	wget_verify $jquery_url/jquery-$jquery_version.min.js 43dc554608df885a59ddeece1598c6ace434d747 $js_lib/jquery.min.js
-	wget_verify $bootstrap_url/js/bootstrap.min.js 430a443d74830fe9be26efca431f448c1b3740f9 $js_lib/bootstrap.min.js
 fi
 
-# Get the CSS(map) files
 if [ ! -d $css_lib ]; then
 	mkdir -p $css_lib
-
-	wget_verify $bootstrap_url/css/bootstrap-theme.min.css 8256575374f430476bdcd49de98c77990229ce31 $css_lib/bootstrap-theme.min.css
-	wget_verify $bootstrap_url/css/bootstrap-theme.min.css.map 87f7dfd79d77051ac2eca7d093d961fbd1c8f6eb $css_lib/bootstrap-theme.min.css.map
-	wget_verify $bootstrap_url/css/bootstrap.min.css 6527d8bf3e1e9368bab8c7b60f56bc01fa3afd68 $css_lib/bootstrap.min.css
-	wget_verify $bootstrap_url/css/bootstrap.min.css.map e0d7b2bde55a0bac1b658a507e8ca491a6729e06 $css_lib/bootstrap.min.css.map
 fi
 
+# Get the Javascript files
+wget_verify $jquery_url/jquery-$jquery_version.min.js 43dc554608df885a59ddeece1598c6ace434d747 $js_lib/jquery.min.js
+wget_verify $bootstrap_url/js/bootstrap.min.js 430a443d74830fe9be26efca431f448c1b3740f9 $js_lib/bootstrap.min.js
+
+# Get the CSS(map) files
+wget_verify $bootstrap_url/css/bootstrap-theme.min.css 8256575374f430476bdcd49de98c77990229ce31 $css_lib/bootstrap-theme.min.css
+wget_verify $bootstrap_url/css/bootstrap-theme.min.css.map 87f7dfd79d77051ac2eca7d093d961fbd1c8f6eb $css_lib/bootstrap-theme.min.css.map
+wget_verify $bootstrap_url/css/bootstrap.min.css 6527d8bf3e1e9368bab8c7b60f56bc01fa3afd68 $css_lib/bootstrap.min.css
+wget_verify $bootstrap_url/css/bootstrap.min.css.map e0d7b2bde55a0bac1b658a507e8ca491a6729e06 $css_lib/bootstrap.min.css.map
 
 
 # Link the management server daemon into a well known location.

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -61,6 +61,41 @@ if [ ! -f $STORAGE_ROOT/backup/secret_key.txt ]; then
 	$(umask 077; openssl rand -base64 2048 > $STORAGE_ROOT/backup/secret_key.txt)
 fi
 
+
+# Download jQuery and Bootstrap local files
+ if [ ! -d $HOME/mailinabox/management/static ]; then
+
+   js_lib=$HOME/mailinabox/management/static/assets/js/lib
+   css_lib=$HOME/mailinabox/management/static/assets/css/lib
+
+	 # jQuery CDN URL
+	 jquery_version=2.1.4
+   jquery_url=https://code.jquery.com
+
+   # Bootstrap CDN URL
+   bootstrap_version=3.3.7
+   bootstrap_url=https://maxcdn.bootstrapcdn.com/bootstrap/$bootstrap_version
+
+	# Get the Javascript files
+	if [ ! -d $js_lib ]; then
+		mkdir -p $js_lib
+
+		wget_verify $jquery_url/jquery-$jquery_version.min.js 43dc554608df885a59ddeece1598c6ace434d747 $js_lib/jquery.min.js
+		wget_verify $bootstrap_url/js/bootstrap.min.js 430a443d74830fe9be26efca431f448c1b3740f9 $js_lib/bootstrap.min.js
+	fi
+
+	# Get the CSS(map) files
+	if [ ! -d $css_lib ]; then
+		mkdir -p $css_lib
+
+		wget_verify $bootstrap_url/css/bootstrap-theme.min.css 8256575374f430476bdcd49de98c77990229ce31 $css_lib/bootstrap-theme.min.css
+		wget_verify $bootstrap_url/css/bootstrap-theme.min.css.map 87f7dfd79d77051ac2eca7d093d961fbd1c8f6eb $css_lib/bootstrap-theme.min.css.map
+		wget_verify $bootstrap_url/css/bootstrap.min.css 6527d8bf3e1e9368bab8c7b60f56bc01fa3afd68 $css_lib/bootstrap.min.css
+		wget_verify $bootstrap_url/css/bootstrap.min.css.map e0d7b2bde55a0bac1b658a507e8ca491a6729e06 $css_lib/bootstrap.min.css.map
+	fi
+ fi
+
+
 # Link the management server daemon into a well known location.
 rm -f /usr/local/bin/mailinabox-daemon
 ln -s `pwd`/management/daemon.py /usr/local/bin/mailinabox-daemon

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -63,37 +63,28 @@ fi
 
 
 # Download jQuery and Bootstrap local files
-echo "Installing Mail-in-a-Box system management web assets..."
+
+# Make sure we have the directory to save to.
+assets_dir=$STORAGE_ROOT/www/default/assets
+mkdir -p $assets_dir
 
 # jQuery CDN URL
 jquery_version=2.1.4
 jquery_url=https://code.jquery.com
 
+# Get the Javascript files
+wget_verify $jquery_url/jquery-$jquery_version.min.js 43dc554608df885a59ddeece1598c6ace434d747 $assets_dir/jquery.min.js
+wget_verify $bootstrap_url/js/bootstrap.min.js 430a443d74830fe9be26efca431f448c1b3740f9 $assets_dir/bootstrap.min.js
+
 # Bootstrap CDN URL
 bootstrap_version=3.3.7
 bootstrap_url=https://maxcdn.bootstrapcdn.com/bootstrap/$bootstrap_version
 
-js_lib=$STORAGE_ROOT/www/default/assets/js/lib
-css_lib=$STORAGE_ROOT/www/default/assets/css/lib
-
-# Make sure we have the directories to save to.
-if [ ! -d $js_lib ]; then
-	mkdir -p $js_lib
-fi
-
-if [ ! -d $css_lib ]; then
-	mkdir -p $css_lib
-fi
-
-# Get the Javascript files
-wget_verify $jquery_url/jquery-$jquery_version.min.js 43dc554608df885a59ddeece1598c6ace434d747 $js_lib/jquery.min.js
-wget_verify $bootstrap_url/js/bootstrap.min.js 430a443d74830fe9be26efca431f448c1b3740f9 $js_lib/bootstrap.min.js
-
-# Get the CSS(map) files
-wget_verify $bootstrap_url/css/bootstrap-theme.min.css 8256575374f430476bdcd49de98c77990229ce31 $css_lib/bootstrap-theme.min.css
-wget_verify $bootstrap_url/css/bootstrap-theme.min.css.map 87f7dfd79d77051ac2eca7d093d961fbd1c8f6eb $css_lib/bootstrap-theme.min.css.map
-wget_verify $bootstrap_url/css/bootstrap.min.css 6527d8bf3e1e9368bab8c7b60f56bc01fa3afd68 $css_lib/bootstrap.min.css
-wget_verify $bootstrap_url/css/bootstrap.min.css.map e0d7b2bde55a0bac1b658a507e8ca491a6729e06 $css_lib/bootstrap.min.css.map
+# Get the CSS/Map files
+wget_verify $bootstrap_url/css/bootstrap-theme.min.css 8256575374f430476bdcd49de98c77990229ce31 $assets_dir/bootstrap-theme.min.css
+wget_verify $bootstrap_url/css/bootstrap-theme.min.css.map 87f7dfd79d77051ac2eca7d093d961fbd1c8f6eb $assets_dir/bootstrap-theme.min.css.map
+wget_verify $bootstrap_url/css/bootstrap.min.css 6527d8bf3e1e9368bab8c7b60f56bc01fa3afd68 $assets_dir/bootstrap.min.css
+wget_verify $bootstrap_url/css/bootstrap.min.css.map e0d7b2bde55a0bac1b658a507e8ca491a6729e06 $assets_dir/bootstrap.min.css.map
 
 
 # Link the management server daemon into a well known location.

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -63,37 +63,37 @@ fi
 
 
 # Download jQuery and Bootstrap local files
- if [ ! -d $HOME/mailinabox/management/static ]; then
+echo "Installing Mail-in-a-Box system management assets..."
 
-   js_lib=$HOME/mailinabox/management/static/assets/js/lib
-   css_lib=$HOME/mailinabox/management/static/assets/css/lib
+js_lib=$STORAGE_ROOT/www/default/assets/js/lib
+css_lib=$STORAGE_ROOT/www/default/assets/css/lib
 
-	 # jQuery CDN URL
-	 jquery_version=2.1.4
-   jquery_url=https://code.jquery.com
+# jQuery CDN URL
+jquery_version=2.1.4
+jquery_url=https://code.jquery.com
 
-   # Bootstrap CDN URL
-   bootstrap_version=3.3.7
-   bootstrap_url=https://maxcdn.bootstrapcdn.com/bootstrap/$bootstrap_version
+# Bootstrap CDN URL
+bootstrap_version=3.3.7
+bootstrap_url=https://maxcdn.bootstrapcdn.com/bootstrap/$bootstrap_version
 
-	# Get the Javascript files
-	if [ ! -d $js_lib ]; then
-		mkdir -p $js_lib
+# Get the Javascript files
+if [ ! -d $js_lib ]; then
+	mkdir -p $js_lib
 
-		wget_verify $jquery_url/jquery-$jquery_version.min.js 43dc554608df885a59ddeece1598c6ace434d747 $js_lib/jquery.min.js
-		wget_verify $bootstrap_url/js/bootstrap.min.js 430a443d74830fe9be26efca431f448c1b3740f9 $js_lib/bootstrap.min.js
-	fi
+	wget_verify $jquery_url/jquery-$jquery_version.min.js 43dc554608df885a59ddeece1598c6ace434d747 $js_lib/jquery.min.js
+	wget_verify $bootstrap_url/js/bootstrap.min.js 430a443d74830fe9be26efca431f448c1b3740f9 $js_lib/bootstrap.min.js
+fi
 
-	# Get the CSS(map) files
-	if [ ! -d $css_lib ]; then
-		mkdir -p $css_lib
+# Get the CSS(map) files
+if [ ! -d $css_lib ]; then
+	mkdir -p $css_lib
 
-		wget_verify $bootstrap_url/css/bootstrap-theme.min.css 8256575374f430476bdcd49de98c77990229ce31 $css_lib/bootstrap-theme.min.css
-		wget_verify $bootstrap_url/css/bootstrap-theme.min.css.map 87f7dfd79d77051ac2eca7d093d961fbd1c8f6eb $css_lib/bootstrap-theme.min.css.map
-		wget_verify $bootstrap_url/css/bootstrap.min.css 6527d8bf3e1e9368bab8c7b60f56bc01fa3afd68 $css_lib/bootstrap.min.css
-		wget_verify $bootstrap_url/css/bootstrap.min.css.map e0d7b2bde55a0bac1b658a507e8ca491a6729e06 $css_lib/bootstrap.min.css.map
-	fi
- fi
+	wget_verify $bootstrap_url/css/bootstrap-theme.min.css 8256575374f430476bdcd49de98c77990229ce31 $css_lib/bootstrap-theme.min.css
+	wget_verify $bootstrap_url/css/bootstrap-theme.min.css.map 87f7dfd79d77051ac2eca7d093d961fbd1c8f6eb $css_lib/bootstrap-theme.min.css.map
+	wget_verify $bootstrap_url/css/bootstrap.min.css 6527d8bf3e1e9368bab8c7b60f56bc01fa3afd68 $css_lib/bootstrap.min.css
+	wget_verify $bootstrap_url/css/bootstrap.min.css.map e0d7b2bde55a0bac1b658a507e8ca491a6729e06 $css_lib/bootstrap.min.css.map
+fi
+
 
 
 # Link the management server daemon into a well known location.

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -63,7 +63,7 @@ fi
 
 
 # Download jQuery and Bootstrap local files
-echo "Installing Mail-in-a-Box system management assets..."
+echo "Installing Mail-in-a-Box system management web assets..."
 
 js_lib=$STORAGE_ROOT/www/default/assets/js/lib
 css_lib=$STORAGE_ROOT/www/default/assets/css/lib


### PR DESCRIPTION
#1167 

Download the management web assets to the local box so we don't use a CDN for jQuery and Bootstrap files.

During setup the files are pulled from `code.jquery.com` and `maxcdn.bootstrapcdn.com` and stored in the `$STORAGE_ROOT/user-data/www/default` folder.

---
```
/home/user-data/www/default
├── assets
│   ├── css
│   │   └── lib
│   │       ├── bootstrap.min.css
│   │       ├── bootstrap.min.css.map
│   │       ├── bootstrap-theme.min.css
│   │       └── bootstrap-theme.min.css.map
│   └── js
│       └── lib
│           ├── bootstrap.min.js
│           └── jquery.min.js
└── index.html
```