### PR TITLE
Add AAAA records for autodiscover & autoconfig

### DIFF
--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -288,14 +288,20 @@ def build_zone(domain, all_domains, additional_records, www_redirect_domains, en
 			if not has_rec(qname, "SRV"):
 				records.append((qname, "SRV", "0 0 443 " + env["PRIMARY_HOSTNAME"] + ".", "Recommended. Specifies the hostname of the server that handles CardDAV/CalDAV services for email addresses on this domain."))
 
-        # Adds autoconfiguration A records for all domains.
-        # This allows the following clients to automatically configure email addresses in the respective applications.
-        # autodiscover.* - Z-Push ActiveSync Autodiscover
-        # autoconfig.* - Thunderbird Autoconfig
-	if not has_rec("autodiscover", "A"):
-		records.append(("autodiscover", "A", env["PUBLIC_IP"], "Provides email configuration autodiscovery support for Z-Push ActiveSync Autodiscover."))
-	if not has_rec("autoconfig", "A"):
-		records.append(("autoconfig", "A", env["PUBLIC_IP"], "Provides email configuration autodiscovery support for Thunderbird Autoconfig."))
+	# Adds autoconfiguration A records for all domains.
+	# This allows the following clients to automatically configure email addresses in the respective applications.
+	# autodiscover.* - Z-Push ActiveSync Autodiscover
+	# autoconfig.* - Thunderbird Autoconfig
+	autodiscover_records = [
+		("autodiscover", "A", env["PUBLIC_IP"], "Provides email configuration autodiscovery support for Z-Push ActiveSync Autodiscover."),
+		("autodiscover", "AAAA", env["PUBLIC_IPV6"], "Provides email configuration autodiscovery support for Z-Push ActiveSync Autodiscover."),
+		("autoconfig", "A", env["PUBLIC_IP"], "Provides email configuration autodiscovery support for Thunderbird Autoconfig."),
+		("autoconfig", "AAAA", env["PUBLIC_IPV6"], "Provides email configuration autodiscovery support for Thunderbird Autoconfig.")
+	]
+	for qname, rtype, value, explanation in autodiscover_records:
+		if value is None or value.strip() == "": continue # skip IPV6 if not set
+		if not has_rec(qname, rtype):
+			records.append((qname, rtype, value, explanation))
 
 	# Sort the records. The None records *must* go first in the nsd zone file. Otherwise it doesn't matter.
 	records.sort(key = lambda rec : list(reversed(rec[0].split(".")) if rec[0] is not None else ""))


### PR DESCRIPTION
In researching autodiscover for Exchange and autoconfig for Thunderbird.  There were only ever references to A record lookups in the specs.  I found [this](https://discourse.mailinabox.email/t/after-upgrading-to-v0-42-autoconfig-domain-tld-and-autodiscover-domain-tld-are-added-as-normal-domains/5129) post in the forums that referenced issues getting ssl certs because the AAAA records were missing for autodiscover.* and autoconfig.*.

It appears that certbot may have [issues](https://community.letsencrypt.org/t/certbot-ipv6-not-configured-and-challenges-fail-ipv6-preferred/34645) with not having both ipv6 & ipv4 addresses for a domain. (perhaps it globs all of the dns records for domains it intends to get on the same cert?).  PR adds AAAA records if host has an IPV6 address. 

I was not using ipv6 until today. I tested the PR, it adds the AAAA dns entries.  I deleted my autoconfig certs and was able to re-issue certs for them.  `grep "GET /.well-known/acme-challenge" /var/log/nginx/access.log` confirms ipv6 was used to verify the http-01 challenge.