### PR TITLE
postfix: add additional rbl lookup domains

### DIFF
--- a/setup/mail-postfix.sh
+++ b/setup/mail-postfix.sh
@@ -200,7 +200,7 @@ tools/editconf.py /etc/postfix/main.cf virtual_transport=lmtp:[127.0.0.1]:10025
 # "450 4.7.1 Client host rejected: Service unavailable". This is a retry code, so the mail doesn't properly bounce. #NODOC
 tools/editconf.py /etc/postfix/main.cf \
 	smtpd_sender_restrictions="reject_non_fqdn_sender,reject_unknown_sender_domain,reject_authenticated_sender_login_mismatch,reject_rhsbl_sender dbl.spamhaus.org" \
-	smtpd_recipient_restrictions=permit_sasl_authenticated,permit_mynetworks,"reject_rbl_client zen.spamhaus.org",reject_unlisted_recipient,"check_policy_service inet:127.0.0.1:10023"
+	smtpd_recipient_restrictions=permit_sasl_authenticated,permit_mynetworks,"reject_rbl_client zen.spamhaus.org","reject_rbl_client multi.uribl.com","reject_rbl_client bl.spamcop.net","reject_rbl_client cbl.abuseat.org",reject_unlisted_recipient,"check_policy_service inet:127.0.0.1:10023"
 
 # Postfix connects to Postgrey on the 127.0.0.1 interface specifically. Ensure that
 # Postgrey listens on the same interface (and not IPv6, for instance).


### PR DESCRIPTION
For quite a while now, I've been running my miab with a few additional rbl lookup domains besides just spamhaus and would like to see if these additional hosts could be added. My wife and I (the only two people I host mail for currently) have not any delivery issues since I've added these additional rbl domains.

This could be upstreamed to master as well as ubuntu_bionic.

Since March 21st 2018 my blocked mail per rbl lookup counts to the following:
root@m:/var/log# grep -o -E 'multi.uribl.com|bl.spamcop.net|cbl.abuseat.org|zen.spamhaus.org' /var/log/mail.log | sort | uniq -c | sort -nr
    471 bl.spamcop.net
    266 cbl.abuseat.org
    150 zen.spamhaus.org
     11 multi.uribl.com