### PR TITLE
Update Roundcube to version 1.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+In Development
+--------------
+ * Update to Roundcube 1.3.9.
+
 v0.41 (February 26, 2019)
 -------------------------
 

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -28,8 +28,8 @@ apt_install \
 # Install Roundcube from source if it is not already present or if it is out of date.
 # Combine the Roundcube version number with the commit hash of plugins to track
 # whether we have the latest version of everything.
-VERSION=1.3.8
-HASH=90c7900ccf7b2f46fe49c650d5adb9b85ee9cc22
+VERSION=1.3.9
+HASH=02850972b416bbfa1c13580f16d06fd7ae2774aa
 PERSISTENT_LOGIN_VERSION=dc5ca3d3f4415cc41edb2fde533c8a8628a94c76
 HTML5_NOTIFIER_VERSION=4b370e3cd60dabd2f428a26f45b677ad1b7118d5
 CARDDAV_VERSION=3.0.3


### PR DESCRIPTION
In accordance with https://github.com/mail-in-a-box/mailinabox/pull/1475

See https://github.com/roundcube/roundcubemail/releases/tag/1.3.9 for details.