### PR TITLE
Backup script should now stop php7.0-fpm instead of php5-fpm

### DIFF
--- a/management/backup.py
+++ b/management/backup.py
@@ -267,7 +267,7 @@ def perform_backup(full_backup):
 			if quit:
 				sys.exit(code)
 
-	service_command("php5-fpm", "stop", quit=True)
+	service_command("php7.0-fpm", "stop", quit=True)
 	service_command("postfix", "stop", quit=True)
 	service_command("dovecot", "stop", quit=True)
 
@@ -301,7 +301,7 @@ def perform_backup(full_backup):
 		# Start services again.
 		service_command("dovecot", "start", quit=False)
 		service_command("postfix", "start", quit=False)
-		service_command("php5-fpm", "start", quit=False)
+		service_command("php7.0-fpm", "start", quit=False)
 
 	# Once the migrated backup is included in a new backup, it can be deleted.
 	if os.path.isdir(migrated_unencrypted_backup_dir):


### PR DESCRIPTION
The backup code was still using php5-fpm. This changes that.