### PR TITLE
Improve postgrey logging

### DIFF
--- a/management/mail_log.py
+++ b/management/mail_log.py
@@ -257,7 +257,7 @@ def scan_mail_log(env):
 
         print(textwrap.fill(
             "The following mail was greylisted, meaning the emails were temporarily rejected. "
-            "Legitimate senders will try again within ten minutes.",
+            "Legitimate senders must try again after three minutes.",
             width=80, initial_indent=" ", subsequent_indent=" "
         ), end='\n\n')
 


### PR DESCRIPTION
We can't presume the redelivery timeframe of the sending server. However, we do know the blacklist timeframe within which we will reject a redelivery.