### PR TITLE
Set static csr fields during initial setup

### DIFF
--- a/setup/ssl.sh
+++ b/setup/ssl.sh
@@ -74,7 +74,7 @@ if [ ! -f $STORAGE_ROOT/ssl/ssl_certificate.pem ]; then
 	CSR=/tmp/ssl_cert_sign_req-$$.csr
 	hide_output \
 	openssl req -new -key $STORAGE_ROOT/ssl/ssl_private_key.pem -out $CSR \
-	  -sha256 -subj "/C=/ST=/L=/O=/CN=$PRIMARY_HOSTNAME"
+	  -sha256 -subj "/CN=$PRIMARY_HOSTNAME"
 
 	# Generate the self-signed certificate.
 	CERT=$STORAGE_ROOT/ssl/$PRIMARY_HOSTNAME-selfsigned-$(date --rfc-3339=date | sed s/-//g).pem


### PR DESCRIPTION
Second attempt at: https://github.com/mail-in-a-box/mailinabox/issues/1213

See discussion here: https://github.com/mail-in-a-box/mailinabox/pull/1221

This keeps the openssl version in the PPA and works around the differences in creating a CSR. It's only briefly used, after we get let's encrypt certs it isn't needed anymore.

This is tested on a fresh box. The box installs and is accessible with the self signed cert (the test machine doesn't have valid dns setup). All of this still works on an existing setup (tested, but code is unreachable in that situation)

I think out of all the options this is the cleanest, but i'm always open to suggestions of course. 