### PR TITLE
Bugfix for free command

### DIFF
--- a/setup/mail-dovecot.sh
+++ b/setup/mail-dovecot.sh
@@ -46,7 +46,7 @@ apt_install \
 # - https://www.dovecot.org/list/dovecot/2011-December/132455.html
 tools/editconf.py /etc/dovecot/conf.d/10-master.conf \
 	default_process_limit=$(echo "`nproc` * 250" | bc) \
-	default_vsz_limit=$(echo "`free -tom  | tail -1 | awk '{print $2}'` / 3" | bc)M \
+	default_vsz_limit=$(echo "`free -tm  | tail -1 | awk '{print $2}'` / 3" | bc)M \
 	log_path=/var/log/mail.log
 
 # The inotify `max_user_instances` default is 128, which constrains


### PR DESCRIPTION
The command was failing is there's no `o` argument for free