### PR TITLE
Full Text Search using Solr Jetty

### DIFF
--- a/conf/cronjob/dovecot
+++ b/conf/cronjob/dovecot
@@ -1,1 +1,2 @@
+#!/bin/bash
 /usr/bin/doveadm fts rescan -A

--- a/conf/cronjob/dovecot
+++ b/conf/cronjob/dovecot
@@ -1,0 +1,1 @@
+/usr/bin/doveadm fts rescan -A

--- a/conf/cronjob/solr
+++ b/conf/cronjob/solr
@@ -1,0 +1,2 @@
+*/1 * * * * root /usr/bin/curl http://127.0.0.1:8080/solr/update?commit=true &>/dev/null
+30 3 * * * root /usr/bin/curl http://127.0.0.1:8080/solr/update?optimize=true &>/dev/null

--- a/conf/solr-jetty.xml
+++ b/conf/solr-jetty.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"  encoding="ISO-8859-1"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+
+<!-- Context configuration file for the Solr web application in Jetty -->
+
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+  <Set name="contextPath">/solr</Set>
+  <Set name="war">/usr/share/solr/web</Set>
+
+  <!-- Set the solr.solr.home system property -->
+  <Call name="setProperty" class="java.lang.System">
+    <Arg type="String">solr.solr.home</Arg>
+    <Arg type="String">/usr/share/solr</Arg>
+  </Call>
+
+  <!-- Enable symlinks -->
+  <!--  <Call name="addAliasCheck">
+    <Arg>
+      <New class="org.eclipse.jetty.server.handler.ContextHandler$ApproveSameSuffixAliases"/>
+    </Arg>
+  </Call>-->
+</Configure>

--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -38,7 +38,7 @@ def get_services():
 		{ "name": "Mail Filters (Sieve/dovecot)", "port": 4190, "public": True, },
 		{ "name": "HTTP Web (nginx)", "port": 80, "public": True, },
 		{ "name": "HTTPS Web (nginx)", "port": 443, "public": True, },
-	    { "name": "Solr Full Text Search (tomcat)", "port": 8080, "public": False, },
+		{ "name": "Solr Full Text Search (Jetty)", "port": 8080, "public": False, },
 	]
 
 def run_checks(rounded_values, env, output, pool):

--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -38,6 +38,7 @@ def get_services():
 		{ "name": "Mail Filters (Sieve/dovecot)", "port": 4190, "public": True, },
 		{ "name": "HTTP Web (nginx)", "port": 80, "public": True, },
 		{ "name": "HTTPS Web (nginx)", "port": 443, "public": True, },
+	    { "name": "Solr Full Text Search (tomcat)", "port": 8080, "public": False, },
 	]
 
 def run_checks(rounded_values, env, output, pool):

--- a/setup/solr.sh
+++ b/setup/solr.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Inspired by the solr.sh from jkaberg (https://github.com/jkaberg/mailinabox-sogo)
+# with some modifications
+#
+# IMAP search with lucene via solr
+# --------------------------------
+#
+# By default dovecot uses its own Squat search index that has awful performance
+# on large mailboxes. Dovecot 2.1+ has support for using Lucene internally but
+# this didn't make it into the Ubuntu packages, so we use Solr instead to run
+# Lucene for us.
+#
+# Solr runs as a tomcat process. The dovecot solr plugin talks to solr via its
+# HTTP interface, causing mail to be indexed when searches occur, and getting
+# results back.
+
+source setup/functions.sh # load our functions
+source /etc/mailinabox.conf # load global vars
+
+# Install packages and basic configuation
+# ---------------------------------------
+
+echo "Installing Solr..."
+
+# Install packages
+apt_install solr-tomcat dovecot-solr
+
+# Solr requires a schema to tell it how to index data, this is provided by dovecot
+cp /usr/share/dovecot/solr-schema.xml /etc/solr/conf/schema.xml
+
+# Update the dovecot plugin configuration
+#
+# Break-imap-search makes search work the way users expect, rather than the way
+# the IMAP specification expects
+tools/editconf.py /etc/dovecot/conf.d/10-mail.conf \
+        mail_plugins="fts fts_solr"
+
+cat > /etc/dovecot/conf.d/90-plugin-fts.conf << EOF;
+plugin {
+  fts = solr
+  fts_autoindex = yes
+  fts_solr = break-imap-search url=http://127.0.0.1:8080/solr/
+}
+EOF
+
+# Bump memory allocation for Solr.
+# Not needed? I'll let it sit here for a while.
+#echo 'export JAVA_OPTS=-Xms512M -Xmx1024M' > /usr/share/tomcat7/bin/setenv.sh
+
+# Install cronjobs to keep FTS up to date
+hide_output install -m 755 conf/cronjob/dovecot /etc/cron.daily/
+hide_output install -m 644 conf/cronjob/solr /etc/cron.d/
+
+# PERMISSIONS
+
+# Ensure configuration files are owned by dovecot and not world readable.
+chown -R mail:dovecot /etc/dovecot
+chmod -R o-rwx /etc/dovecot
+
+# Restart services to reload solr schema & dovecot plugins
+restart_service tomcat8
+restart_service dovecot

--- a/setup/solr.sh
+++ b/setup/solr.sh
@@ -92,7 +92,7 @@ cat > /etc/logrotate.d/jetty9.conf <<EOF
 /var/log/jetty-console.log {
     copytruncate
     weekly
-    rotate 52
+    rotate 12
     compress
     delaycompress
     missingok

--- a/setup/solr.sh
+++ b/setup/solr.sh
@@ -58,6 +58,7 @@ chmod -R o-rwx /etc/dovecot
 
 # Newer updates to jetty9 restrict write directories, this allows for
 # jetty to write to solr database directories
+mkdir -p /etc/systemd/system/jetty9.service.d/
 cat > /etc/systemd/system/jetty9.service.d/solr-permissions.conf << EOF
 [Service]
 ReadWritePaths=/var/lib/solr/

--- a/setup/solr.sh
+++ b/setup/solr.sh
@@ -28,6 +28,9 @@ apt_install solr-jetty dovecot-solr
 # Solr requires a schema to tell it how to index data, this is provided by dovecot
 cp /usr/share/dovecot/solr-schema.xml /etc/solr/conf/schema.xml
 
+# Default config has an error with our config, placing our custom version
+cp conf/solr-jetty.xml  /etc/solr/solr-jetty.xml
+
 # Update the dovecot plugin configuration
 #
 # Break-imap-search makes search work the way users expect, rather than the way

--- a/setup/solr.sh
+++ b/setup/solr.sh
@@ -61,3 +61,18 @@ chmod -R o-rwx /etc/dovecot
 # Restart services to reload solr schema & dovecot plugins
 restart_service tomcat8
 restart_service dovecot
+
+
+# Kickoff building the index
+
+# Per doveadm-fts manpage: Scan what mails exist in the full text search index
+# and compare those to what actually exist in mailboxes.
+# This removes mails from the index that have already been expunged  and  makes
+# sure that the next doveadm index will index all the missing mails (if any).
+doveadm fts rescan -A
+
+# Adds unindexed files to the fts database
+# * `-q`: Queues the indexing to be run by indexer process. (will background the indexing)
+# * `-A`: All users
+# * `'*'`: All folders
+doveadm index -q -A '*'

--- a/setup/start.sh
+++ b/setup/start.sh
@@ -102,6 +102,7 @@ source setup/dns.sh
 source setup/mail-postfix.sh
 source setup/mail-dovecot.sh
 source setup/mail-users.sh
+source setup/solr.sh
 source setup/dkim.sh
 source setup/spamassassin.sh
 source setup/web.sh

--- a/setup/web.sh
+++ b/setup/web.sh
@@ -48,6 +48,13 @@ tools/editconf.py /etc/php/7.2/fpm/php.ini -c ';' \
 tools/editconf.py /etc/php/7.2/fpm/php.ini -c ';' \
         default_charset="UTF-8"
 
+# Set higher timeout since searches with Roundcube and Solr may take longer
+# than the default 60 seconds. We will also match Roundcube's timeout to the
+# same value
+tools/editconf.py /etc/php/7.2/fpm/php.ini -c ';' \
+        default_socket_timeout=180
+
+
 # Switch from the dynamic process manager to the ondemand manager see #1216
 tools/editconf.py /etc/php/7.2/fpm/pool.d/www.conf -c ';' \
 	pm=ondemand

--- a/setup/web.sh
+++ b/setup/web.sh
@@ -54,7 +54,6 @@ tools/editconf.py /etc/php/7.2/fpm/php.ini -c ';' \
 tools/editconf.py /etc/php/7.2/fpm/php.ini -c ';' \
         default_socket_timeout=180
 
-
 # Switch from the dynamic process manager to the ondemand manager see #1216
 tools/editconf.py /etc/php/7.2/fpm/pool.d/www.conf -c ';' \
 	pm=ondemand

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -108,7 +108,7 @@ cat > $RCM_CONFIG <<EOF;
      'verify_peer_name'  => false,
    ),
  );
-\$config['imap_timeout'] = 15;
+\$config['imap_timeout'] = 180;
 \$config['smtp_server'] = 'tls://127.0.0.1';
 \$config['smtp_port'] = 587;
 \$config['smtp_user'] = '%u';


### PR DESCRIPTION
PR adds full text search using solr-jetty package instead of tomcat like #1506.  I've been using this PR for a few months and it's been working well.  Search in Webmail, Android IMAP (I use Nine on Android), and with Z-Push 2.5.0, Nine on Android works when using Exchange.

I feel like solr-jetty uses less memory than the Tomcat version does.

```
root@m:~# find /home/user-data/mail/mailboxes/ | wc -l
29063
root@m:~# uptime
 10:39:49 up 2 days,  3:28,  1 user,  load average: 0.27, 0.13, 0.10
root@m:~# free -m
              total        used        free      shared  buff/cache   available
Mem:            985         564         115          59         305         218
Swap:          1535          56        1479
```