### PR TITLE
replace free_tls_certificates with certbot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@ CHANGELOG
 In Development
 --------------
 
+Mail:
+
 * A report of box activity, including sent/received mail totals and logins by user, is now emailed to the box's administrator user each week.
 * Update Roundcube to version 1.3.6 and Z-Push to version 2.3.9.
+
+Control Panel:
+
+* We now use EFF's `certbot` tool to provision HTTPS certificates instead of our home-grown free_tls_certificates package.
 * The undocumented feature for proxying web requests to another server now sets X-Forwarded-For.
 
 v0.26c (February 13, 2018)

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -25,7 +25,7 @@ server {
 		# This path must be served over HTTP for ACME domain validation.
 		# We map this to a special path where our TLS cert provisioning
 		# tool knows to store challenge response files.
-		alias $STORAGE_ROOT/ssl/lets_encrypt/acme_challenges/;
+		alias $STORAGE_ROOT/ssl/lets_encrypt/webroot/.well-known/acme-challenge/;
 	}
 }
 

--- a/management/daily_tasks.sh
+++ b/management/daily_tasks.sh
@@ -19,7 +19,7 @@ fi
 management/backup.py | management/email_administrator.py "Backup Status"
 
 # Provision any new certificates for new domains or domains with expiring certificates.
-management/ssl_certificates.py -q --headless | management/email_administrator.py "Error Provisioning TLS Certificate"
+management/ssl_certificates.py -q | management/email_administrator.py "Error Provisioning TLS Certificate"
 
 # Run status checks and email the administrator if anything changed.
 management/status_checks.py --show-changes | management/email_administrator.py "Status Checks Change Notice"

--- a/management/templates/ssl.html
+++ b/management/templates/ssl.html
@@ -8,7 +8,7 @@
 <p>You need a TLS certificate for this box&rsquo;s hostname ({{hostname}}) and every other domain name and subdomain that this box is hosting a website for (see the list below).</p>
 
 <div id="ssl_provision">
-<h3>Provision a certificate</h3>
+<h3>Provision certificates</h3>
 
 <div id="ssl_provision_p" style="display: none; margin-top: 1.5em">
   <button onclick='return provision_tls_cert();' class='btn btn-primary' style="float: left; margin: 0 1.5em 1em 0;">Provision</button>
@@ -19,21 +19,6 @@
 <div class="clearfix"> </div>
 
 <div id="ssl_provision_result"></div>
-
-<div id="ssl_provision_problems_div" style="display: none;">
-<p style="margin-bottom: .5em;">Certificates cannot be automatically provisioned for:</p>
-<table id="ssl_provision_problems" style="margin-top: 0;" class="table">
-  <thead>
-    <tr>
-      <th>Domain</th>
-      <th>Problem</th>
-    </tr>
-  </thead>
-  <tbody>
-  </tbody>
-</table>
-<p>Use the <em>Install Certificate</em> button below for these domains.</p>
-</div>
 </div>
 
 <h3>Certificate status</h3>
@@ -103,23 +88,11 @@ function show_tls(keep_provisioning_shown) {
       // provisioning status
 
       if (!keep_provisioning_shown)
-        $('#ssl_provision').toggle(res.can_provision.length + res.cant_provision.length > 0)
+        $('#ssl_provision').toggle(res.can_provision.length > 0)
 
       $('#ssl_provision_p').toggle(res.can_provision.length > 0);
       if (res.can_provision.length > 0)
           $('#ssl_provision_p span').text(res.can_provision.join(", "));
-
-      $('#ssl_provision_problems_div').toggle(res.cant_provision.length > 0);
-      $('#ssl_provision_problems tbody').text("");
-      for (var i = 0; i < res.cant_provision.length; i++) {
-        var domain = res.cant_provision[i];
-        var row = $("<tr><th class='domain'><a href=''></a></th><td class='status'></td></tr>");
-        $('#ssl_provision_problems tbody').append(row);
-        row.attr('data-domain', domain.domain);
-        row.find('.domain a').text(domain.domain);
-        row.find('.domain a').attr('href', 'https://' + domain.domain);
-        row.find('.status').text(domain.problem);
-      }
 
       // certificate status
       var domains = res.status;
@@ -196,20 +169,15 @@ function install_cert() {
     });
 }
 
-var agree_to_tos_url_prompt = null;
-var agree_to_tos_url = null;
 function provision_tls_cert() {
   // Automatically provision any certs.
   $('#ssl_provision_p .btn').attr('disabled', '1'); // prevent double-clicks
   api(
     "/ssl/provision",
     "POST",
-    {
-      agree_to_tos_url: agree_to_tos_url
-    },
+    { },
     function(status) {
       // Clear last attempt.
-      agree_to_tos_url = null;
       $('#ssl_provision_result').text("");
       may_reenable_provision_button = true;
 
@@ -225,52 +193,33 @@ function provision_tls_cert() {
       for (var i = 0; i < status.requests.length; i++) {
         var r = status.requests[i];
 
+        if (r.result == "skipped") {
+          // not interested --- this domain wasn't in the table
+          // to begin with
+          continue;
+        }
+
         // create an HTML block to display the results of this request
         var n = $("<div><h4/><p/></div>");
         $('#ssl_provision_result').append(n);
+
+        // plain log line
+        if (typeof r === "string") {
+          n.find("p").text(r);
+          continue;
+        }
 
         // show a header only to disambiguate request blocks
         if (status.requests.length > 0)
           n.find("h4").text(r.domains.join(", "));
 
-        if (r.result == "agree-to-tos") {
-          // user needs to agree to Let's Encrypt's TOS
-          agree_to_tos_url_prompt = r.url;
-          $('#ssl_provision_p .btn').attr('disabled', '1');
-          n.find("p").html("Please open and review <a href='" + r.url + "' target='_blank'>Let's Encrypt's terms of service agreement</a>. You must agree to their terms for a certificate to be automatically provisioned from them.");
-          n.append($('<button onclick="agree_to_tos_url = agree_to_tos_url_prompt; return provision_tls_cert();" class="btn btn-success" style="margin-left: 2em">Agree &amp; Try Again</button>'));
-
-          // don't re-enable the Provision button -- user must use the Agree button
-          may_reenable_provision_button = false;
-
-        } else if (r.result == "error") {
+        if (r.result == "error") {
           n.find("p").addClass("text-danger").text(r.message);
-
-        } else if (r.result == "wait") {
-          // Show a button that counts down to zero, at which point it becomes enabled.
-          n.find("p").text("A certificate is now in the process of being provisioned, but it takes some time. Please wait until the Finish button is enabled, and then click it to acquire the certificate.");
-          var b = $('<button onclick="return provision_tls_cert();" class="btn btn-success" style="margin-left: 2em">Finish</button>');
-          b.attr("disabled", "1");
-          var now = new Date();
-          n.append(b);
-          function ready_to_finish() {
-            var remaining = Math.round(r.seconds - (new Date() - now)/1000);
-            if (remaining > 0) {
-              setTimeout(ready_to_finish, 1000);
-              b.text("Finish (" + remaining + "...)")
-            } else {
-              b.text("Finish (ready)")
-              b.removeAttr("disabled");
-            }
-          }
-          ready_to_finish();
-
-          // don't re-enable the Provision button -- user must use the Retry button when it becomes enabled
-          may_reenable_provision_button = false;
 
         } else if (r.result == "installed") {
           n.find("p").addClass("text-success").text("The TLS certificate was provisioned and installed.");
           setTimeout("show_tls(true)", 1); // update main table of certificate statuses, call with arg keep_provisioning_shown true so that we don't clear what we just outputted
+
         }
 
         // display the detailed log info in case of problems
@@ -278,7 +227,6 @@ function provision_tls_cert() {
         n.append(trace);
         for (var j = 0; j < r.log.length; j++)
           trace.append($("<div/>").text(r.log[j]));
-
       }
 
       if (may_reenable_provision_button)

--- a/management/web_update.py
+++ b/management/web_update.py
@@ -201,8 +201,11 @@ def get_web_domains_info(env):
 
 	# for the SSL config panel, get cert status
 	def check_cert(domain):
-		tls_cert = get_domain_ssl_files(domain, ssl_certificates, env, allow_missing_cert=True)
-		if tls_cert is None: return ("danger", "No Certificate Installed")
+		try:
+			tls_cert = get_domain_ssl_files(domain, ssl_certificates, env, allow_missing_cert=True)
+		except OSError: # PRIMARY_HOSTNAME cert is missing
+			tls_cert = None
+		if tls_cert is None: return ("danger", "No certificate installed.")
 		cert_status, cert_status_details = check_certificate(domain, tls_cert["certificate"], tls_cert["private-key"])
 		if cert_status == "OK":
 			return ("success", "Signed & valid. " + cert_status_details)

--- a/setup/migrate.py
+++ b/setup/migrate.py
@@ -137,6 +137,17 @@ def migration_10(env):
 				shutil.move(sslcert, newname)
 				os.rmdir(d)
 
+def migration_11(env):
+	# Archive the old Let's Encrypt account directory managed by free_tls_certificates
+	# because we'll use that path now for the directory managed by certbot.
+	try:
+		old_path = os.path.join(env["STORAGE_ROOT"], 'ssl', 'lets_encrypt')
+		new_path = os.path.join(env["STORAGE_ROOT"], 'ssl', 'lets_encrypt-old')
+		shutil.move(old_path, new_path)
+	except:
+		# meh
+		pass
+
 def get_current_migration():
 	ver = 0
 	while True:

--- a/setup/start.sh
+++ b/setup/start.sh
@@ -127,12 +127,20 @@ tools/web_update
 # fail2ban was first configured, but they should exist now.
 restart_service fail2ban
 
-# If DNS is already working, try to provision TLS certficates from Let's Encrypt.
-# Suppress extra reasons why domains aren't getting a new certificate.
-management/ssl_certificates.py -q
-
 # If there aren't any mail users yet, create one.
 source setup/firstuser.sh
+
+# Register with Let's Encrypt, including agreeing to the Terms of Service. This
+# is an interactive command.
+if [ ! -d $STORAGE_ROOT/ssl/lets_encrypt/accounts/acme-v01.api.letsencrypt.org/ ]; then
+echo
+echo "-----------------------------------------------"
+echo "Mail-in-a-Box uses Let's Encrypt to provision free certificates"
+echo "to enable HTTPS connections to your box. You'll now be asked to agree"
+echo "to Let's Encrypt's terms of service."
+echo
+certbot register --register-unsafely-without-email --config-dir $STORAGE_ROOT/ssl/lets_encrypt
+fi
 
 # Done.
 echo

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -68,17 +68,10 @@ then
 	fi
 fi
 
-# ### Add Mail-in-a-Box's PPA.
+# ### Add PPAs.
 
-# We've built several .deb packages on our own that we want to include.
-# One is a replacement for Ubuntu's stock postgrey package that makes
-# some enhancements. The other is dovecot-lucene, a Lucene-based full
-# text search plugin for (and by) dovecot, which is not available in
-# Ubuntu currently.
-#
-# So, first ensure add-apt-repository is installed, then use it to install
-# the [mail-in-a-box ppa](https://launchpad.net/~mail-in-a-box/+archive/ubuntu/ppa).
-
+# We install some non-standard Ubuntu packages maintained by us and other
+# third-party providers. First ensure add-apt-repository is installed.
 
 if [ ! -f /usr/bin/add-apt-repository ]; then
 	echo "Installing add-apt-repository..."
@@ -86,11 +79,21 @@ if [ ! -f /usr/bin/add-apt-repository ]; then
 	apt_install software-properties-common
 fi
 
+# [Main-in-a-Box's own PPA](https://launchpad.net/~mail-in-a-box/+archive/ubuntu/ppa)
+# holds several .deb packages that we built on our own.
+# One is a replacement for Ubuntu's stock postgrey package that makes
+# some enhancements. The other is dovecot-lucene, a Lucene-based full
+# text search plugin for (and by) dovecot, which is not available in
+# Ubuntu currently.
+
 hide_output add-apt-repository -y ppa:mail-in-a-box/ppa
+hide_output add-apt-repository -y ppa:certbot/certbot
 
 # ### Update Packages
 
-# Update system packages to make sure we have the latest upstream versions of things from Ubuntu.
+# Update system packages to make sure we have the latest upstream versions
+# of things from Ubuntu, as well as the directory of packages provide by the
+# PPAs so we can install those packages later.
 
 echo Updating system packages...
 hide_output apt-get update


### PR DESCRIPTION
When I first added Let's Encrypt support to Mail-in-a-Box, the `certbot` tool wasn't very mature and so I wrote [my own library](https://github.com/mail-in-a-box/free_tls_certificates) to interface with Let's Encrypt directly using the ACME protocol. The ACME protocol has changed and folks are reporting that they can't get TLS certificates anymore.

I don't want to maintain custom code if I don't have to, so this pull request drops my library and replaces it with executing the `certbot` tool.

I'd appreciate it if anyone could try out this pull request and report back if everything worked OK.