### PR TITLE
Add changelog entry for custom dns CAA records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Control Panel/Management:
 * Fix an error in the control panel related to IPv6 addresses.
 * TLS certificates for internationalized domain names can now be provisioned from Let's Encrypt automatically.
 
+DNS:
+
+* Add support for custom CAA records.
 
 v0.22 (April 2, 2017)
 ---------------------


### PR DESCRIPTION
The CAA records didn't have a changelog entry yet.