### PR TITLE
Add check so munin-cron is not run at the same time as the same cron munin-cron; Fixes #660

### DIFF
--- a/setup/munin.sh
+++ b/setup/munin.sh
@@ -76,4 +76,8 @@ restart_service munin-node
 # generate initial statistics so the directory isn't empty
 # (We get "Pango-WARNING **: error opening config file '/root/.config/pango/pangorc': Permission denied"
 # if we don't explicitly set the HOME directory when sudo'ing.)
-sudo -H -u munin munin-cron
+# We check to see if munin-cron is already running, if it is, there is no need to run it simultaneously
+# generating an error.
+if [ ! -f /var/run/munin/munin-update.lock ]; then
+	sudo -H -u munin munin-cron
+fi


### PR DESCRIPTION
When the following cron is running...
/etc/cron.d/munin:
```
*/5 * * * *     munin if [ -x /usr/bin/munin-cron ]; then /usr/bin/munin-cron; fi
```
...during setup/munin.sh it causes the following error:
```
[FATAL ERROR] Lock already exists: /var/run/munin/munin-update.lock. Dying.
 at /usr/share/perl5/Munin/Master/Update.pm line 128.
```

PR should resolve #660