### PR TITLE
Secondary name server could not be set

### DIFF
--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -764,12 +764,12 @@ def set_custom_dns_record(qname, rtype, value, action, env):
 		if qname != "_secondary_nameserver":
 			raise ValueError("%s is not a domain name or a subdomain of a domain name managed by this box." % qname)
 
-	if not re.search(DOMAIN_RE, qname):
-		raise ValueError("Invalid name.")
-
 	# validate rtype
 	rtype = rtype.upper()
 	if value is not None and qname != "_secondary_nameserver":
+		if not re.search(DOMAIN_RE, qname):
+			raise ValueError("Invalid name.")
+
 		if rtype in ("A", "AAAA"):
 			if value != "local": # "local" is a special flag for us
 				v = ipaddress.ip_address(value) # raises a ValueError if there's a problem


### PR DESCRIPTION
This was broken in: https://github.com/mail-in-a-box/mailinabox/pull/1177

Reported by @xetorixik in https://github.com/mail-in-a-box/mailinabox/issues/1208

The checks for the NS records still work. I tested setting on primary, subdomain and invalid characters. 

Adding a secondary name server works again.