### PR TITLE
turn off verbose

### DIFF
--- a/setup/system.sh
+++ b/setup/system.sh
@@ -241,7 +241,7 @@ cat > /etc/apt/apt.conf.d/02periodic <<EOF;
 APT::Periodic::MaxAge "7";
 APT::Periodic::Update-Package-Lists "1";
 APT::Periodic::Unattended-Upgrade "1";
-APT::Periodic::Verbose "1";
+APT::Periodic::Verbose "0";
 EOF
 
 # ### Firewall


### PR DESCRIPTION
I created an alias for root@$hostname on my box and started getting these emails daily:

```
Subject: Cron <root@box> test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.daily )

/etc/cron.daily/apt:
verbose level 1
power status (255) undetermined, continuing
system is on main power.
sleeping for 1412 seconds
power status (255) undetermined, continuing
system is on main power.
check_stamp: interval=86400, now=1507244400, stamp=1507158000, delta=86400 (sec)
apt-key net-update (failure)
download updated metadata (success).
send dbus signal (success)
check_stamp: interval=0
download upgradable (not run)
check_stamp: interval=86400, now=1507244400, stamp=1507158000, delta=86400 (sec)
unattended-upgrade (success)
check_stamp: interval=0
autoclean (not run)
aged: ctime <7 and mtime <7 and ctime>2 and mtime>2
end remove by archive size: size=21220 < 512000

```

Turning off verbose in the apt periodic configuration resolves this.
