### PR TITLE
Updated login, logout flow to show navbar links

### DIFF
--- a/management/templates/index.html
+++ b/management/templates/index.html
@@ -82,34 +82,41 @@
           <a class="navbar-brand" href="#">{{hostname}}</a>
         </div>
         <div class="navbar-collapse collapse">
-          <ul class="nav navbar-nav">
-            <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">System <b class="caret"></b></a>
-              <ul class="dropdown-menu">
-                <li><a href="#system_status" onclick="return show_panel(this);">Status Checks</a></li>
-                <li><a href="#tls" onclick="return show_panel(this);">TLS (SSL) Certificates</a></li>
-                <li><a href="#system_backup" onclick="return show_panel(this);">Backup Status</a></li>
-                <li class="divider"></li>
-                <li class="dropdown-header">Advanced Pages</li>
-                <li><a href="#custom_dns" onclick="return show_panel(this);">Custom DNS</a></li>
-                <li><a href="#external_dns" onclick="return show_panel(this);">External DNS</a></li>
-                <li><a href="/admin/munin" target="_blank">Munin Monitoring</a></li>
-              </ul>
-            </li>
-            <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">Mail <b class="caret"></b></a>
-              <ul class="dropdown-menu">
-                <li><a href="#mail-guide" onclick="return show_panel(this);">Instructions</a></li>
-                <li><a href="#users" onclick="return show_panel(this);">Users</a></li>
-                <li><a href="#aliases" onclick="return show_panel(this);">Aliases</a></li>
-              </ul>
-            </li>
-            <li><a href="#sync_guide" onclick="return show_panel(this);">Contacts/Calendar</a></li>
-            <li><a href="#web" onclick="return show_panel(this);">Web</a></li>
-          </ul>
-          <ul class="nav navbar-nav navbar-right">
-            <li><a href="#" onclick="do_logout(); return false;" style="color: white">Log out</a></li>
-          </ul>
+          <span id="loggedInNav" class="hidden">
+            <ul class="nav navbar-nav">
+              <li class="dropdown">
+                <a href="#" class="dropdown-toggle" data-toggle="dropdown">System <b class="caret"></b></a>
+                <ul class="dropdown-menu">
+                  <li><a href="#system_status" onclick="return show_panel(this);">Status Checks</a></li>
+                  <li><a href="#tls" onclick="return show_panel(this);">TLS (SSL) Certificates</a></li>
+                  <li><a href="#system_backup" onclick="return show_panel(this);">Backup Status</a></li>
+                  <li class="divider"></li>
+                  <li class="dropdown-header">Advanced Pages</li>
+                  <li><a href="#custom_dns" onclick="return show_panel(this);">Custom DNS</a></li>
+                  <li><a href="#external_dns" onclick="return show_panel(this);">External DNS</a></li>
+                  <li><a href="/admin/munin" target="_blank">Munin Monitoring</a></li>
+                </ul>
+              </li>
+              <li class="dropdown">
+                <a href="#" class="dropdown-toggle" data-toggle="dropdown">Mail <b class="caret"></b></a>
+                <ul class="dropdown-menu">
+                  <li><a href="#mail-guide" onclick="return show_panel(this);">Instructions</a></li>
+                  <li><a href="#users" onclick="return show_panel(this);">Users</a></li>
+                  <li><a href="#aliases" onclick="return show_panel(this);">Aliases</a></li>
+                </ul>
+              </li>
+              <li><a href="#sync_guide" onclick="return show_panel(this);">Contacts/Calendar</a></li>
+              <li><a href="#web" onclick="return show_panel(this);">Web</a></li>
+            </ul>
+            <ul class="nav navbar-nav navbar-right">
+              <li><a href="#" onclick="do_logout(); return false;" style="color: white">Log out</a></li>
+            </ul>
+          </span>
+          <span id="guestNav">
+            <ul class="nav navbar-nav navbar-right">
+              <li><a href="#" onclick="return show_panel('login');" style="color: white">Log in</a></li>
+            </ul>
+          </span>
         </div><!--/.navbar-collapse -->
       </div>
     </div>
@@ -382,6 +389,11 @@ $(function() {
     api_credentials = sessionStorage.getItem("miab-cp-credentials").split(":");
   else if (typeof localStorage != 'undefined' && localStorage.getItem("miab-cp-credentials"))
     api_credentials = localStorage.getItem("miab-cp-credentials").split(":");
+
+  if (api_credentials[0].length !== 0) {
+    $("#guestNav").addClass("hidden");
+    $("#loggedInNav").removeClass("hidden");
+  }
 
   // Recall what the user was last looking at.
   if (typeof localStorage != 'undefined' && localStorage.getItem("miab-cp-lastpanel")) {

--- a/management/templates/login.html
+++ b/management/templates/login.html
@@ -117,7 +117,11 @@ function do_login() {
       // Open the next panel the user wants to go to. Do this after the XHR response
       // is over so that we don't start a new XHR request while this one is finishing,
       // which confuses the loading indicator.
-      setTimeout(function() { show_panel(!switch_back_to_panel || switch_back_to_panel == "login" ? 'system_status' : switch_back_to_panel) }, 300);
+      setTimeout(function() {
+          $("#guestNav").addClass("hidden");
+          $("#loggedInNav").removeClass("hidden");
+          show_panel(!switch_back_to_panel || switch_back_to_panel == "login" ? 'system_status' : switch_back_to_panel)
+        }, 300);
     }
   })
 }
@@ -128,6 +132,9 @@ function do_logout() {
     localStorage.removeItem("miab-cp-credentials");
   if (typeof sessionStorage != 'undefined')
     sessionStorage.removeItem("miab-cp-credentials");
+
+  $("#guestNav").addClass("hidden");
+  $("#loggedInNav").removeClass("hidden");
   show_panel('login');
 }
 


### PR DESCRIPTION
Made improvements to the previous version to allow the navbar to be updated based on logged in status. Got away from using any Python to do so, and the code is much more simple. JavaScript snippet on login / logout toggles bootstrap's `hidden` class on two navbar `span` fields in order to show the proper links for the user.