### PR TITLE
Fix an issue when Secondary NS has multiple A records

### DIFF
--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -486,10 +486,12 @@ def check_dns_zone(domain, env, output, dns_zonefiles):
 	if custom_secondary_ns and not probably_external_dns:
 		for ns in custom_secondary_ns:
 			# We must first resolve the nameserver to an IP address so we can query it.
-			ns_ip = query_dns(ns, "A")
-			if not ns_ip:
+			ns_ips = query_dns(ns, "A")
+			if not ns_ips:
 				output.print_error("Secondary nameserver %s is not valid (it doesn't resolve to an IP address)." % ns)
 				continue
+			# Choose the first IP if nameserver returns multiple
+			ns_ip = ns_ips.split('; ')[0]
 
 			# Now query it to see what it says about this domain.
 			ip = query_dns(domain, "A", at=ns_ip, nxdomain=None)


### PR DESCRIPTION
Fix for #1485 

If a custom secondary NS server has multiple A records status_checks.py will fail with a timeout and Web UI won't load.
_query_dns_ method may return multiple IPs separated by "; ", but _at_ parameter for the same method only works with one IP passed. 
This fix gets the first IP if multiple were returned and performs a secondary NS validation on it.
Another approach would be to perform checks on all IPs, which will work fine on example in #1485 as it returns only 2 IPs, but if there are many more returned, it may delay checks for a prolonged period of time, which may not be necessary.
An example of such server may be found in #1485 , like ns2.1984.is that currently returns

    nslookup ns2.1984.is 1.1.1.1
    Server:		1.1.1.1
    Address:	1.1.1.1#53
    
    Non-authoritative answer:
    Name:	ns2.1984.is
    Address: 93.95.226.52
    Name:	ns2.1984.is
    Address:  45.32.180.186 `