### PR TITLE
Upgrade Z-Push to 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ In Development
 --------------
  * Update to Roundcube 1.3.9.
 
+Z-Push:
+ * Upgraded Z-Push from 2.4.4 to 2.5.0.
+
 v0.41 (February 26, 2019)
 -------------------------
 

--- a/setup/zpush.sh
+++ b/setup/zpush.sh
@@ -22,8 +22,8 @@ apt_install \
 phpenmod -v php imap
 
 # Copy Z-Push into place.
-VERSION=2.4.4
-TARGETHASH=104d44426852429dac8ec2783a4e9ad7752d4682
+VERSION=2.5.0
+TARGETHASH=30ce5c1af3f10939036361b6032d1187651b621e
 needs_update=0 #NODOC
 if [ ! -f /usr/local/lib/z-push/version ]; then
 	needs_update=1 #NODOC


### PR DESCRIPTION
On a side note, I've been using solr-jetty for a while now and it works rather well.  It's the jetty server version of Tomcat from this PR #1506.  I've noticed that with Z-Push 2.5.0 search now works in Nine for Android with Activesync. (Maybe other clients, I haven't got to testing that yet)