### PR TITLE
Prepare for deployment of MIAB Bionic to a Scaleway instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ In Development
 --------------
 
 * Starting with v0.28, TLS certificate provisioning wouldn't work on new boxes until the mailinabox setup command was run a second time because of a problem with the non-interactive setup.
+
 * Update to Nextcloud 13.0.6.
 * Update to Roundcube 1.3.7.
 * Update to Z-Push 2.4.4.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ In Development
 --------------
 
 * Starting with v0.28, TLS certificate provisioning wouldn't work on new boxes until the mailinabox setup command was run a second time because of a problem with the non-interactive setup.
+<<<<<<< HEAD
 
-* Update to Nextcloud 13.0.5.
+* Update to Nextcloud 13.0.6.
 * Update to Roundcube 1.3.7.
 * Update to Z-Push 2.4.4.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ In Development
 --------------
 
 * Starting with v0.28, TLS certificate provisioning wouldn't work on new boxes until the mailinabox setup command was run a second time because of a problem with the non-interactive setup.
-<<<<<<< HEAD
-
 * Update to Nextcloud 13.0.6.
 * Update to Roundcube 1.3.7.
 * Update to Z-Push 2.4.4.

--- a/setup/nextcloud.sh
+++ b/setup/nextcloud.sh
@@ -75,8 +75,8 @@ InstallNextcloud() {
 	fi
 }
 
-nextcloud_ver=13.0.5
-nextcloud_hash=e2b4a4bebd4fac14feae1e6e8997682f73fa8b50
+nextcloud_ver=13.0.6
+nextcloud_hash=33e41f476f0e2be5dc7cdb9d496673d9647aa3d6
 
 # Check if Nextcloud dir exist, and check if version matches nextcloud_ver (if either doesn't - install/upgrade)
 if [ ! -d /usr/local/lib/owncloud/ ] \

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -14,6 +14,20 @@ source setup/functions.sh # load our functions
 echo $PRIMARY_HOSTNAME > /etc/hostname
 hostname $PRIMARY_HOSTNAME
 
+# ### Fix permissions
+
+# The default Ubuntu Bionic image on Scaleway throws warnings during setup about incorrect
+# permissions (group writeable) set on the following directories.
+
+chmod g-w /etc /etc/default /usr
+
+# ### Fix sudo
+
+# The default Ubuntu Bionic image on Scaleway doesn't include root in the sudoers file
+# preventing us from running commands as other users
+
+tools/editconf.py /etc/sudoers "root ALL=(ALL) ALL"
+
 # ### Add swap space to the system
 
 # If the physical memory of the system is below 2GB it is wise to create a
@@ -119,7 +133,8 @@ echo Installing system packages...
 apt_install python3 python3-dev python3-pip \
 	netcat-openbsd wget curl git sudo coreutils bc \
 	haveged pollinate unzip \
-	unattended-upgrades cron ntp fail2ban
+	unattended-upgrades cron ntp fail2ban \
+	rsyslog
 
 # ### Suppress Upgrade Prompts
 # When Ubuntu 20 comes out, we don't want users to be prompted to upgrade,


### PR DESCRIPTION
The Scaleway image has several issues that prevent the deployment on Ubuntu 18.04. My guess is that this can happen with other providers too. 

The first issue is the missing rsyslog package.

This results in:

```
FAILED: service rsyslog restart
-----------------------------------------
Failed to restart rsyslog.service: Unit rsyslog.service not found.
-----------------------------------------
```

The second issue is incorrect permissions on certain directories, this causes the following warnings:

```
WARN: /etc/default is group writable!
WARN: /etc is group writable!
WARN: /usr is group writable!
```

The third issue is that root isn't in the sudoers file. This prevents us from running commands as other users.

This PR fixes these issues.

There seem to be issues with the nextcloud install too, but I'll investigate and fix those later.