### PR TITLE
Hide output for venv

### DIFF
--- a/setup/management.sh
+++ b/setup/management.sh
@@ -38,7 +38,7 @@ inst_dir=/usr/local/lib/mailinabox
 mkdir -p $inst_dir
 venv=$inst_dir/env
 if [ ! -d $venv ]; then
-	virtualenv -ppython3 $venv
+	hide_output virtualenv -ppython3 $venv
 fi
 
 # Upgrade pip because the Ubuntu-packaged version is out of date.


### PR DESCRIPTION
PR hides the virtual environment install console message.  Usually the venv is only installed on first run. So only new installs typically saw this message.

Before:
```
Installing Mail-in-a-Box system management daemon...
Already using interpreter /usr/bin/python3
Using base prefix '/usr'
New python executable in /usr/local/lib/mailinabox/env/bin/python3
Also creating executable in /usr/local/lib/mailinabox/env/bin/python
Installing setuptools, pkg_resources, pip, wheel...done.
```

After:
```
Installing Mail-in-a-Box system management daemon...
```