### PR TITLE
munin: spamfilter graphs

### DIFF
--- a/conf/munin/sa-learn-plugin
+++ b/conf/munin/sa-learn-plugin
@@ -1,0 +1,76 @@
+#!/bin/bash
+# https://github.com/munin-monitoring/contrib/blob/889e47197562485cf7e45eb30af160b697bbb95e/plugins/spamassasin/sa-learn
+
+: <<=cut
+=head1 NAME
+
+sa-learn - Munin plugin to monitor spamassasin bayes database size
+
+=head1 APPLICABLE SYSTEMS
+
+Any server running spamassassin
+
+=head1 CONFIGURATION
+
+This plugin assumes your Spamassassin database is in /var/lib/MailScanner.
+If it's elsewhere (or you want to use a different database) you will need
+a configuration such as:
+
+   [sa-learn]
+      env.BayesDir /path/to/bayes/directory/
+      user mail
+
+(where 'user mail' refers to a user that can read the database).
+
+=head1 MAGIC MARKERS
+
+#%# family=contrib
+
+=head1 VERSION
+
+2
+
+=head1 AUTHOR
+
+Paul Saunders L<darac+munin@darac.org.uk>
+
+=cut
+#'
+
+case $1 in
+  config)
+    cat <<'EOM'
+graph_title SA-Learn Magic
+graph_vlabel Count
+graph_args --base 1000 -l 0
+graph_category Mail
+spam.label Num Spam
+spam.type GAUGE
+ham.label Num Ham
+ham.type GAUGE
+tokens.label Num Tokens
+tokens.type GAUGE
+EOM
+    exit 0;;
+esac
+
+## Print values
+BayesDir=${BayesDir:-/var/lib/MailScanner}
+
+sa-learn --dbpath $BayesDir/ --dump magic 2>/dev/null | while read line
+do
+  case "$line" in
+    *nspam*)
+      echo -n "spam.value "
+      echo $line | awk '{print $3}'
+      ;;
+    *nham*)
+      echo -n "ham.value "
+      echo $line | awk '{print $3}'
+      ;;
+    *ntokens*)
+      echo -n "tokens.value "
+      echo $line | awk '{print $3}'
+      ;;
+  esac
+done

--- a/conf/munin/sa-learn.conf
+++ b/conf/munin/sa-learn.conf
@@ -1,0 +1,3 @@
+[sa-learn]
+env.BayesDir ##BAYES_DIR##
+user spampd

--- a/conf/munin/sa-learn.patch
+++ b/conf/munin/sa-learn.patch
@@ -1,0 +1,11 @@
+--- sa-learn
++++ sa-learn
+@@ -43,7 +43,7 @@ case $1 in
+ graph_title SA-Learn Magic
+ graph_vlabel Count
+ graph_args --base 1000 -l 0
+-graph_category Mail
++graph_category spamfilter
+ spam.label Num Spam
+ spam.type GAUGE
+ ham.label Num Ham

--- a/conf/munin/spamstats.conf
+++ b/conf/munin/spamstats.conf
@@ -1,0 +1,3 @@
+[spamstats]
+group adm
+env.logfile mail.log

--- a/conf/munin/spamstats.patch
+++ b/conf/munin/spamstats.patch
@@ -1,0 +1,11 @@
+see https://github.com/munin-monitoring/munin/commit/7d163251667016cd7e4d6b4d188553312b8190c9#diff-052b0a943b0e9e24ce557d557ce2f318
+--- spamstats
++++ spamstats
+@@ -55,6 +55,7 @@
+     print "graph_title SpamAssassin throughput\n";
+     print "graph_args --base 1000 -l 0\n";
+     print "graph_vlabel mails/\${graph_period}\n";
++    print "graph_category spamfilter\n";
+     print "graph_order ham spam\n";
+     print "ham.label ham\n";
+     print "ham.type DERIVE\n";


### PR DESCRIPTION
this pr enables the spamstats plugin and adds the sa-learn plugin from munin-monitoring/contrib.
visually, it adds the category "spamfilter" to the munin ui which groups spamassassin bayes and ham/spam traffic graphs.

<img width="743" alt="munin-spamfilter" src="https://user-images.githubusercontent.com/201135/46968416-6f4f6e00-d0b3-11e8-9e59-7695743286d6.png">
