### PR TITLE
Fix always creating full backups when rsyncing

### DIFF
--- a/management/backup.py
+++ b/management/backup.py
@@ -15,7 +15,7 @@ from exclusiveprocess import Lock
 from utils import load_environment, shell, wait_for_service, fix_boto
 
 rsync_ssh_options = [
-	"--ssh-options='-i /root/.ssh/id_rsa_miab'",
+	# "--ssh-options='-i /root/.ssh/id_rsa_miab'",
 	"--rsync-options=-e \"/usr/bin/ssh -oStrictHostKeyChecking=no -oBatchMode=yes -p 22 -i /root/.ssh/id_rsa_miab\"",
 ]
 


### PR DESCRIPTION
With the row uncommented backup.py always creates full backups and rsyncs them to the destination configured.
Commented away, backup.py returns to normal and creates incremental backups.

~~_However_, listing on webgui is still broken.~~
CLI --list and --status now also works.

This is my first ever pull request, I'm no developer except for quick and dirty (shows in the pull request...). Also it's only fixing the issue by 75%, fixing incremental backups. ~~I've got no idea about the webgui.~~

Edit:
A reboot actually fixed the webgui listing.