### PR TITLE
Change Nextcloud upgrade logic to look at config.php version vs version.php version

### DIFF
--- a/setup/nextcloud.sh
+++ b/setup/nextcloud.sh
@@ -25,11 +25,11 @@ InstallNextcloud() {
 	echo "Upgrading to Nextcloud version $version"
 	echo
 
+        # Download and verify
+        wget_verify https://download.nextcloud.com/server/releases/nextcloud-$version.zip $hash /tmp/nextcloud.zip
+
 	# Remove the current owncloud/Nextcloud
 	rm -rf /usr/local/lib/owncloud
-
-	# Download and verify
-	wget_verify https://download.nextcloud.com/server/releases/nextcloud-$version.zip $hash /tmp/nextcloud.zip
 
 	# Extract ownCloud/Nextcloud
 	unzip -q /tmp/nextcloud.zip -d /usr/local/lib

--- a/setup/nextcloud.sh
+++ b/setup/nextcloud.sh
@@ -90,11 +90,20 @@ InstallNextcloud() {
 	fi
 }
 
+# Nextcloud Version to install. Checks are done down below to step through intermediate versions.
 nextcloud_ver=15.0.8
 nextcloud_hash=4129d8d4021c435f2e86876225fb7f15adf764a3
-# Check if Nextcloud dir exist, and check if version matches nextcloud_ver (if either doesn't - install/upgrade)
-if [ ! -d /usr/local/lib/owncloud/ ] \
-		|| ! grep -q $nextcloud_ver /usr/local/lib/owncloud/version.php; then
+
+# Current Nextcloud Version, #1623
+# Checking /usr/local/lib/owncloud/version.php shows version of the Nextcloud application, not the DB
+# $STORAGE_ROOT/owncloud is kept together even during a backup.  It is better to rely on config.php than
+# version.php since the restore procedure can leave the system in a state where you have a newer Nextcloud
+# application version than the database.
+CURRENT_NEXTCLOUD_VER=$(php -r "include(\"$STORAGE_ROOT/owncloud/config.php\"); echo(\$CONFIG['version']);")
+
+# If the Nextcloud directory is missing (never been installed before, or the nextcloud version to be installed is different
+# from the version currently installed, do the install/upgrade
+if [ ! -d /usr/local/lib/owncloud/ ] || [[ ! $nextcloud_ver =~ ^${CURRENT_NEXTCLOUD_VER} ]]; then
 
 	# Stop php-fpm if running. If theyre not running (which happens on a previously failed install), dont bail.
 	service php7.2-fpm stop &> /dev/null || /bin/true
@@ -115,25 +124,21 @@ if [ ! -d /usr/local/lib/owncloud/ ] \
 	fi
 
 	# If ownCloud or Nextcloud was previously installed....
-	if [ -e /usr/local/lib/owncloud/version.php ]; then
+	if [ ! -z ${CURRENT_NEXTCLOUD_VER} ]; then
 		# Database migrations from ownCloud are no longer possible because ownCloud cannot be run under
 		# PHP 7.
-		if grep -q "OC_VersionString = '[89]\." /usr/local/lib/owncloud/version.php; then
+		if [[ ${CURRENT_NEXTCLOUD_VER} =~ ^[89] ]]; then
 			echo "Upgrades from Mail-in-a-Box prior to v0.28 (dated July 30, 2018) with Nextcloud < 13.0.6 (you have ownCloud 8 or 9) are not supported. Upgrade to Mail-in-a-Box version v0.30 first. Setup aborting."
 			exit 1
-		fi
-		if grep -q "OC_VersionString = '1[012]\." /usr/local/lib/owncloud/version.php; then
+		elif [[ ${CURRENT_NEXTCLOUD_VER} =~ ^1[012] ]]; then
 			echo "Upgrades from Mail-in-a-Box prior to v0.28 (dated July 30, 2018) with Nextcloud < 13.0.6 (you have ownCloud 10, 11 or 12) are not supported. Upgrade to Mail-in-a-Box version v0.30 first. Setup aborting."
 			exit 1
-		fi
-		# If we are running Nextcloud 13, upgrade to Nextcloud 14
-		if grep -q "OC_VersionString = '13\." /usr/local/lib/owncloud/version.php; then
+		elif [[ ${CURRENT_NEXTCLOUD_VER} =~ ^13 ]]; then
+			# If we are running Nextcloud 13, upgrade to Nextcloud 14
 			InstallNextcloud 14.0.6 4e43a57340f04c2da306c8eea98e30040399ae5a
-
-		fi
-		# During the upgrade from Nextcloud 14 to 15, user_external may cause the upgrade to fail.
-		# We will disable it here before the upgrade and install it again after the upgrade.
-		if grep -q "OC_VersionString = '14\." /usr/local/lib/owncloud/version.php; then
+		elif [[ ${CURRENT_NEXTCLOUD_VER} =~ ^14 ]]; then
+			# During the upgrade from Nextcloud 14 to 15, user_external may cause the upgrade to fail.
+			# We will disable it here before the upgrade and install it again after the upgrade.
 			hide_output sudo -u www-data php /usr/local/lib/owncloud/console.php app:disable user_external
 		fi
 	fi

--- a/setup/nextcloud.sh
+++ b/setup/nextcloud.sh
@@ -103,7 +103,7 @@ CURRENT_NEXTCLOUD_VER=$(php -r "include(\"$STORAGE_ROOT/owncloud/config.php\"); 
 
 # If the Nextcloud directory is missing (never been installed before, or the nextcloud version to be installed is different
 # from the version currently installed, do the install/upgrade
-if [ ! -d /usr/local/lib/owncloud/ ] || [[ ! $nextcloud_ver =~ ^${CURRENT_NEXTCLOUD_VER} ]]; then
+if [ ! -d /usr/local/lib/owncloud/ ] || [[ ! ${CURRENT_NEXTCLOUD_VER} =~ ^$nextcloud_ver ]]; then
 
 	# Stop php-fpm if running. If theyre not running (which happens on a previously failed install), dont bail.
 	service php7.2-fpm stop &> /dev/null || /bin/true

--- a/setup/nextcloud.sh
+++ b/setup/nextcloud.sh
@@ -99,7 +99,13 @@ nextcloud_hash=4129d8d4021c435f2e86876225fb7f15adf764a3
 # $STORAGE_ROOT/owncloud is kept together even during a backup.  It is better to rely on config.php than
 # version.php since the restore procedure can leave the system in a state where you have a newer Nextcloud
 # application version than the database.
-CURRENT_NEXTCLOUD_VER=$(php -r "include(\"$STORAGE_ROOT/owncloud/config.php\"); echo(\$CONFIG['version']);")
+
+# If config.php exists, get version number, otherwise CURRENT_NEXTCLOUD_VER is empty.
+if [ -f "$STORAGE_ROOT/owncloud/config.php" ]; then
+	CURRENT_NEXTCLOUD_VER=$(php -r "include(\"$STORAGE_ROOT/owncloud/config.php\"); echo(\$CONFIG['version']);")
+else
+	CURRENT_NEXTCLOUD_VER=""
+fi
 
 # If the Nextcloud directory is missing (never been installed before, or the nextcloud version to be installed is different
 # from the version currently installed, do the install/upgrade


### PR DESCRIPTION
Fix for #1623

PR changes so that Nextcloud download is wget_verify before deleting the install directory.  Additionally #1623 raised the issue that /usr/local/lib/owncloud/version.php was being used instead of version of user data.  So scenario's where data has been restored from an old version of MIAB on a new one, those versions would differ.


Tested as follows:
Fresh 18.04 install
Installed git master
restored data from v0.40 (running Nextcloud 13)
tested PR:
```
git remote add jvolkenant https://github.com/jvolkenant/mailinabox.git
git fetch jvolkenant
git checkout master
git merge jvolkenant/nextcloud_multi_version_upgrade
```
Verified version difference between Nextcloud installed from git master and Nextcloud user database restored from backup

```


root@m:~/mailinabox# STORAGE_ROOT=/home/user-data php -r "include(\"$STORAGE_ROOT/owncloud/config.php\"); echo(\$CONFIG['version']);"
13.0.6.1
root@m:~/mailinabox# grep OC_Version /usr/local/lib/owncloud/version.php 
$OC_Version = array(15,0,8,1);
$OC_VersionString = '15.0.8';
$OC_VersionCanBeUpgradedFrom = array (
```
ran setup/start.sh which is git head with PR
```

Primary Hostname: snip
Public IP Address: snip
Mail-in-a-Box Version:  v0.42b-6-g6bbdd75

Updating system packages...
Installing system packages...
Initializing system random number generator...
Firewall is active and enabled on system startup
Installing nsd (DNS server)...
Installing Postfix (SMTP server)...
Installing Dovecot (IMAP server)...
Installing OpenDKIM/OpenDMARC...
Installing SpamAssassin...
Installing Nginx (web server)...
Installing Roundcube (webmail)...
Installing Nextcloud (contacts/calendar)...
Upgrading Nextcloud --- backing up existing installation, configuration, and database to directory to /home/user-data/owncloud-backup/2019-08-23-13:48:39...

Upgrading to Nextcloud version 14.0.6

Nextcloud or one of the apps require upgrade - only a limited number of commands are available
You may use your browser or the occ upgrade command to do the upgrade
Set log level to debug
Turned on maintenance mode
Updating database schema
Updated database
Disabled incompatible app: contacts
Updating <calendar> ...
Updated <calendar> to 1.6.5
Updating <federatedfilesharing> ...
Updated <federatedfilesharing> to 1.4.0
Updating <files_texteditor> ...
Updated <files_texteditor> to 2.6.0
Updating <files_videoplayer> ...
Updated <files_videoplayer> to 1.3.0
Updating <gallery> ...
Updated <gallery> to 18.1.0
Updating <password_policy> ...
Updated <password_policy> to 1.4.0
Updating <provisioning_api> ...
Updated <provisioning_api> to 1.4.0
Updating <serverinfo> ...
Updated <serverinfo> to 1.4.0
Updating <survey_client> ...
Updated <survey_client> to 1.2.0
Updating <twofactor_backupcodes> ...
Updated <twofactor_backupcodes> to 1.3.1
Updating <updatenotification> ...
Updated <updatenotification> to 1.4.1
Updating <federation> ...
Updated <federation> to 1.4.0
Updating <lookup_server_connector> ...
Updated <lookup_server_connector> to 1.2.0
Updating <oauth2> ...
Updated <oauth2> to 1.2.1
Updating <files> ...
Updated <files> to 1.9.0
Updating <activity> ...
Updated <activity> to 2.7.0
Updating <dav> ...
Fix broken values of calendar objects

 Done
    0/0 [>---------------------------]   0%
Updated <dav> to 1.6.1
Updating <files_sharing> ...
Updated <files_sharing> to 1.6.2
Updating <files_trashbin> ...
Updated <files_trashbin> to 1.4.1
Updating <files_versions> ...
Updated <files_versions> to 1.7.1
Updating <sharebymail> ...
Updated <sharebymail> to 1.4.0
Updating <workflowengine> ...
Updated <workflowengine> to 1.4.0
Updating <comments> ...
Updated <comments> to 1.4.0
Updating <nextcloud_announcements> ...
Updated <nextcloud_announcements> to 1.3.0
Updating <notifications> ...
Updated <notifications> to 2.2.1
Updating <systemtags> ...
Updated <systemtags> to 1.4.0
Updating <theming> ...
Updated <theming> to 1.5.0
Checking for update of app activity in appstore
Checked for update of app "activity" in appstore 
Checking for update of app calendar in appstore
Checked for update of app "calendar" in appstore 
Checking for update of app cloud_federation_api in appstore
Checked for update of app "cloud_federation_api" in appstore 
Checking for update of app comments in appstore
Checked for update of app "comments" in appstore 
Checking for update of app dav in appstore
Checked for update of app "dav" in appstore 
Checking for update of app federatedfilesharing in appstore
Checked for update of app "federatedfilesharing" in appstore 
Checking for update of app federation in appstore
Checked for update of app "federation" in appstore 
Checking for update of app files in appstore
Checked for update of app "files" in appstore 
Checking for update of app files_sharing in appstore
Checked for update of app "files_sharing" in appstore 
Checking for update of app files_texteditor in appstore
Checked for update of app "files_texteditor" in appstore 
Checking for update of app files_trashbin in appstore
Checked for update of app "files_trashbin" in appstore 
Checking for update of app files_versions in appstore
Checked for update of app "files_versions" in appstore 
Checking for update of app files_videoplayer in appstore
Checked for update of app "files_videoplayer" in appstore 
Checking for update of app gallery in appstore
Checked for update of app "gallery" in appstore 
Checking for update of app logreader in appstore
Checked for update of app "logreader" in appstore 
Checking for update of app lookup_server_connector in appstore
Checked for update of app "lookup_server_connector" in appstore 
Checking for update of app nextcloud_announcements in appstore
Checked for update of app "nextcloud_announcements" in appstore 
Checking for update of app notifications in appstore
Checked for update of app "notifications" in appstore 
Checking for update of app oauth2 in appstore
Checked for update of app "oauth2" in appstore 
Checking for update of app password_policy in appstore
Checked for update of app "password_policy" in appstore 
Checking for update of app provisioning_api in appstore
Checked for update of app "provisioning_api" in appstore 
Checking for update of app serverinfo in appstore
Checked for update of app "serverinfo" in appstore 
Checking for update of app sharebymail in appstore
Checked for update of app "sharebymail" in appstore 
Checking for update of app survey_client in appstore
Checked for update of app "survey_client" in appstore 
Checking for update of app systemtags in appstore
Checked for update of app "systemtags" in appstore 
Checking for update of app theming in appstore
Checked for update of app "theming" in appstore 
Checking for update of app twofactor_backupcodes in appstore
Checked for update of app "twofactor_backupcodes" in appstore 
Checking for update of app updatenotification in appstore
Checked for update of app "updatenotification" in appstore 
Checking for update of app user_external in appstore
Checked for update of app "user_external" in appstore 
Checking for update of app workflowengine in appstore
Checked for update of app "workflowengine" in appstore 
Starting code integrity check...
Finished code integrity check
Update successful
Turned off maintenance mode
Reset log level
Check indices of the share table.
Adding additional mtime index to the filecache table, this can take some time...
Filecache table updated successfully.
This can take up to hours, depending on the number of files in your instance!

Upgrading to Nextcloud version 15.0.8

Nextcloud or one of the apps require upgrade - only a limited number of commands are available
You may use your browser or the occ upgrade command to do the upgrade
Set log level to debug
Turned on maintenance mode
Updating database schema
Updated database
Updating <accessibility> ...
Updated <accessibility> to 1.1.0
Updating <federatedfilesharing> ...
Updated <federatedfilesharing> to 1.5.0
Updating <files_pdfviewer> ...
Updated <files_pdfviewer> to 1.4.0
Updating <files_texteditor> ...
Updated <files_texteditor> to 2.7.0
Updating <files_videoplayer> ...
Updated <files_videoplayer> to 1.4.0
Updating <gallery> ...
Updated <gallery> to 18.2.0
Updating <password_policy> ...
Updated <password_policy> to 1.5.0
Updating <provisioning_api> ...
Updated <provisioning_api> to 1.5.0
Updating <serverinfo> ...
Updated <serverinfo> to 1.5.0
Updating <survey_client> ...
Updated <survey_client> to 1.3.0
Updating <twofactor_backupcodes> ...
Updated <twofactor_backupcodes> to 1.4.1
Updating <updatenotification> ...
Updated <updatenotification> to 1.5.0
Updating <federation> ...
Updated <federation> to 1.5.0
Updating <lookup_server_connector> ...
Updated <lookup_server_connector> to 1.3.0
Updating <oauth2> ...
Updated <oauth2> to 1.3.0
Updating <user_external> ...
Updated <user_external> to 0.6.3
Updating <files> ...
Updated <files> to 1.10.0
Updating <activity> ...
Updated <activity> to 2.8.2
Updating <cloud_federation_api> ...
Updated <cloud_federation_api> to 0.1.0
Updating <dav> ...
Fix broken values of calendar objects

 Done
    0/0 [>---------------------------]   0%
Updated <dav> to 1.8.2
Updating <files_sharing> ...
Updated <files_sharing> to 1.7.0
Updating <files_trashbin> ...
Updated <files_trashbin> to 1.5.0
Updating <files_versions> ...
Updated <files_versions> to 1.8.0
Updating <sharebymail> ...
Updated <sharebymail> to 1.5.0
Updating <workflowengine> ...
Updated <workflowengine> to 1.5.0
Updating <comments> ...
Updated <comments> to 1.5.0
Updating <nextcloud_announcements> ...
Updated <nextcloud_announcements> to 1.4.0
Updating <notifications> ...
Updated <notifications> to 2.3.0
Updating <systemtags> ...
Updated <systemtags> to 1.5.0
Updating <theming> ...
Updated <theming> to 1.6.0
Checking for update of app accessibility in appstore
Checked for update of app "accessibility" in appstore 
Checking for update of app activity in appstore
Checked for update of app "activity" in appstore 
Checking for update of app calendar in appstore
Checked for update of app "calendar" in appstore 
Checking for update of app cloud_federation_api in appstore
Checked for update of app "cloud_federation_api" in appstore 
Checking for update of app comments in appstore
Checked for update of app "comments" in appstore 
Checking for update of app dav in appstore
Checked for update of app "dav" in appstore 
Checking for update of app federatedfilesharing in appstore
Checked for update of app "federatedfilesharing" in appstore 
Checking for update of app federation in appstore
Checked for update of app "federation" in appstore 
Checking for update of app files in appstore
Checked for update of app "files" in appstore 
Checking for update of app files_pdfviewer in appstore
Checked for update of app "files_pdfviewer" in appstore 
Checking for update of app files_sharing in appstore
Checked for update of app "files_sharing" in appstore 
Checking for update of app files_texteditor in appstore
Checked for update of app "files_texteditor" in appstore 
Checking for update of app files_trashbin in appstore
Checked for update of app "files_trashbin" in appstore 
Checking for update of app files_versions in appstore
Checked for update of app "files_versions" in appstore 
Checking for update of app files_videoplayer in appstore
Checked for update of app "files_videoplayer" in appstore 
Checking for update of app gallery in appstore
Checked for update of app "gallery" in appstore 
Checking for update of app logreader in appstore
Checked for update of app "logreader" in appstore 
Checking for update of app lookup_server_connector in appstore
Checked for update of app "lookup_server_connector" in appstore 
Checking for update of app nextcloud_announcements in appstore
Checked for update of app "nextcloud_announcements" in appstore 
Checking for update of app notifications in appstore
Checked for update of app "notifications" in appstore 
Checking for update of app oauth2 in appstore
Checked for update of app "oauth2" in appstore 
Checking for update of app password_policy in appstore
Checked for update of app "password_policy" in appstore 
Checking for update of app provisioning_api in appstore
Checked for update of app "provisioning_api" in appstore 
Checking for update of app serverinfo in appstore
Checked for update of app "serverinfo" in appstore 
Checking for update of app sharebymail in appstore
Checked for update of app "sharebymail" in appstore 
Checking for update of app support in appstore
Checked for update of app "support" in appstore 
Checking for update of app survey_client in appstore
Checked for update of app "survey_client" in appstore 
Checking for update of app systemtags in appstore
Checked for update of app "systemtags" in appstore 
Checking for update of app theming in appstore
Checked for update of app "theming" in appstore 
Checking for update of app twofactor_backupcodes in appstore
Checked for update of app "twofactor_backupcodes" in appstore 
Checking for update of app updatenotification in appstore
Checked for update of app "updatenotification" in appstore 
Checking for update of app user_external in appstore
Update app user_external from appstore
Checked for update of app "user_external" in appstore 
Checking for update of app workflowengine in appstore
Checked for update of app "workflowengine" in appstore 
Remove potentially over exposing share links
 Done
    0/0 [>---------------------------]   0%
Starting code integrity check...
Finished code integrity check
Update successful
Turned off maintenance mode
Reset log level
Check indices of the share table.
Adding additional owner index to the share table, this can take some time...
Share table updated successfully.
Adding additional initiator index to the share table, this can take some time...
Share table updated successfully.
All tables already up to date!
Nextcloud is already latest version
Installing Z-Push (Exchange/ActiveSync server)...
Installing Mail-in-a-Box system management daemon...
Installing Munin (system monitoring)...
updated DNS: snip
web updated

-----------------------------------------------

Your Mail-in-a-Box is running.

Please log in to the control panel for further instructions at:

https://snip/admin

You will be alerted that the website has an invalid certificate. Check that
the certificate fingerprint matches:

9C...snip

Then you can confirm the security exception and continue.
```