### PR TITLE
OpenDKIM canonicalization changed to relaxed for headers

### DIFF
--- a/setup/dkim.sh
+++ b/setup/dkim.sh
@@ -31,6 +31,7 @@ if grep -q "ExternalIgnoreList" /etc/opendkim.conf; then
 else
 	# Add various configuration options to the end of `opendkim.conf`.
 	cat >> /etc/opendkim.conf << EOF;
+Canonicalization		relaxed/simple
 MinimumKeyBits          1024
 ExternalIgnoreList      refile:/etc/opendkim/TrustedHosts
 InternalHosts           refile:/etc/opendkim/TrustedHosts


### PR DESCRIPTION
Because Mailman reformats headers it breaks DKIM signatures. SPF also does not apply to mailing lists. This together causes DMARC to fail and all emails sent from the box are rejected. This change fixes DKIM signatures for Mailman-based mailing lists and makes sure DMARC test is passed.

After this change, the signature is not that strict, but it should still be sufficient.