### PR TITLE
make it possible to use subnet addresses for axfr

### DIFF
--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -903,8 +903,12 @@ def set_secondary_dns(hostnames, env):
 			else:
 				# Validate IP address.
 				try:
-					v = ipaddress.ip_address(item[4:]) # raises a ValueError if there's a problem
-					if not isinstance(v, ipaddress.IPv4Address): raise ValueError("That's an IPv6 address.")
+                    if "/" in item[4:]:
+                        v = ipaddress.ip_network(item[4:] # raises a ValueError if there's a problem
+                        if not isinstance(v, ipaddress.IPv4Network): raise ValueError("That's an IPv6 subnet.")
+                    else:
+					    v = ipaddress.ip_address(item[4:]) # raises a ValueError if there's a problem
+					    if not isinstance(v, ipaddress.IPv4Address): raise ValueError("That's an IPv6 address.")
 				except ValueError:
 					raise ValueError("'%s' is not an IPv4 address." % item[4:])
 


### PR DESCRIPTION
it is sometimes needed to be able to set axfr to more than just one ip address. This can be done with multiple xfr: in  the secondary dns input but if you need to add an entire subnet segment (xxx.xxx.xxx.0/yy) then it will not work.
With this patch it is now possible to use a subnet as input for xfr the same way as if it was an ip address.