### PR TITLE
Added GitHub Actions CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron:  '0 0 * * 0'
+
+jobs:
+  Mail-in-a-Box:
+    name: Mail-in-a-Box
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # Add Ubuntu 26.04 here when supported.
+        os: [ubuntu-22.04]
+      fail-fast: false
+    env:
+      NONINTERACTIVE: 1
+      PUBLIC_IP: auto
+      PUBLIC_IPV6: auto
+      PRIMARY_HOSTNAME: auto
+      SKIP_NETWORK_CHECKS: 1
+      PYTHONDEVMODE: 1
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Before Script
+      run: |
+        set -x
+        cat /etc/hosts
+        # Adds a hostname to the hosts file.
+        sudo sed -i "/^127\.0\.0\.1/a 127.0.0.1\t$HOSTNAME.example.com\t$HOSTNAME" /etc/hosts
+    - name: Script
+      run: |
+        set -x
+        # Compiles all Python files to check syntax
+        shopt -s globstar; python3 -m compileall -o{0..2} -x tools/mail.py */**.py
+        # Runs the script.
+        sudo -E bash -e -o pipefail -- setup/start.sh
+        # Verifies all the services are running by getting the HTTP headers.
+        curl -sSIkLf "https://$HOSTNAME/"
+        curl -sSIkLf "https://$HOSTNAME/admin"
+        curl -sSIkLf "https://$HOSTNAME/mail/"
+        curl -sSIkLf "https://$HOSTNAME/cloud/" || true
+        # Runs the test suite. Uncomment these three lines once #1039 is merged.
+        # cd test
+        # python3 -m pip install -r requirements.txt
+        # pytest
+
+  ShellCheck:
+    name: ShellCheck
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: ShellCheck
+      run: shopt -s globstar; shellcheck -o avoid-nullary-conditions,check-extra-masked-returns,check-set-e-suppressed,deprecate-which,quote-safe-variables,require-double-brackets -s bash **/*.sh tools/{dns,web}_update
+      # Remove this line once all errors are fixed.
+      continue-on-error: true
+
+  Ruff:
+    name: Ruff
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: |
+        python3 -m pip install --upgrade pip
+        python3 -m pip install ruff
+    - name: Script
+      run: ruff check --output-format=github .
+      # Remove this line once all errors are fixed.
+      continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CI](https://github.com/mail-in-a-box/mailinabox/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/mail-in-a-box/mailinabox/actions/workflows/ci.yml)
+
 Mail-in-a-Box
 =============
 


### PR DESCRIPTION
~**Edit**: This PR is now very outdated, but I would be happy to update it if there is ever interest in adding CI. Travis CI is no longer free, so we would need to use GitHub Actions CI instead.~

- Added GitHub Actions CI (continuous integration).
  - Tests on Ubuntu 22.04.
  - Runs the ShellCheck linter. Bugs fixed in #1457.
  - Run the Ruff Python linter. Some errors fixed in #2343.
    - Config file added in #2473.
  - Ready to run the #1039 test suite, once it is merged. Just uncomment the three lines.

This pull request was originally part of #1435.