### PR TITLE
Fixes #1453 - fail2ban ssh/ssh-ddos and sasl are now sshd and postfix-sasl

### DIFF
--- a/conf/fail2ban/filter.d/miab-owncloud.conf
+++ b/conf/fail2ban/filter.d/miab-owncloud.conf
@@ -3,5 +3,6 @@
 before = common.conf
 
 [Definition]
+datepattern = %%Y-%%m-%%d %%H:%%M:%%S
 failregex=Login failed: .*Remote IP: '<HOST>[\)']
 ignoreregex =

--- a/conf/fail2ban/jails.conf
+++ b/conf/fail2ban/jails.conf
@@ -69,13 +69,10 @@ action   = iptables-allports[name=recidive]
 # So the notification is ommited. This will prevent message appearing in the mail.log that mail
 # can't be delivered to fail2ban@$HOSTNAME.
 
-[sasl]
+[postfix-sasl]
 enabled  = true
 
-[ssh]
+[sshd]
 enabled = true
 maxretry = 7
 bantime = 3600
-
-[ssh-ddos]
-enabled  = true

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -332,6 +332,7 @@ systemctl restart systemd-resolved
 
 # Configure the Fail2Ban installation to prevent dumb bruce-force attacks against dovecot, postfix, ssh, etc.
 rm -f /etc/fail2ban/jail.local # we used to use this file but don't anymore
+rm -f /etc/fail2ban/jail.d/defaults-debian.conf # removes default config so we can manage all of fail2ban rules in one config
 cat conf/fail2ban/jails.conf \
 	| sed "s/PUBLIC_IP/$PUBLIC_IP/g" \
 	| sed "s#STORAGE_ROOT#$STORAGE_ROOT#" \


### PR DESCRIPTION
Fixes #1453

ssh&ssh-ddos are now combined into the same rule (which is why 18.04 is 9 rules instead of 10
sasl has been renamed to postfix-sasl

Also, a fresh install adds the file /etc/fail2ban/jail.d/defaults-debian.conf that will enable sshd, it won't be a problem having it in defaults-debian.conf and mailinabox.conf, but it would be best to manage all the rules in the same place.

I still need to run through the tests/fail2ban.py, not sure exactly how it works.  Seems to exit after being banned without continuting the rest of the tests.  This commit his should work fine since the filter regexes in 14.04 are still included in the new namings on 18.04

14.04:
```
root@m:~# fail2ban-client status
Status
|- Number of jail:      10
`- Jail list:           miab-munin, recidive, miab-owncloud, miab-postfix587, ssh-ddos, miab-management, ssh, sasl, dovecot, miab-roundcube
```

18.04:
```
root@m:~# fail2ban-client status
Status
|- Number of jail:      9
`- Jail list:   dovecot, miab-management, miab-munin, miab-owncloud, miab-postfix587, miab-roundcube, postfix-sasl, recidive, sshd
```