### PR TITLE
Fixes #1450 - add nameserver declaration to /etc/resolv.conf

### DIFF
--- a/setup/system.sh
+++ b/setup/system.sh
@@ -321,7 +321,7 @@ fi
 # download bind9 from.
 rm -f /etc/resolv.conf
 tools/editconf.py /etc/systemd/resolved.conf DNSStubListener=no
-echo "127.0.0.1" > /etc/resolv.conf
+echo "nameserver 127.0.0.1" > /etc/resolv.conf
 
 # Restart the DNS services.
 


### PR DESCRIPTION
Fixes #1450 to be "nameserver 127.0.0.1" instead of just "127.0.0.1"