### PR TITLE
Discrepancy in password length statement and accepted length

### DIFF
--- a/management/templates/users.html
+++ b/management/templates/users.html
@@ -213,7 +213,7 @@ function users_set_password(elem) {
 
   show_modal_confirm(
     "Set Password",
-    $("<p>Set a new password for <b>" + email + "</b>?</p> <p><label for='users_set_password_pw' style='display: block; font-weight: normal'>New Password:</label><input type='password' id='users_set_password_pw'></p><p><small>Passwords must be at least four characters and may not contain spaces.</small>" + yourpw + "</p>"),
+    $("<p>Set a new password for <b>" + email + "</b>?</p> <p><label for='users_set_password_pw' style='display: block; font-weight: normal'>New Password:</label><input type='password' id='users_set_password_pw'></p><p><small>Passwords must be at least eight characters and may not contain spaces.</small>" + yourpw + "</p>"),
     "Set Password",
     function() {
       api(


### PR DESCRIPTION
Minor edit to displayed text on user page. Passwords must be at least eight characters long; when passwords are changed via the users page it states that passwords need to be at least four characters but only eight or more characters are acceptable.