### PR TITLE
Changed temp_dir to /var/temp/roundcube to avoid loss on reboot.

### DIFF
--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -106,7 +106,7 @@ cat > $RCM_CONFIG <<EOF;
  */
 \$config = array();
 \$config['log_dir'] = '/var/log/roundcubemail/';
-\$config['temp_dir'] = '/tmp/roundcubemail/';
+\$config['temp_dir'] = '/var/tmp/roundcubemail/';
 \$config['db_dsnw'] = 'sqlite:///$STORAGE_ROOT/mail/roundcube/roundcube.sqlite?mode=0640';
 \$config['default_host'] = 'ssl://localhost';
 \$config['default_port'] = 993;
@@ -159,8 +159,8 @@ cat > ${RCM_PLUGIN_DIR}/carddav/config.inc.php <<EOF;
 EOF
 
 # Create writable directories.
-mkdir -p /var/log/roundcubemail /tmp/roundcubemail $STORAGE_ROOT/mail/roundcube
-chown -R www-data.www-data /var/log/roundcubemail /tmp/roundcubemail $STORAGE_ROOT/mail/roundcube
+mkdir -p /var/log/roundcubemail /var/tmp/roundcubemail $STORAGE_ROOT/mail/roundcube
+chown -R www-data.www-data /var/log/roundcubemail /var/tmp/roundcubemail $STORAGE_ROOT/mail/roundcube
 
 # Ensure the log file monitored by fail2ban exists, or else fail2ban can't start.
 sudo -u www-data touch /var/log/roundcubemail/errors


### PR DESCRIPTION
#1290 this should fix the issue and follows FSH v3. 
Should the "temp_dir_ttl" in defaults be changed to keep attachments to drafts around longer?  