### PR TITLE
Use ISO 8601 on backups table dates, fixes #1397

### DIFF
--- a/management/backup.py
+++ b/management/backup.py
@@ -54,7 +54,7 @@ def backup_status(env):
 		date = dateutil.parser.parse(keys[1]).astimezone(dateutil.tz.tzlocal())
 		return {
 			"date": keys[1],
-			"date_str": date.strftime("%x %X") + " " + now.tzname(),
+			"date_str": date.strftime("%Y-%m-%d %X") + " " + now.tzname(),
 			"date_delta": reldate(date, now, "the future?"),
 			"full": keys[0] == "full",
 			"size": 0, # collection-status doesn't give us the size

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -155,6 +155,7 @@ cat > ${RCM_PLUGIN_DIR}/carddav/config.inc.php <<EOF;
 	 'preemptive_auth' => '1',
 	 'hide'        =>  false,
 );
+?>
 EOF
 
 # Create writable directories.


### PR DESCRIPTION
Minor enhancements/fixes:
- Implement #1397. Shows only date as ISO 8601, time display unchanged with TZ.
- Fix missing php tag. Had no incidences.
