### PR TITLE
512MB min RAM - 502MB on smaller Amazon EC2 instances

### DIFF
--- a/setup/preflight.sh
+++ b/setup/preflight.sh
@@ -26,7 +26,7 @@ fi
 #
 # Skip the check if we appear to be running inside of Vagrant, because that's really just for testing.
 TOTAL_PHYSICAL_MEM=$(head -n 1 /proc/meminfo | awk '{print $2}')
-if [ $TOTAL_PHYSICAL_MEM -lt 500000 ]; then
+if [ $TOTAL_PHYSICAL_MEM -lt 480000 ]; then
 if [ ! -d /vagrant ]; then
 	TOTAL_PHYSICAL_MEM=$(expr \( \( $TOTAL_PHYSICAL_MEM \* 1024 \) / 1000 \) / 1000)
 	echo "Your Mail-in-a-Box needs more memory (RAM) to function properly."


### PR DESCRIPTION
Suggest lowering the RAM requirement slightly. Amazon EC2 only gives me 503 MB...

```
Your Mail-in-a-Box needs more memory (RAM) to function properly.
Please provision a machine with at least 512 MB, 1 GB recommended.
This machine has 503 MB memory.
```