### PR TITLE
Implement sender and recipient checks

### DIFF
--- a/conf/reject.recipients
+++ b/conf/reject.recipients
@@ -1,0 +1,35 @@
+# #### WARNING - ONLY EDIT THIS FILE IF YOU KNOW WHAT YOU ARE DOING       #### #
+# ####           YOU HAVE BEEN WARNED!                                    #### #
+
+# this file contains a list of regular expressions that could match wanted
+# or unwanted email RECIPIENTS
+
+# after editing this file remember to use the command: "service postfix reload"
+#
+# Useful commands:
+# postconf -n (list current config)
+# postmap -q "test@example.com" regexp:/etc/postfix/sender_checks (test what would happen with test@example.com)
+
+# Example regular expressions
+# this will reject the exact email address 123@example.com:
+# /^123\@example\.com$/   REJECT
+#
+# this will reject any email addresses beginning with 123@:
+# /^123\@/   REJECT
+#
+# this will reject email addresses ending with example.com:
+# /(\.|\@)example\.com$/   REJECT
+
+# #### WARNING - ONLY EDIT THIS FILE IF YOU KNOW WHAT YOU ARE DOING       #### #
+# ####           YOU HAVE BEEN WARNED TWICE NOW AND I WON'T WARN          #### #
+# ####           YOU AGAIN!  YOU ARE ON YOUR OWN NOW.                     #### #
+
+# Let email to the following destinations bypass all the remaining
+# "reject" and "check" tests.  We always want to let email for these
+# recipients in.  These should not be altered.
+
+/^postmaster\@/ OK
+/^hostmaster\@/ OK
+/^abuse\@/      OK
+/^admin\@/      OK
+/^administrator\@/        OK

--- a/conf/reject.senders
+++ b/conf/reject.senders
@@ -1,0 +1,25 @@
+# #### WARNING - ONLY EDIT THIS FILE IF YOU KNOW WHAT YOU ARE DOING       #### #
+# ####           YOU HAVE BEEN WARNED!                                    #### #
+
+# this file contains a list of regular expressions that could match wanted
+# or unwanted email SENDERS
+
+# after editing this file remember to use the command: "service postfix reload"
+#
+# Useful commands:
+# postconf -n (list current config)
+# postmap -q "test@example.com" regexp:/etc/postfix/sender_checks (test what would happen with test@example.com)
+
+# Example regular expressions
+# this will reject the exact email address 123@example.com:
+# /^123\@example\.com$/   REJECT
+#
+# this will reject any email addresses beginning with 123@:
+# /^123\@/   REJECT
+#
+# this will reject email addresses ending with example.com:
+# /(\.|\@)example\.com$/   REJECT
+
+# #### WARNING - ONLY EDIT THIS FILE IF YOU KNOW WHAT YOU ARE DOING       #### #
+# ####           YOU HAVE BEEN WARNED TWICE NOW AND I WON'T WARN          #### #
+# ####           YOU AGAIN!  YOU ARE ON YOUR OWN NOW.                     #### #

--- a/setup/mail-postfix.sh
+++ b/setup/mail-postfix.sh
@@ -102,7 +102,7 @@ tools/editconf.py /etc/postfix/master.cf -s -w \
 # Install the `outgoing_mail_header_filters` file required by the new 'authclean' service.
 cp conf/postfix_outgoing_mail_header_filters /etc/postfix/outgoing_mail_header_filters
 
-# Modify the `outgoing_mail_header_filters` file to use the local machine name and ip 
+# Modify the `outgoing_mail_header_filters` file to use the local machine name and ip
 # on the first received header line.  This may help reduce the spam score of email by
 # removing the 127.0.0.1 reference.
 sed -i "s/PRIMARY_HOSTNAME/$PRIMARY_HOSTNAME/" /etc/postfix/outgoing_mail_header_filters
@@ -178,6 +178,15 @@ tools/editconf.py /etc/postfix/main.cf virtual_transport=lmtp:[127.0.0.1]:10025
 # See https://github.com/mail-in-a-box/mailinabox/issues/1523.
 tools/editconf.py /etc/postfix/main.cf lmtp_destination_recipient_limit=1
 
+# ### RECIPIENT AND SENDER BLOCKING
+# implement the rejection of email sent by certain senders or received by
+# certain email addresses
+if [ ! -f /etc/postfix/sender_checks ]; then
+    cp conf/reject.senders /etc/postfix/sender_checks
+fi
+if [ ! -f /etc/postfix/recipient_checks ]; then
+    cp conf/reject.recipients /etc/postfix/recipient_checks
+fi
 
 # Who can send mail to us? Some basic filters.
 #
@@ -198,7 +207,8 @@ tools/editconf.py /etc/postfix/main.cf lmtp_destination_recipient_limit=1
 # "450 4.7.1 Client host rejected: Service unavailable". This is a retry code, so the mail doesn't properly bounce. #NODOC
 tools/editconf.py /etc/postfix/main.cf \
 	smtpd_sender_restrictions="reject_non_fqdn_sender,reject_unknown_sender_domain,reject_authenticated_sender_login_mismatch,reject_rhsbl_sender dbl.spamhaus.org" \
-	smtpd_recipient_restrictions=permit_sasl_authenticated,permit_mynetworks,"reject_rbl_client zen.spamhaus.org",reject_unlisted_recipient,"check_policy_service inet:127.0.0.1:10023"
+	smtpd_recipient_restrictions="permit_sasl_authenticated,permit_mynetworks,reject_rbl_client zen.spamhaus.org,reject_unlisted_recipient,check_policy_service inet:127.0.0.1:10023, check_recipient_access regexp:/etc/postfix/recipient_checks, check_sender_access regexp:/etc/postfix/sender_checks"
+
 
 # Postfix connects to Postgrey on the 127.0.0.1 interface specifically. Ensure that
 # Postgrey listens on the same interface (and not IPv6, for instance).


### PR DESCRIPTION
**What this does**
This pull request allows an administrator to reject email from matching senders or reject email sent to matching recipients.  No domain hosted on the box will be allowed to receive email from the matching queries (in other words this is a system-wide rejection mechanism).  For individual user cases filters can be set up with roundcube.

**Why it is needed**
Blocking senders is useful, for example, when a mailing list refuses to unsubscribe users.  There are still too many rogue mailing list distributors, I know I was subscribed to receive many spam emails daily that I never signed up for and could never unsubscribe from, this solution means I no longer receive these emails.

Blocking recipients is useful when you know an email address has been compromised and has effectively been retired (for example it has been listed on the excellent [haveibeenpwned](https://haveibeenpwned.com/) website).  This can be useful if you have a catch-all domain (*@example.com) set up where all the email sent to the domain is sent to a global email address.  This allows you to reject any email set to, for example, john@example.com or sue@example.com but still keep the catch-all domain working.

Both of these measures rejects email *sent to* a recipient and not whether the recipient can send email.

**How it works**
Using the built-in postfix configuration parameter's check_recipient_access and check_sender_access.  Search on this page for more details about these: http://www.postfix.org/postconf.5.html

Postfix uses the two configurable files at /etc/postfix/recipient_checks and /etc/postfix/sender_checks to discover regular expressions that are used to match the email to be rejected.

An experienced user can edit these two files to allow or reject emails as necessary.  See the files conf/reject.senders and conf/reject.recipients for further details.  Without editing these files nothing will get rejected.

Further reading:
https://jimsun.linxnet.com/misc/postfix-anti-UCE.txt
https://linuxlasse.net/linux/howtos/Blacklist_and_Whitelist_with_Postfix
https://www.davidmartinwhite.com/2016/10/25/fighting-spam-block-entire-ttld-with-postfix/