### PR TITLE
B2 Storage Backup Integration

### DIFF
--- a/management/backup.py
+++ b/management/backup.py
@@ -473,10 +473,18 @@ def list_target_files(config):
 			raise ValueError(e.reason)
 
 		return [(key.name[len(path):], key.size) for key in bucket.list(prefix=path)]
-
+	elif target.scheme == "b2":
 	else:
 		raise ValueError(config["target"])
 
+def b2_perform_authentication(acc_id, app_key):
+	# Perform Authentication with B2 Storage. Returns a tuple
+	# containing the auth token and the API endpoint to use.
+	from urllib.request import Request, urlopen
+	import base64
+	import json
+
+	req = Request()
 
 def backup_set_custom(env, target, target_user, target_pass, min_age):
 	config = get_backup_config(env, for_save=True)

--- a/management/templates/system-backup.html
+++ b/management/templates/system-backup.html
@@ -121,13 +121,13 @@
   <div class="form-group backup-target-b2">
     <label for="backup-target-user" class="col-sm-2 control-label">B2 Account Id</label>
     <div class="col-sm-8">
-      <input type="text" class="form-control" rows="1" id="backup-target-user">
+      <input type="text" class="form-control" rows="1" id="backup-target-b2-user">
     </div>
   </div>
   <div class="form-group backup-target-b2">
     <label for="backup-target-pass" class="col-sm-2 control-label">B2 Application Key</label>
     <div class="col-sm-8">
-      <input type="text" class="form-control" rows="1" id="backup-target-pass">
+      <input type="text" class="form-control" rows="1" id="backup-target-b2-pass">
     </div>
   </div>
   <!-- Common -->
@@ -163,7 +163,7 @@
 
 function toggle_form() {
   var target_type = $("#backup-target-type").val();
-  $(".backup-target-local, .backup-target-rsync, .backup-target-s3").hide();
+  $(".backup-target-local, .backup-target-rsync, .backup-target-s3, .backup-target-b2").hide();
   $(".backup-target-" + target_type).show();
 }
 
@@ -264,7 +264,9 @@ function show_custom_backup() {
         } else if (r.target.substring(0, 5) == "b2://") {
           $("#backup-target-type").val("b2");
           var hostpath = r.target.substring(5).split('@');
-          var host = hostpath.shift();
+          var usernamepass = hostpath.shift().split(":");
+          $("#backup-target-rsync-b2-user").val(usernamepass[0]);
+          $("#backup-target-rsync-b2-user").val(usernamepass[1]);
           $("#backup-target-b2-path").val(hostpath.join('/'));
         }
         toggle_form()
@@ -283,7 +285,7 @@ function set_custom_backup() {
     target = "s3://" + $("#backup-target-s3-host").val() + "/" + $("#backup-target-s3-path").val();
   else if (target_type == "b2")
     target = "b2://" + $("#backup-target-b2-user").val() + ":" 
-      + $("#backup-target-b2-pass").val() + "@" + $("#backup-target-b2-path");
+      + $("#backup-target-b2-pass").val() + "@" + $("#backup-target-b2-path").val();
   else if (target_type == "rsync") {
     target = "rsync://" + $("#backup-target-rsync-user").val() + "@" + $("#backup-target-rsync-host").val()
                                                                 + "/" + $("#backup-target-rsync-path").val();

--- a/management/templates/system-backup.html
+++ b/management/templates/system-backup.html
@@ -18,7 +18,7 @@
         <option value="local">{{hostname}}</option>
         <option value="rsync">rsync</option>
         <option value="s3">Amazon S3</option>
-        <option value="b2">B2Blaze</option>
+        <option value="b2">B2 Storage</option>
       </select>
     </div>
   </div>
@@ -105,11 +105,11 @@
       <input type="text" class="form-control" rows="1" id="backup-target-pass">
     </div>
   </div>
-  <!-- B2Blaze BACKUP -->
+  <!-- B2 Storage BACKUP -->
   <div class="form-group backup-target-b2">
     <div class="col-sm-10 col-sm-offset-2">
-      <p>Backups are stored in an B2Blaze bucket. You must have an B2Blaze account already.</p>
-      <p>You MUST manually copy the encryption password from <tt class="backup-encpassword-file"></tt> to a safe and secure location. You will need this file to decrypt backup files. It is NOT stored in your B2Blaze bucket.</p>
+      <p>Backups are stored in an B2 Storage bucket. You must have an B2 Storage account already.</p>
+      <p>You MUST manually copy the encryption password from <tt class="backup-encpassword-file"></tt> to a safe and secure location. You will need this file to decrypt backup files. It is NOT stored in your B2 Storage bucket.</p>
     </div>
   </div>
   <div class="form-group backup-target-b2">

--- a/management/templates/system-backup.html
+++ b/management/templates/system-backup.html
@@ -109,7 +109,7 @@
   <div class="form-group backup-target-b2">
     <div class="col-sm-10 col-sm-offset-2">
       <p>Backups are stored in an B2Blaze bucket. You must have an B2Blaze account already.</p>
-      <p>You MUST manually copy the encryption password from <tt class="backup-encpassword-file"></tt> to a safe and secure location. You will need this file to decrypt backup files. It is NOT stored in your Amazon S3 bucket.</p>
+      <p>You MUST manually copy the encryption password from <tt class="backup-encpassword-file"></tt> to a safe and secure location. You will need this file to decrypt backup files. It is NOT stored in your B2Blaze bucket.</p>
     </div>
   </div>
   <div class="form-group backup-target-b2">
@@ -131,7 +131,7 @@
     </div>
   </div>
   <!-- Common -->
-  <div class="form-group backup-target-local backup-target-rsync backup-target-s3">
+  <div class="form-group backup-target-local backup-target-rsync backup-target-s3 backup-target-b2">
     <label for="min-age" class="col-sm-2 control-label">Days:</label>
     <div class="col-sm-8">
       <input type="number" class="form-control" rows="1" id="min-age">
@@ -281,6 +281,9 @@ function set_custom_backup() {
     target = target_type;
   else if (target_type == "s3")
     target = "s3://" + $("#backup-target-s3-host").val() + "/" + $("#backup-target-s3-path").val();
+  else if (target_type == "b2")
+    target = "b2://" + $("#backup-target-b2-user").val() + ":" 
+      + $("#backup-target-b2-pass").val() + "@" + $("#backup-target-b2-path");
   else if (target_type == "rsync") {
     target = "rsync://" + $("#backup-target-rsync-user").val() + "@" + $("#backup-target-rsync-host").val()
                                                                 + "/" + $("#backup-target-rsync-path").val();

--- a/management/templates/system-backup.html
+++ b/management/templates/system-backup.html
@@ -18,6 +18,7 @@
         <option value="local">{{hostname}}</option>
         <option value="rsync">rsync</option>
         <option value="s3">Amazon S3</option>
+        <option value="b2">B2Blaze</option>
       </select>
     </div>
   </div>
@@ -100,6 +101,31 @@
   </div>
   <div class="form-group backup-target-s3">
     <label for="backup-target-pass" class="col-sm-2 control-label">S3 Secret Access Key</label>
+    <div class="col-sm-8">
+      <input type="text" class="form-control" rows="1" id="backup-target-pass">
+    </div>
+  </div>
+  <!-- B2Blaze BACKUP -->
+  <div class="form-group backup-target-b2">
+    <div class="col-sm-10 col-sm-offset-2">
+      <p>Backups are stored in an B2Blaze bucket. You must have an B2Blaze account already.</p>
+      <p>You MUST manually copy the encryption password from <tt class="backup-encpassword-file"></tt> to a safe and secure location. You will need this file to decrypt backup files. It is NOT stored in your Amazon S3 bucket.</p>
+    </div>
+  </div>
+  <div class="form-group backup-target-b2">
+    <label for="backup-target-b2-path" class="col-sm-2 control-label">B2 Path</label>
+    <div class="col-sm-8">
+      <input type="text" placeholder="your-bucket-name/backup-directory" class="form-control" rows="1" id="backup-target-b2-path">
+    </div>
+  </div>
+  <div class="form-group backup-target-b2">
+    <label for="backup-target-user" class="col-sm-2 control-label">B2 Account Id</label>
+    <div class="col-sm-8">
+      <input type="text" class="form-control" rows="1" id="backup-target-user">
+    </div>
+  </div>
+  <div class="form-group backup-target-b2">
+    <label for="backup-target-pass" class="col-sm-2 control-label">B2 Application Key</label>
     <div class="col-sm-8">
       <input type="text" class="form-control" rows="1" id="backup-target-pass">
     </div>
@@ -235,6 +261,11 @@ function show_custom_backup() {
           var host = hostpath.shift();
           $("#backup-target-s3-host").val(host);
           $("#backup-target-s3-path").val(hostpath.join('/'));
+        } else if (r.target.substring(0, 5) == "b2://") {
+          $("#backup-target-type").val("b2");
+          var hostpath = r.target.substring(5).split('@');
+          var host = hostpath.shift();
+          $("#backup-target-b2-path").val(hostpath.join('/'));
         }
         toggle_form()
       })

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -129,6 +129,16 @@ hide_output add-apt-repository -y ppa:ondrej/php
 apt_add_repository_to_unattended_upgrades LP-PPA-ondrej-php:trusty
 hide_output apt-get update
 
+# ### Add duplicity PPA
+
+# We would use the package in the system repository, but the version in the system repo
+# does not support some backends like B2Blaze. This adds the stable PPA that should be
+# reasonably reliable. This also enables the ability for duplicity to be upgraded to the 
+# latest version. Since the relibility of this package affects the stabillity of system
+# backups, unintended upgrades are not enabled.
+
+hide_output add-apt-repository -y ppa:duplicity-team/ppa
+hide_output apt-get update
 
 # ### Suppress Upgrade Prompts
 # Since Mail-in-a-Box might jump straight to 18.04 LTS, there's no need

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -132,7 +132,7 @@ hide_output apt-get update
 # ### Add duplicity PPA
 
 # We would use the package in the system repository, but the version in the system repo
-# does not support some backends like B2Blaze. This adds the stable PPA that should be
+# does not support some backends like B2 Storage. This adds the stable PPA that should be
 # reasonably reliable. This also enables the ability for duplicity to be upgraded to the 
 # latest version. Since the relibility of this package affects the stabillity of system
 # backups, unintended upgrades are not enabled.


### PR DESCRIPTION
Adds support for B2 Storage from Backblaze as a backup target. This would be extremely nice to have as it is much cheaper than something like S3 (first 10GB free), and easier to use. The necessary edits to the control panel and backup.py were made. I also needed to add the duplicity official PPA in order to get a version supporting B2 Storage.

