### PR TITLE
Fix CSR generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 CHANGELOG
 =========
 
+* Fix CSR generation bug by updating the `-subj` value passed to `openssl`, and changing the input order.
+
 v0.26b (January 25, 2018)
 -------------------------
 

--- a/management/ssl_certificates.py
+++ b/management/ssl_certificates.py
@@ -556,7 +556,7 @@ def create_csr(domain, ssl_key, country_code, env):
                 "openssl", "req", "-new",
                 "-key", ssl_key,
                 "-sha256",
-                "-subj", "/C=%s/ST=/L=/O=/CN=%s" % (country_code, domain)])
+                "-subj", "/C=%s/CN=%s" % (country_code, domain)])
 
 def install_cert(domain, ssl_cert, ssl_chain, env, raw=False):
 	# Write the combined cert+chain to a temporary path and validate that it is OK.

--- a/management/templates/ssl.html
+++ b/management/templates/ssl.html
@@ -57,12 +57,6 @@
 
 <p>If you don't want to use our automatic Let's Encrypt integration, you can give any other certificate provider a try. You can generate the needed CSR below.</p>
 
-<p>Which domain are you getting a certificate for?</p>
-
-<p><select id="ssldomain" onchange="show_csr()" class="form-control" style="width: auto"></select></p>
-
-<p>(A multi-domain or wildcard certificate will be automatically applied to any domains it is valid for besides the one you choose above.)</p>
-
 <p>What country are you in? This is required by some TLS certificate providers. You may leave this blank if you know your TLS certificate provider doesn't require it.</p>
 
 <p><select id="sslcc" onchange="show_csr()" class="form-control" style="width: auto">
@@ -71,6 +65,12 @@
 		<option value="{{code}}">{{name}}</option>
 	{% endfor %}
 </select></p>
+
+<p>Which domain are you getting a certificate for?</p>
+
+<p><select id="ssldomain" onchange="show_csr()" class="form-control" style="width: auto"></select></p>
+
+<p>(A multi-domain or wildcard certificate will be automatically applied to any domains it is valid for besides the one you choose above.)</p>
 
 <div id="csr_info" style="display: none">
   <p>You will need to provide the certificate provider this Certificate Signing Request (CSR):</p>


### PR DESCRIPTION
This fixes the CSR generation bug described at https://discourse.mailinabox.email/t/generate-csr-for-an-other-certificate-provider/2555/3.

@JoshData was correct that "The -subj option ... needs to be revised to be `"/C=%s/CN=%s"`".

However, even after that change, I continued receiving the "Something went wrong, sorry" error.  Swapping the order of the country and domain inputs, to put country first, solved that problem for some reason.