### PR TITLE
Switch PHP's default process manager

### DIFF
--- a/setup/web.sh
+++ b/setup/web.sh
@@ -50,7 +50,11 @@ tools/editconf.py /etc/php/7.0/fpm/php.ini -c ';' \
 # Set PHPs default charset to UTF-8, since we use it. See #367.
 tools/editconf.py /etc/php/7.0/fpm/php.ini -c ';' \
         default_charset="UTF-8"
-
+        
+# Switch from the dynamic process manager to the ondemand manager see #1215
+tools/editconf.py /etc/php/7.0/fpm/pool.d/www.conf -c ';' \
+	pm = ondemand
+    
 # Bump up PHP's max_children to support more concurrent connections
 tools/editconf.py /etc/php/7.0/fpm/pool.d/www.conf -c ';' \
 	pm.max_children=8

--- a/setup/web.sh
+++ b/setup/web.sh
@@ -51,7 +51,7 @@ tools/editconf.py /etc/php/7.0/fpm/php.ini -c ';' \
 tools/editconf.py /etc/php/7.0/fpm/php.ini -c ';' \
         default_charset="UTF-8"
         
-# Switch from the dynamic process manager to the ondemand manager see #1215
+# Switch from the dynamic process manager to the ondemand manager see #1216
 tools/editconf.py /etc/php/7.0/fpm/pool.d/www.conf -c ';' \
 	pm = ondemand
     


### PR DESCRIPTION
Changing from dynamic to ondemand lowers the number of idle PHP processes from the default of 3 to 1. PHP automatically scales up the number of processes when required, but kills them after 10 seconds (default). I've seen PHP's memory consumption drop significantly. This should be very helpful for low-end VPS servers. Tested for a couple of months on a VPS with 1 GB and 1 CPU with 5 users. No noticeable negative loading times, but about 15% less RAM usage.

Based on this article: https://ma.ttias.be/a-better-way-to-run-php-fpm/