### PR TITLE
Fix ios-profile.xml so CalDAV calendar works on Mac OS X

### DIFF
--- a/conf/ios-profile.xml
+++ b/conf/ios-profile.xml
@@ -18,8 +18,6 @@
       <string>PRIMARY_HOSTNAME</string>
       <key>CalDAVPort</key>
       <real>443</real>
-      <key>CalDAVPrincipalURL</key>
-      <string>/cloud/remote.php/caldav/calendars/</string>
       <key>CalDAVUseSSL</key>
       <true/>
       <key>PayloadDescription</key>


### PR DESCRIPTION
The `CalDAVPrincipalURL` currently specified in the `ios-profile.xml` mobileconfig file is `/cloud/remote.php/caldav/calendars/` which causes an error in OS X. (It is unable to find that path.)

See: https://discourse.mailinabox.email/t/caldav-with-macos-10-12-2-does-not-work/1649 and other similar issues.

The correct `CalDAVPrincipalURL` is `/cloud/remote.php/caldav/principals/USERNAME/` but it is unnecessary to specify this key/value at all as OS X/iOS successfully auto discovers the correct URL.

This regression occurred when these routes changed when MiB updated to OwnCloud 9.