### PR TITLE
Use Nextcloud’s occ command to unlock the admin

### DIFF
--- a/tools/owncloud-unlockadmin.sh
+++ b/tools/owncloud-unlockadmin.sh
@@ -20,4 +20,4 @@ echo
 echo Press enter to continue.
 read
 
-sqlite3 $STORAGE_ROOT/owncloud/owncloud.db "INSERT OR IGNORE INTO oc_group_user VALUES ('admin', '$ADMIN')" && echo Done.
+sudo -u www-data php /usr/local/lib/owncloud/occ group:adduser admin $ADMIN && echo Done.


### PR DESCRIPTION
Add the admin to the admin group using the `occ` cli tool by Nextcloud.
This makes this script independently by the Nextloud version and used database.

Btw: The sqlite3 way was not working for me.