### PR TITLE
Add php7.0-mbstring to webmail.sh

### DIFF
--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -24,7 +24,7 @@ apt_install \
 	dbconfig-common \
 	php7.0-cli php7.0-sqlite php7.0-mcrypt php7.0-intl php7.0-json php7.0-common \
 	php-auth php-net-smtp php-net-socket php-net-sieve php-mail-mime php-crypt-gpg \
-	php7.0-gd php7.0-pspell tinymce libjs-jquery libjs-jquery-mousewheel libmagic1
+	php7.0-gd php7.0-pspell tinymce libjs-jquery libjs-jquery-mousewheel libmagic1 php7.0-mbstring
 
 apt_get_quiet remove php-mail-mimedecode # no longer needed since Roundcube 1.1.3
 


### PR DESCRIPTION
For https://github.com/mail-in-a-box/mailinabox/issues/1259

I haven't been able to reproduce the issue because of time constraints. I have tested the webmail setup and it works fine. 