### PR TITLE
Open csr_country_codes as a utf-8 file

### DIFF
--- a/management/daemon.py
+++ b/management/daemon.py
@@ -23,7 +23,7 @@ except OSError:
 
 # for generating CSRs we need a list of country codes
 csr_country_codes = []
-with open(os.path.join(os.path.dirname(me), "csr_country_codes.tsv")) as f:
+with open(os.path.join(os.path.dirname(me), "csr_country_codes.tsv"), encoding="utf-8") as f:
 	for line in f:
 		if line.strip() == "" or line.startswith("#"): continue
 		code, name = line.strip().split("\t")[0:2]


### PR DESCRIPTION
Prevent issues like :

Jul 08 14:07:44 box.hostname.com systemd[1]: Started Mail-in-a-Box System Management Service.
Jul 08 14:07:44 box.hostname.com start[13602]: Traceback (most recent call last):
Jul 08 14:07:44 box.hostname.com start[13602]:   File "/root/mailinabox/management/daemon.py", line 27, in <module>
Jul 08 14:07:44 box.hostname.com start[13602]:     for line in f:
Jul 08 14:07:44 box.hostname.com start[13602]:   File "/usr/local/lib/mailinabox/env/lib/python3.6/encodings/ascii.py
Jul 08 14:07:44 box.hostname.com start[13602]:     return codecs.ascii_decode(input, self.errors)[0]
Jul 08 14:07:44 box.hostname.com start[13602]: UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 7
Jul 08 14:07:44 box.hostname.com systemd[1]: mailinabox.service: Main process exited, code=exited, status=1/FAILURE
Jul 08 14:07:44 box.hostname.com systemd[1]: mailinabox.service: Failed with result 'exit-code'.