### PR TITLE
Ubuntu bionic solr fts

### DIFF
--- a/conf/cronjob/dovecot
+++ b/conf/cronjob/dovecot
@@ -1,0 +1,1 @@
+/usr/bin/doveadm fts rescan -A

--- a/conf/cronjob/solr
+++ b/conf/cronjob/solr
@@ -1,0 +1,2 @@
+*/1 * * * * root /usr/bin/curl http://127.0.0.1:8080/solr/update?commit=true &>/dev/null
+30 3 * * * root /usr/bin/curl http://127.0.0.1:8080/solr/update?optimize=true &>/dev/null

--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -38,6 +38,7 @@ def get_services():
 		{ "name": "Mail Filters (Sieve/dovecot)", "port": 4190, "public": True, },
 		{ "name": "HTTP Web (nginx)", "port": 80, "public": True, },
 		{ "name": "HTTPS Web (nginx)", "port": 443, "public": True, },
+	    { "name": "Solr Full Text Search (tomcat)", "port": 8080, "public": False, },
 	]
 
 def run_checks(rounded_values, env, output, pool):

--- a/setup/solr.sh
+++ b/setup/solr.sh
@@ -58,6 +58,11 @@ hide_output install -m 644 conf/cronjob/solr /etc/cron.d/
 chown -R mail:dovecot /etc/dovecot
 chmod -R o-rwx /etc/dovecot
 
+# Tomcat9 uses systemd permissions restrictions, solr writes outside of the
+# Tomcat default directories, we want to allow Tomcat to access our
+# search index
+mkdir -p /etc/systemd/system/tomcat9.service.d
+
 cat > /etc/systemd/system/tomcat9.service.d/solr-permissions.conf << EOF
 [Service]
 ReadWritePaths=/var/lib/solr/

--- a/setup/solr.sh
+++ b/setup/solr.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Inspired by the solr.sh from jkaberg (https://github.com/jkaberg/mailinabox-sogo)
+# with some modifications
+#
+# IMAP search with lucene via solr
+# --------------------------------
+#
+# By default dovecot uses its own Squat search index that has awful performance
+# on large mailboxes. Dovecot 2.1+ has support for using Lucene internally but
+# this didn't make it into the Ubuntu packages, so we use Solr instead to run
+# Lucene for us.
+#
+# Solr runs as a tomcat process. The dovecot solr plugin talks to solr via its
+# HTTP interface, causing mail to be indexed when searches occur, and getting
+# results back.
+
+source setup/functions.sh # load our functions
+source /etc/mailinabox.conf # load global vars
+
+# Install packages and basic configuation
+# ---------------------------------------
+
+echo "Installing Solr..."
+
+# Install packages
+apt_install solr-tomcat dovecot-solr
+
+# Solr requires a schema to tell it how to index data, this is provided by dovecot
+cp /usr/share/dovecot/solr-schema.xml /etc/solr/conf/schema.xml
+
+# Update the dovecot plugin configuration
+#
+# Break-imap-search makes search work the way users expect, rather than the way
+# the IMAP specification expects
+tools/editconf.py /etc/dovecot/conf.d/10-mail.conf \
+        mail_plugins="fts fts_solr"
+
+cat > /etc/dovecot/conf.d/90-plugin-fts.conf << EOF;
+plugin {
+  fts = solr
+  fts_autoindex = yes
+  fts_solr = break-imap-search url=http://127.0.0.1:8080/solr/
+}
+EOF
+
+# Bump memory allocation for Solr.
+# Not needed? I'll let it sit here for a while.
+#echo 'export JAVA_OPTS=-Xms512M -Xmx1024M' > /usr/share/tomcat7/bin/setenv.sh
+
+# Install cronjobs to keep FTS up to date
+hide_output install -m 755 conf/cronjob/dovecot /etc/cron.daily/
+hide_output install -m 644 conf/cronjob/solr /etc/cron.d/
+
+# PERMISSIONS
+
+# Ensure configuration files are owned by dovecot and not world readable.
+chown -R mail:dovecot /etc/dovecot
+chmod -R o-rwx /etc/dovecot
+
+# Restart services to reload solr schema & dovecot plugins
+restart_service tomcat8
+restart_service dovecot

--- a/setup/solr.sh
+++ b/setup/solr.sh
@@ -58,8 +58,14 @@ hide_output install -m 644 conf/cronjob/solr /etc/cron.d/
 chown -R mail:dovecot /etc/dovecot
 chmod -R o-rwx /etc/dovecot
 
+cat > /etc/systemd/system/tomcat9.service.d/solr-permissions.conf << EOF
+[Service]
+ReadWritePaths=/var/lib/solr/
+ReadWritePaths=/var/lib/solr/data/
+EOF
+
 # Restart services to reload solr schema & dovecot plugins
-restart_service tomcat8
+restart_service tomcat9
 restart_service dovecot
 
 

--- a/setup/solr.sh
+++ b/setup/solr.sh
@@ -61,3 +61,18 @@ chmod -R o-rwx /etc/dovecot
 # Restart services to reload solr schema & dovecot plugins
 restart_service tomcat8
 restart_service dovecot
+
+
+# Kickoff building the index
+
+# Per doveadm-fts manpage: Scan what mails exist in the full text search index
+# and compare those to what actually exist in mailboxes.
+# This removes mails from the index that have already been expunged  and  makes
+# sure that the next doveadm index will index all the missing mails (if any).
+doveadm fts rescan -A
+
+# Adds unindexed files to the fts database
+# * `-q`: Queues the indexing to be run by indexer process. (will background the indexing)
+# * `-A`: All users
+# * `'*'`: All folders
+doveadm index -q -A '*'

--- a/setup/start.sh
+++ b/setup/start.sh
@@ -102,6 +102,7 @@ source setup/dns.sh
 source setup/mail-postfix.sh
 source setup/mail-dovecot.sh
 source setup/mail-users.sh
+source setup/solr.sh
 source setup/dkim.sh
 source setup/spamassassin.sh
 source setup/web.sh

--- a/setup/web.sh
+++ b/setup/web.sh
@@ -48,6 +48,13 @@ tools/editconf.py /etc/php/7.2/fpm/php.ini -c ';' \
 tools/editconf.py /etc/php/7.2/fpm/php.ini -c ';' \
         default_charset="UTF-8"
 
+# Set higher timeout since searches with Roundcube and Solr may take longer
+# than the default 60 seconds. We will also match Roundcube's timeout to the
+# same value
+tools/editconf.py /etc/php/7.2/fpm/php.ini -c ';' \
+        default_socket_timeout=180
+
+
 # Switch from the dynamic process manager to the ondemand manager see #1216
 tools/editconf.py /etc/php/7.2/fpm/pool.d/www.conf -c ';' \
 	pm=ondemand

--- a/setup/web.sh
+++ b/setup/web.sh
@@ -54,7 +54,6 @@ tools/editconf.py /etc/php/7.2/fpm/php.ini -c ';' \
 tools/editconf.py /etc/php/7.2/fpm/php.ini -c ';' \
         default_socket_timeout=180
 
-
 # Switch from the dynamic process manager to the ondemand manager see #1216
 tools/editconf.py /etc/php/7.2/fpm/pool.d/www.conf -c ';' \
 	pm=ondemand

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -108,7 +108,7 @@ cat > $RCM_CONFIG <<EOF;
      'verify_peer_name'  => false,
    ),
  );
-\$config['imap_timeout'] = 15;
+\$config['imap_timeout'] = 180;
 \$config['smtp_server'] = 'tls://127.0.0.1';
 \$config['smtp_port'] = 587;
 \$config['smtp_user'] = '%u';


### PR DESCRIPTION
Patch adds Full text search using apt package for Solr.

Tested clients:
* Roundcube works, might want to increase timeouts in case searches take longer than 15sec. (php.ini default_socket_timeout = 180 and roundcube config.inc.php $config['imap_timeout'] = 180)  Should be fine since I added indexing to the install script and it does auto indexing as new mail comes in.
* Nine mail client on Android via IMAP searches with Solr, Exchange doesn't work however I believe it is Nine mail at fault; Gives this error in log file:
```z-push-error.log:16/01/2019 15:37:37 [11269] [WARN] [user@email.com] /usr/local/lib/z-push/lib/request/search.php:462 Invalid argument supplied for foreach() (2)```
* Blue mail client on Android via IMAP searches with Solr, Exchange works.
* Google mail client on Android via IMAP searches via Solr, Exchange doesn't search the server (from what I can tell)

* Tested via cli (see below)

You can test via the cli like so:
```
openssl s_client -connect localhost:imaps
1 LOGIN email@domain.com password
2 select inbox
3 SEARCH text "blah"
```