### PR TITLE
Yeti Theme

### DIFF
--- a/management/templates/index.html
+++ b/management/templates/index.html
@@ -10,6 +10,7 @@
         <meta name="robots" content="noindex, nofollow">
 
         <link rel="stylesheet" href="/admin/assets/bootstrap/css/bootstrap.min.css">
+		<link rel="stylesheet" href="https://raw.githubusercontent.com/mitchellurgero/miab-theme-yeti/master/yeti.css">
         <style>
 	    body {
 		overflow-y: scroll;


### PR DESCRIPTION
Added yeti theme from #bootswatch. (MIT License)

- Loads the CSS remotely in the event internet access is not possible the old theme can still load.

changes are subtle, but have lots of potential, I also want to change the inverse navbar to the default colors, but that can be a separate PR I guess.

@JoshData  What do you think? Just adds one line to the index.html template file, very simple.
The themes are from https://bootswatch.com/3/ (Maybe if you wanted to pick one, personally I like `United` however I felt `Yeti` looked better for general users.)

Screenshot:

![yeti-miab](https://user-images.githubusercontent.com/4168998/36680657-029244a0-1adc-11e8-88d5-24d674a4fdf3.png)
