### PR TITLE
Fixed multiple commented add_header entries in /etc/spamassassin/local.cf

### DIFF
--- a/setup/spamassassin.sh
+++ b/setup/spamassassin.sh
@@ -64,8 +64,8 @@ tools/editconf.py /etc/default/spampd \
 # the X-Spam-Status & X-Spam-Score mail headers and related headers.
 tools/editconf.py /etc/spamassassin/local.cf -s \
 	report_safe=0 \
-	add_header="all Report _REPORT_" \
-    add_header="all Score _SCORE_"
+	"add_header all Report"=_REPORT_ \
+	"add_header all Score"=_SCORE_
 
 # Bayesean learning
 # -----------------


### PR DESCRIPTION
Because there are 2 add_header sections being used,  there exists the case that  there are multiple comments left behind when the following command is run:
https://github.com/mail-in-a-box/mailinabox/blob/0c0a0793543005bd2471d79d811a244863e73109/setup/spamassassin.sh#L65-L68

My /etc/spamassasin/local.cf file looks like the following:
```
...snip
pyzor_options --homedir /etc/spamassassin/pyzor
add_header all Report _REPORT_
bayes_path /home/user-data/mail/spamassassin/bayes
bayes_file_mode 0666
#add_header all Score _SCORE_
#add_header all Score _SCORE_
#add_header all Score _SCORE_
#add_header all Score _SCORE_
#add_header all Score _SCORE_
#add_header all Score _SCORE_
#add_header all Score _SCORE_
#add_header all Score _SCORE_
#add_header all Score _SCORE_
#add_header all Score _SCORE_
#add_header all Score _SCORE_
add_header all Score _SCORE_
```

Using the PR...
```
tools/editconf.py /etc/spamassassin/local.cf -s report_safe=0 "add_header all Report"=_REPORT_ "add_header all Score"=_SCORE_

root@m:~/mailinabox# for i in a a a a a ; do tools/editconf.py /etc/spamassassin/local.cf -s         report_safe=0         "add_header all Report"=_REPORT_         "add_header all Score"=_SCORE_; done
root@m:~/mailinabox# tail /etc/spamassassin/local.cf 
#
# shortcircuit BAYES_99                spam
# shortcircuit BAYES_00                ham

endif # Mail::SpamAssassin::Plugin::Shortcircuit
pyzor_options --homedir /etc/spamassassin/pyzor
bayes_path /home/user-data/mail/spamassassin/bayes
bayes_file_mode 0666
add_header all Report _REPORT_
add_header all Score _SCORE_
```

Tested multiple runs.  Doesn't seem to leave multiple erroneous #add_header ... comments
