### PR TITLE
Do not install the openssl version from the php7 PPA

### DIFF
--- a/setup/system.sh
+++ b/setup/system.sh
@@ -127,6 +127,21 @@ apt_install python3 python3-dev python3-pip \
 
 hide_output add-apt-repository -y ppa:ondrej/php
 apt_add_repository_to_unattended_upgrades LP-PPA-ondrej-php:trusty
+
+# The PHP7 PPA has an updated openssl package that breaks our setup. It has some extra patches.
+# For instance it completely disables SSLv3. Which isn't bad, but not thoroughly tested with our setup.
+# So we will instruct apt to ignore the package.
+#
+# Pin priorities are explained here: https://www.debian.org/doc/manuals/apt-howto/ch-apt-get.en.html#s-pin
+#
+# We lower the priority of the PPA so apt will prefer the packages from Ubuntu
+cat > /etc/apt/preferences.d/openssl <<EOF;
+Package: *
+Pin: release o=lp-ppa-ondrej-php
+Pin-Priority: 400
+EOF
+
+# Update apt to get the PPA
 hide_output apt-get update
 
 


### PR DESCRIPTION
This is a fix for: https://github.com/mail-in-a-box/mailinabox/issues/1213

Setup was broken on new systems due to a new version of openssl installed via the php7 ppa. This was a newer version with additional patches applied that broke our initial CSR generation during setup/ssl.sh. We could work around the CSR problem by filling in the now required fields with dummy values, however there might be other side effects we haven't discovered yet.

The reason the PPA has it's own openssl is as far as I can see from the changelog to disable certain cypher suites we don't use anymore (SSLv2 and 3) and update to version 1.1 in favour of 1.0.

This PR will pin the openssl package to the one supplied by Ubuntu and downgrade it if it was upgraded by accident. 

This was tested on a completely new machine (last time I restored a backup first which prevented the issue from occurring). I also ran setup on a machine with the ppa version installed and that was downgraded.

apt-get needed a --force-yes to force the downgrade of the package automatically.

This should result in a system which doesn't install the openssl ppa version, but does get the updates from trusty/security. The latter I haven't seen yet since there were no updates. However running the policy command shows this:

```
apt-cache policy openssl
openssl:
  Installed: 1.0.1f-1ubuntu2.22
  Candidate: 1.0.1f-1ubuntu2.22
  Package pin: 1.0.1f-1ubuntu2.22
  Version table:
     1.1.0f-2~ubuntu14.04.1+deb.sury.org+1 1001
        500 http://ppa.launchpad.net/ondrej/php/ubuntu/ trusty/main amd64 Packages
 *** 1.0.1f-1ubuntu2.22 1001
        500 http://archive.ubuntu.com/ubuntu/ trusty-updates/main amd64 Packages
        500 http://archive.ubuntu.com/ubuntu/ trusty-security/main amd64 Packages
        100 /var/lib/dpkg/status
     1.0.1f-1ubuntu2 1001
        500 http://archive.ubuntu.com/ubuntu/ trusty/main amd64 Packages
```