### PR TITLE
Automatic account creation in Nextcloud Mail

### DIFF
--- a/setup/owncloud.sh
+++ b/setup/owncloud.sh
@@ -352,11 +352,9 @@ include("$STORAGE_ROOT/owncloud/config.php");
     'email' => '%EMAIL%',
     'imapHost' => '$PRIMARY_HOSTNAME',
     'imapPort' => 993,
-    'imapUser' => '%EMAIL%',
     'imapSslMode' => 'ssl',
     'smtpHost' => '$PRIMARY_HOSTNAME',
     'smtpPort' => 587,
-    'smtpUser' => '%EMAIL%',
     'smtpSslMode' => 'tls',
 );
 

--- a/setup/owncloud.sh
+++ b/setup/owncloud.sh
@@ -329,6 +329,7 @@ fi
 # * We need to set the logdateformat to something that will work correctly with fail2ban
 # * mail_domain' needs to be set every time we run the setup. Making sure we are setting 
 #   the correct domain name if the domain is being change from the previous setup.
+# * Automatically add e-mail accounts in nextcloud mail
 # Use PHP to read the settings file, modify it, and write out the new settings array.
 TIMEZONE=$(cat /etc/timezone)
 CONFIG_TEMP=$(/bin/mktemp)
@@ -346,6 +347,18 @@ include("$STORAGE_ROOT/owncloud/config.php");
 \$CONFIG['logdateformat'] = 'Y-m-d H:i:s';
 
 \$CONFIG['mail_domain'] = '$PRIMARY_HOSTNAME';
+
+\$CONFIG['app.mail.accounts.default'] = array(
+    'email' => '%EMAIL%',
+    'imapHost' => '$PRIMARY_HOSTNAME',
+    'imapPort' => 993,
+    'imapUser' => '%EMAIL%',
+    'imapSslMode' => 'ssl',
+    'smtpHost' => '$PRIMARY_HOSTNAME',
+    'smtpPort' => 587,
+    'smtpUser' => '%EMAIL%',
+    'smtpSslMode' => 'tls',
+);
 
 echo "<?php\n\\\$CONFIG = ";
 var_export(\$CONFIG);

--- a/setup/owncloud.sh
+++ b/setup/owncloud.sh
@@ -349,12 +349,14 @@ include("$STORAGE_ROOT/owncloud/config.php");
 \$CONFIG['mail_domain'] = '$PRIMARY_HOSTNAME';
 
 \$CONFIG['app.mail.accounts.default'] = array(
-    'email' => '%EMAIL%',
+    'email' => '%USERID%',
     'imapHost' => '$PRIMARY_HOSTNAME',
     'imapPort' => 993,
+    'imapUser' => '%USERID%',
     'imapSslMode' => 'ssl',
     'smtpHost' => '$PRIMARY_HOSTNAME',
     'smtpPort' => 587,
+    'smtpUser' => '%USERID%',
     'smtpSslMode' => 'tls',
 );
 


### PR DESCRIPTION
If the app [Nextcloud Mail app](https://github.com/nextcloud/mail) is installed the user mail account should be automatically added to this app.
This is [already possible](https://github.com/nextcloud/mail/blob/master/doc/admin.md#automatic-account-creation) via the config.php.

So the mails can be reached directly in nextcloud, like already the contacts and the calendar.