### PR TITLE
Updated UI so navbar links only show for logged in

### DIFF
--- a/management/daemon.py
+++ b/management/daemon.py
@@ -31,6 +31,9 @@ with open(os.path.join(os.path.dirname(me), "csr_country_codes.tsv")) as f:
 
 app = Flask(__name__, template_folder=os.path.abspath(os.path.join(os.path.dirname(me), "templates")))
 
+# Variable to determine if the user is logged in, for UI
+is_logged_in = False
+
 # Decorator to protect views that require a user with 'admin' privileges.
 def authorized_personnel_only(viewfunc):
 	@wraps(viewfunc)
@@ -49,6 +52,8 @@ def authorized_personnel_only(viewfunc):
 
 		# Authorized to access an API view?
 		if "admin" in privs:
+			# User is now logged in
+			is_logged_in = True
 			# Call view func.
 			return viewfunc(*args, **kwargs)
 		elif not error:
@@ -108,6 +113,8 @@ def index():
 
 		no_users_exist=no_users_exist,
 		no_admins_exist=no_admins_exist,
+
+		is_logged_in=is_logged_in
 
 		backup_s3_hosts=backup_s3_hosts,
 		csr_country_codes=csr_country_codes,
@@ -334,7 +341,7 @@ def ssl_get_status():
 
 	# What domains can we provision certificates for? What unexpected problems do we have?
 	provision, cant_provision = get_certificates_to_provision(env, show_valid_certs=False)
-	
+
 	# What's the current status of TLS certificates on all of the domain?
 	domains_status = get_web_domains_info(env)
 	domains_status = [

--- a/management/daemon.py
+++ b/management/daemon.py
@@ -151,6 +151,23 @@ def me():
 	# Return.
 	return json_response(resp)
 
+@app.route('/logout')
+def user_logout():
+	global is_logged_in
+
+	# Is the caller logged in?
+	if is_logged_in == True:
+		# User is now logged out
+		is_logged_in = False
+		return json_response({
+			"status": "ok"
+		})
+
+	# Return.
+	return json_response({
+		"status": "invalid"
+	})
+
 # MAIL
 
 @app.route('/mail/users')

--- a/management/daemon.py
+++ b/management/daemon.py
@@ -53,6 +53,7 @@ def authorized_personnel_only(viewfunc):
 		# Authorized to access an API view?
 		if "admin" in privs:
 			# User is now logged in
+			global is_logged_in
 			is_logged_in = True
 			# Call view func.
 			return viewfunc(*args, **kwargs)
@@ -114,7 +115,7 @@ def index():
 		no_users_exist=no_users_exist,
 		no_admins_exist=no_admins_exist,
 
-		is_logged_in=is_logged_in
+		is_logged_in=is_logged_in,
 
 		backup_s3_hosts=backup_s3_hosts,
 		csr_country_codes=csr_country_codes,
@@ -142,6 +143,9 @@ def me():
 
 	# Is authorized as admin? Return an API key for future use.
 	if "admin" in privs:
+		# User is now logged in
+		global is_logged_in
+		is_logged_in = True
 		resp["api_key"] = auth_service.create_user_key(email, env)
 
 	# Return.

--- a/management/templates/index.html
+++ b/management/templates/index.html
@@ -82,34 +82,40 @@
           <a class="navbar-brand" href="#">{{hostname}}</a>
         </div>
         <div class="navbar-collapse collapse">
-          <ul class="nav navbar-nav">
-            <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">System <b class="caret"></b></a>
-              <ul class="dropdown-menu">
-                <li><a href="#system_status" onclick="return show_panel(this);">Status Checks</a></li>
-                <li><a href="#tls" onclick="return show_panel(this);">TLS (SSL) Certificates</a></li>
-                <li><a href="#system_backup" onclick="return show_panel(this);">Backup Status</a></li>
-                <li class="divider"></li>
-                <li class="dropdown-header">Advanced Pages</li>
-                <li><a href="#custom_dns" onclick="return show_panel(this);">Custom DNS</a></li>
-                <li><a href="#external_dns" onclick="return show_panel(this);">External DNS</a></li>
-                <li><a href="/admin/munin" target="_blank">Munin Monitoring</a></li>
-              </ul>
-            </li>
-            <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">Mail <b class="caret"></b></a>
-              <ul class="dropdown-menu">
-                <li><a href="#mail-guide" onclick="return show_panel(this);">Instructions</a></li>
-                <li><a href="#users" onclick="return show_panel(this);">Users</a></li>
-                <li><a href="#aliases" onclick="return show_panel(this);">Aliases</a></li>
-              </ul>
-            </li>
-            <li><a href="#sync_guide" onclick="return show_panel(this);">Contacts/Calendar</a></li>
-            <li><a href="#web" onclick="return show_panel(this);">Web</a></li>
-          </ul>
-          <ul class="nav navbar-nav navbar-right">
-            <li><a href="#" onclick="do_logout(); return false;" style="color: white">Log out</a></li>
-          </ul>
+          {% if is_logged_in %}
+            <ul class="nav navbar-nav">
+              <li class="dropdown">
+                <a href="#" class="dropdown-toggle" data-toggle="dropdown">System <b class="caret"></b></a>
+                <ul class="dropdown-menu">
+                  <li><a href="#system_status" onclick="return show_panel(this);">Status Checks</a></li>
+                  <li><a href="#tls" onclick="return show_panel(this);">TLS (SSL) Certificates</a></li>
+                  <li><a href="#system_backup" onclick="return show_panel(this);">Backup Status</a></li>
+                  <li class="divider"></li>
+                  <li class="dropdown-header">Advanced Pages</li>
+                  <li><a href="#custom_dns" onclick="return show_panel(this);">Custom DNS</a></li>
+                  <li><a href="#external_dns" onclick="return show_panel(this);">External DNS</a></li>
+                  <li><a href="/admin/munin" target="_blank">Munin Monitoring</a></li>
+                </ul>
+              </li>
+              <li class="dropdown">
+                <a href="#" class="dropdown-toggle" data-toggle="dropdown">Mail <b class="caret"></b></a>
+                <ul class="dropdown-menu">
+                  <li><a href="#mail-guide" onclick="return show_panel(this);">Instructions</a></li>
+                  <li><a href="#users" onclick="return show_panel(this);">Users</a></li>
+                  <li><a href="#aliases" onclick="return show_panel(this);">Aliases</a></li>
+                </ul>
+              </li>
+              <li><a href="#sync_guide" onclick="return show_panel(this);">Contacts/Calendar</a></li>
+              <li><a href="#web" onclick="return show_panel(this);">Web</a></li>
+            </ul>
+            <ul class="nav navbar-nav navbar-right">
+              <li><a href="#" onclick="do_logout(); return false;" style="color: white">Log out</a></li>
+            </ul>
+          {% else %}
+            <ul class="nav navbar-nav navbar-right">
+              <li><a href="#" onclick="return show_panel('login');" style="color: white">Log in</a></li>
+            </ul>
+          {% endif %}
         </div><!--/.navbar-collapse -->
       </div>
     </div>

--- a/management/templates/login.html
+++ b/management/templates/login.html
@@ -117,7 +117,10 @@ function do_login() {
       // Open the next panel the user wants to go to. Do this after the XHR response
       // is over so that we don't start a new XHR request while this one is finishing,
       // which confuses the loading indicator.
-      setTimeout(function() { show_panel(!switch_back_to_panel || switch_back_to_panel == "login" ? 'system_status' : switch_back_to_panel) }, 300);
+      setTimeout(function() {
+          window.location = "/admin";
+          show_panel(!switch_back_to_panel || switch_back_to_panel == "login" ? 'system_status' : switch_back_to_panel)
+        }, 300);
     }
   })
 }
@@ -128,7 +131,19 @@ function do_logout() {
     localStorage.removeItem("miab-cp-credentials");
   if (typeof sessionStorage != 'undefined')
     sessionStorage.removeItem("miab-cp-credentials");
-  show_panel('login');
+
+  api(
+    "/logout",
+    "GET",
+    {},
+    function (response) {
+      // This API call always succeeds. It returns a JSON object
+      // with a status based on whether or not the user was actually logged in.
+      if (response.status == "ok") {
+        window.location = "/admin";
+        show_panel('login');
+      }
+  })
 }
 
 function show_login() {


### PR DESCRIPTION
Something that has bothered me about the MiaB UI has been that the navbar constantly displays the links, regardless of whether or not you're logged in. I do not see it fit from a UI or a UX perspective. 

Simple change that sets `is_logged_in` to `True` only when a user has the `admin` privilege and is able to use the UI. This is passed to the template and is used to control the navbar links. If the user is not logged in, then a link for the login panel is displayed instead, in the far right-hand corner.

The login and logout flow has been updated so that the page is refreshed in order for the navbar to become updated.