### PR TITLE
Autodiscovery fix for additional hosted email domains, Fixes #941

### DIFF
--- a/conf/nginx-alldomains.conf
+++ b/conf/nginx-alldomains.conf
@@ -18,6 +18,9 @@
 	location = /.well-known/autoconfig/mail/config-v1.1.xml {
 		alias /var/lib/mailinabox/mozilla-autoconfig.xml;
 	}
+	location = /mail/config-v1.1.xml {
+		alias /var/lib/mailinabox/mozilla-autoconfig.xml;
+	}
 
 	# Roundcube Webmail configuration.
 	rewrite ^/mail$ /mail/ redirect;

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -288,13 +288,15 @@ def build_zone(domain, all_domains, additional_records, www_redirect_domains, en
 			if not has_rec(qname, "SRV"):
 				records.append((qname, "SRV", "0 0 443 " + env["PRIMARY_HOSTNAME"] + ".", "Recommended. Specifies the hostname of the server that handles CardDAV/CalDAV services for email addresses on this domain."))
 
-        # Adds CNAME records for hosted email address domains (Email addresses that are added apart from the PRIMARY_HOSTNAME)
+        # Adds autoconfiguration A records for all domains.
+        # This allows the following clients to automatically configure email addresses in the respective applications.
         # autodiscover.* - Z-Push ActiveSync Autodiscover
         # autoconfig.* - Thunderbird Autoconfig
 	if domain != env["PRIMARY_HOSTNAME"]:
-		for qname in ("autodiscover", "autoconfig"):
-			if not has_rec(qname, "CNAME"):
-				records.append((qname, "CNAME", env["PRIMARY_HOSTNAME"] + ".", "Provides autodiscovery support for hosted email address domains."))
+		if not has_rec("autodiscover", "A"):
+			records.append(("autodiscover", "A", env["PUBLIC_IP"], "Provides email configuration autodiscovery support for Z-Push ActiveSync Autodiscover."))
+		if not has_rec("autoconfig", "A"):
+			records.append(("autoconfig", "A", env["PUBLIC_IP"], "Provides email configuration autodiscovery support for Thunderbird Autoconfig."))
 
 	# Sort the records. The None records *must* go first in the nsd zone file. Otherwise it doesn't matter.
 	records.sort(key = lambda rec : list(reversed(rec[0].split(".")) if rec[0] is not None else ""))

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -288,6 +288,14 @@ def build_zone(domain, all_domains, additional_records, www_redirect_domains, en
 			if not has_rec(qname, "SRV"):
 				records.append((qname, "SRV", "0 0 443 " + env["PRIMARY_HOSTNAME"] + ".", "Recommended. Specifies the hostname of the server that handles CardDAV/CalDAV services for email addresses on this domain."))
 
+        # Adds CNAME records for hosted email address domains (Email addresses that are added apart from the PRIMARY_HOSTNAME)
+        # autodiscover.* - Z-Push ActiveSync Autodiscover
+        # autoconfig.* - Thunderbird Autoconfig
+	if domain != env["PRIMARY_HOSTNAME"]:
+		for qname in ("autodiscover", "autoconfig"):
+			if not has_rec(qname, "CNAME"):
+				records.append((qname, "CNAME", env["PRIMARY_HOSTNAME"] + ".", "Provides autodiscovery support for hosted email address domains."))
+
 	# Sort the records. The None records *must* go first in the nsd zone file. Otherwise it doesn't matter.
 	records.sort(key = lambda rec : list(reversed(rec[0].split(".")) if rec[0] is not None else ""))
 

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -292,11 +292,10 @@ def build_zone(domain, all_domains, additional_records, www_redirect_domains, en
         # This allows the following clients to automatically configure email addresses in the respective applications.
         # autodiscover.* - Z-Push ActiveSync Autodiscover
         # autoconfig.* - Thunderbird Autoconfig
-	if domain != env["PRIMARY_HOSTNAME"]:
-		if not has_rec("autodiscover", "A"):
-			records.append(("autodiscover", "A", env["PUBLIC_IP"], "Provides email configuration autodiscovery support for Z-Push ActiveSync Autodiscover."))
-		if not has_rec("autoconfig", "A"):
-			records.append(("autoconfig", "A", env["PUBLIC_IP"], "Provides email configuration autodiscovery support for Thunderbird Autoconfig."))
+	if not has_rec("autodiscover", "A"):
+		records.append(("autodiscover", "A", env["PUBLIC_IP"], "Provides email configuration autodiscovery support for Z-Push ActiveSync Autodiscover."))
+	if not has_rec("autoconfig", "A"):
+		records.append(("autoconfig", "A", env["PUBLIC_IP"], "Provides email configuration autodiscovery support for Thunderbird Autoconfig."))
 
 	# Sort the records. The None records *must* go first in the nsd zone file. Otherwise it doesn't matter.
 	records.sort(key = lambda rec : list(reversed(rec[0].split(".")) if rec[0] is not None else ""))

--- a/management/web_update.py
+++ b/management/web_update.py
@@ -29,6 +29,12 @@ def get_web_domains(env, include_www_redirects=True, exclude_dns_elsewhere=True)
 		# IP address than this box. Remove those domains from our list.
 		domains -= get_domains_with_a_records(env)
 
+		# Add Autoconfiguration domains, allowing us to serve correct SSL certs.
+		# 'autoconfig.' for Mozilla Thunderbird auto setup.
+		# 'autodiscover.' for Activesync autodiscovery.
+		domains |= set('autoconfig.' + zone for zone, zonefile in get_dns_zones(env))
+		domains |= set('autodiscover.' + zone for zone, zonefile in get_dns_zones(env))
+
 	# Ensure the PRIMARY_HOSTNAME is in the list so we can serve webmail
 	# as well as Z-Push for Exchange ActiveSync. This can't be removed
 	# by a custom A/AAAA record and is never a 'www.' redirect.

--- a/management/web_update.py
+++ b/management/web_update.py
@@ -29,11 +29,11 @@ def get_web_domains(env, include_www_redirects=True, exclude_dns_elsewhere=True)
 		# IP address than this box. Remove those domains from our list.
 		domains -= get_domains_with_a_records(env)
 
-		# Add Autoconfiguration domains, allowing us to serve correct SSL certs.
-		# 'autoconfig.' for Mozilla Thunderbird auto setup.
-		# 'autodiscover.' for Activesync autodiscovery.
-		domains |= set('autoconfig.' + zone for zone, zonefile in get_dns_zones(env))
-		domains |= set('autodiscover.' + zone for zone, zonefile in get_dns_zones(env))
+	# Add Autoconfiguration domains, allowing us to serve correct SSL certs.
+	# 'autoconfig.' for Mozilla Thunderbird auto setup.
+	# 'autodiscover.' for Activesync autodiscovery.
+	domains |= set('autoconfig.' + zone for zone, zonefile in get_dns_zones(env))
+	domains |= set('autodiscover.' + zone for zone, zonefile in get_dns_zones(env))
 
 	# Ensure the PRIMARY_HOSTNAME is in the list so we can serve webmail
 	# as well as Z-Push for Exchange ActiveSync. This can't be removed

--- a/management/web_update.py
+++ b/management/web_update.py
@@ -32,8 +32,8 @@ def get_web_domains(env, include_www_redirects=True, exclude_dns_elsewhere=True)
 	# Add Autoconfiguration domains, allowing us to serve correct SSL certs.
 	# 'autoconfig.' for Mozilla Thunderbird auto setup.
 	# 'autodiscover.' for Activesync autodiscovery.
-	domains |= set('autoconfig.' + zone for zone, zonefile in get_dns_zones(env))
-	domains |= set('autodiscover.' + zone for zone, zonefile in get_dns_zones(env))
+	domains |= set('autoconfig.' + maildomain for maildomain in get_mail_domains(env))
+	domains |= set('autodiscover.' + maildomain for maildomain in get_mail_domains(env))
 
 	# Ensure the PRIMARY_HOSTNAME is in the list so we can serve webmail
 	# as well as Z-Push for Exchange ActiveSync. This can't be removed


### PR DESCRIPTION
 Autodiscovery problems exist for email domains added in addition to the first domain used for setup. This problem exists for both Thunderbird lookup, as well as ActiveSync Autodiscovery.

For example,  If we setup a MIAB at box.example.com.  Thunderbird autoconfig will work because MIAB already hosts the config here https://example.com/.well-known/autoconfig/mail/config-v1.1.xml.  ActiveSync Autodiscovery will work because MIAB already hosts https://example.com/Autodiscover/Autodiscover.xml

This patch fixes the following problem. On the same example MIAB server, I setup otherdomain.com for email, but I don't host my website there.  https://otherdomain.com/.well-known/autoconfig/mail/config-v1.1.xml is never found since the A record points somewhere else.  Thunderbird will then try https://autoconfig.otherdomain.com/mail/config-v1.1.xml. Currently that file (and associating dns record) is not configured, and in this scenario Thunderbird would need to be configured Manually.

ActiveSync Autodiscovery fails as well, https://otherdomain.com/Autodiscover/Autodiscover.xml runs into the same problem.

Lucky for us both Thunderbird and ActiveSync Autodiscovery will check additional URL's during its search for auto information.

This patch adds CNAME entries to make autoconfig.otherdomain.com and autodiscover.otherdomain.com entries with dns_update.  (It will technically make all non PRIMARY_HOSTNAME domains have a CNAME ENTRY). As well as a nginx config posted on #941.

This patch gives us the additional Thunderbird lookup at https://autoconfig.otherdomain.com/mail/config-v1.1.xml.  For ActiveSync Autodiscovery, the path https://autodiscover.otherdomain.com/Autodiscover/Autodiscover.xml is a 302 redirect to https://box.example.com/Autodiscover/Autodiscover.xml.

Testing:
Thunderbird:  Test with Thunderbird for an email that is in addition to the domain used to setup MIAB.
Activesync Autodiscover: [Microsoft Remote Connectivity Analyzer](https://autodiscover.otherdomain.com/Autodiscover/Autodiscover.xml) or any Activesync App, I tested Nine on Android.


The only better way I can see would be to add the nginx edit 0e69c5e, but instead of CNAME, we would generate SSL certs instead for autoconfig. and autodiscover. for every domain.  But the CNAME seems to work from what I've tested.