### PR TITLE
Update to Nextcloud 15.0.8, Contacts to 3.1.1, and Calendar to 1.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,16 @@ CHANGELOG
 
 In Development
 --------------
- * Update to Roundcube 1.3.9.
+
+Mail:
+
+* Update to Roundcube 1.3.9.
+
+Contacts/Calendar:
+
+* Upgraded Nextcloud from 14.0.6 to 15.0.8.
+* Upgraded Contacts from 2.1.8 to 3.1.1.
+* Upgraded Calendar from 1.6.4 to 1.6.5.
 
 v0.41 (February 26, 2019)
 -------------------------

--- a/conf/nginx-primaryonly.conf
+++ b/conf/nginx-primaryonly.conf
@@ -19,6 +19,7 @@
 	rewrite ^/cloud/$ /cloud/index.php;
 	rewrite ^/cloud/(contacts|calendar|files)$ /cloud/index.php/apps/$1/ redirect;
 	rewrite ^(/cloud/core/doc/[^\/]+/)$ $1/index.html;
+	rewrite ^(/cloud/oc[sm]-provider)/$ $1/index.php redirect;
 	location /cloud/ {
 		alias /usr/local/lib/owncloud/;
 	 	location ~ ^/cloud/(build|tests|config|lib|3rdparty|templates|data|README)/ {
@@ -27,6 +28,14 @@
 	 	location ~ ^/cloud/(?:\.|autotest|occ|issue|indie|db_|console) {
 	 		deny all;
 	 	}
+		# Enable paths for service and cloud federation discovery
+		# Resolves warning in Nextcloud Settings panel
+                location ~ ^/cloud/(oc[sm]-provider)?/([^/]+\.php)$ {
+                        index index.php;
+                        include fastcgi_params;
+                        fastcgi_param SCRIPT_FILENAME /usr/local/lib/owncloud/$1/$2;
+                        fastcgi_pass php-fpm;
+                }
 	}
 	location ~ ^(/cloud)((?:/ocs)?/[^/]+\.php)(/.*)?$ {
 		# note: ~ has precendence over a regular location block

--- a/setup/mail-dovecot.sh
+++ b/setup/mail-dovecot.sh
@@ -135,6 +135,14 @@ service lmtp {
   }
 }
 
+# Enable imap-login on localhost to allow the user_external plugin
+# for Nextcloud to do imap authentication. (See #1577)
+service imap-login {
+  inet_listener imap {
+    address = 127.0.0.1
+    port = 143
+  }
+}
 protocol imap {
   mail_max_userip_connections = 20
 }

--- a/setup/nextcloud.sh
+++ b/setup/nextcloud.sh
@@ -13,7 +13,8 @@ apt-get purge -qq -y owncloud* # we used to use the package manager
 
 apt_install php php-fpm \
 	php-cli php-sqlite3 php-gd php-imap php-curl php-pear curl \
-	php-dev php-gd php-xml php-mbstring php-zip php-apcu php-json php-intl
+	php-dev php-gd php-xml php-mbstring php-zip php-apcu php-json \
+	php-intl php-imagick
 
 InstallNextcloud() {
 
@@ -81,6 +82,9 @@ InstallNextcloud() {
 
 		# Add missing indices. NextCloud didn't include this in the normal upgrade because it might take some time.
 		sudo -u www-data php /usr/local/lib/owncloud/occ db:add-missing-indices
+
+		# Run conversion to BigInt identifiers, this process may take some time on large tables.
+		sudo -u www-data php /usr/local/lib/owncloud/occ db:convert-filecache-bigint --no-interaction
 	fi
 }
 

--- a/setup/nextcloud.sh
+++ b/setup/nextcloud.sh
@@ -84,8 +84,8 @@ InstallNextcloud() {
 	fi
 }
 
-nextcloud_ver=15.0.7
-nextcloud_hash=1becd99a5cbe52b94be282b845ab68f871025d94
+nextcloud_ver=15.0.8
+nextcloud_hash=4129d8d4021c435f2e86876225fb7f15adf764a3
 # Check if Nextcloud dir exist, and check if version matches nextcloud_ver (if either doesn't - install/upgrade)
 if [ ! -d /usr/local/lib/owncloud/ ] \
 		|| ! grep -q $nextcloud_ver /usr/local/lib/owncloud/version.php; then

--- a/setup/nextcloud.sh
+++ b/setup/nextcloud.sh
@@ -155,7 +155,7 @@ if [ ! -f $STORAGE_ROOT/owncloud/owncloud.db ]; then
     array(
       'class' => 'OC_User_IMAP',
         'arguments' => array(
-          '${PRIMARY_HOSTNAME}', 993, 'ssl', ''
+          '127.0.0.1', 143, '', ''
          ),
     ),
   ),
@@ -229,7 +229,7 @@ include("$STORAGE_ROOT/owncloud/config.php");
 
 \$CONFIG['mail_domain'] = '$PRIMARY_HOSTNAME';
 
-\$CONFIG['user_backends'] = array(array('class' => 'OC_User_IMAP','arguments' => array('${PRIMARY_HOSTNAME}', 993, 'ssl', ''),),);
+\$CONFIG['user_backends'] = array(array('class' => 'OC_User_IMAP','arguments' => array('127.0.0.1', 143, '', ''),),);
 
 echo "<?php\n\\\$CONFIG = ";
 var_export(\$CONFIG);

--- a/setup/nextcloud.sh
+++ b/setup/nextcloud.sh
@@ -50,7 +50,7 @@ InstallNextcloud() {
 
 	# Starting with Nextcloud 15, the app user_external is no longer included in Nextcloud core,
 	# we will install from their github repository.
-	wget_verify https://github.com/nextcloud/user_external/releases/download/v0.6.1/user_external-0.6.1.tar.gz 1e9c40eb9b1e2504c03edcab88f11d7d1f008df1 /tmp/user_external.tgz
+	wget_verify https://github.com/nextcloud/user_external/releases/download/v0.6.3/user_external-0.6.3.tar.gz 0f756d35fef6b64a177d6a16020486b76ea5799c /tmp/user_external.tgz
 	tar -xf /tmp/user_external.tgz -C /usr/local/lib/owncloud/apps/
 	rm /tmp/user_external.tgz
 
@@ -159,7 +159,7 @@ if [ ! -f $STORAGE_ROOT/owncloud/owncloud.db ]; then
     array(
       'class' => 'OC_User_IMAP',
         'arguments' => array(
-          '127.0.0.1', 143, '', ''
+          '127.0.0.1', 143, null
          ),
     ),
   ),
@@ -233,7 +233,7 @@ include("$STORAGE_ROOT/owncloud/config.php");
 
 \$CONFIG['mail_domain'] = '$PRIMARY_HOSTNAME';
 
-\$CONFIG['user_backends'] = array(array('class' => 'OC_User_IMAP','arguments' => array('127.0.0.1', 143, '', ''),),);
+\$CONFIG['user_backends'] = array(array('class' => 'OC_User_IMAP','arguments' => array('127.0.0.1', 143, null),),);
 
 echo "<?php\n\\\$CONFIG = ";
 var_export(\$CONFIG);


### PR DESCRIPTION
Nextcloud 15 no longer includes users_external in Nextcloud core so it now needs to be installed to apps like Contacts and Calendar. 

It has been reported here: https://github.com/nextcloud/server/issues/12506 that upgrades might fail if user_external is enabled for upgrades between 14->15 so a check has been added for that.

Because of the updates to user_external, the config.php syntax was changed.  I was not able to get auth working when pointed to 127.0.0.1 thus the change to $PRIMARY_HOSTNAME (perhaps they removed the novalidate-cert style setting?) No mention of that option here: https://github.com/nextcloud/user_external

I tested on a fresh install ok. Test in your dev and let me know how things go.