### PR TITLE
Write rsync settings before validating

### DIFF
--- a/management/backup.py
+++ b/management/backup.py
@@ -473,6 +473,8 @@ def backup_set_custom(env, target, target_user, target_pass, min_age):
 	config["target_pass"] = target_pass
 	config["min_age_in_days"] = min_age
 
+    write_backup_config(env, config)
+        
 	# Validate.
 	try:
 		if config["target"] not in ("off", "local"):
@@ -481,8 +483,6 @@ def backup_set_custom(env, target, target_user, target_pass, min_age):
 			list_target_files(config)
 	except ValueError as e:
 		return str(e)
-
-	write_backup_config(env, config)
 
 	return "OK"
 


### PR DESCRIPTION
I understand the philosophy behind not saving until validated, but there are many examples in software where this is not true.  For instance, setting up a mail account in Thunderbird or outlook.  You can use the wrong settings on initial setup (indeed, outlook forces you to in some circumstances) then go repair them later.  This also solves the second issue I raised in mail-in-a-box#1624 because running backup.py --validate will try to use the new settings, just like the Unkown Error case error message implies it should.