### PR TITLE
Update Roundcube to version 1.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+In Development
+--------------
+ * Update to Roundcube 1.3.8.
+
 v0.29 (October 25, 2018)
 ------------------------
 

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -35,8 +35,8 @@ apt-get purge -qq -y roundcube* #NODOC
 # Install Roundcube from source if it is not already present or if it is out of date.
 # Combine the Roundcube version number with the commit hash of plugins to track
 # whether we have the latest version of everything.
-VERSION=1.3.7
-HASH=df0e29d09aae0b7a7ae98023dcd1ae3c6be77cd0
+VERSION=1.3.8
+HASH=90c7900ccf7b2f46fe49c650d5adb9b85ee9cc22
 PERSISTENT_LOGIN_VERSION=dc5ca3d3f4415cc41edb2fde533c8a8628a94c76
 HTML5_NOTIFIER_VERSION=4b370e3cd60dabd2f428a26f45b677ad1b7118d5
 CARDDAV_VERSION=2.0.4


### PR DESCRIPTION
This includes a fix for an XSS vulnerability in Roundcube.

See https://github.com/roundcube/roundcubemail/releases/tag/1.3.8 for details.