### PR TITLE
Update Roundcube to 1.3.6

### DIFF
--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -35,8 +35,8 @@ apt-get purge -qq -y roundcube* #NODOC
 # Install Roundcube from source if it is not already present or if it is out of date.
 # Combine the Roundcube version number with the commit hash of plugins to track
 # whether we have the latest version of everything.
-VERSION=1.3.4
-HASH=8ed21cf96b5196e66ac4adaf85807bc1b043020a
+VERSION=1.3.6
+HASH=ece5cfc9c7af0cbe90c0065ef33e85ed42991830
 PERSISTENT_LOGIN_VERSION=dc5ca3d3f4415cc41edb2fde533c8a8628a94c76
 HTML5_NOTIFIER_VERSION=4b370e3cd60dabd2f428a26f45b677ad1b7118d5
 CARDDAV_VERSION=2.0.4


### PR DESCRIPTION
1.3.6 is a security update, see https://github.com/roundcube/roundcubemail/releases/tag/1.3.6