### PR TITLE
Nextcloud optional

### DIFF
--- a/conf/fail2ban/jails_no_nextcloud.conf
+++ b/conf/fail2ban/jails_no_nextcloud.conf
@@ -1,0 +1,70 @@
+# Fail2Ban configuration file for Mail-in-a-Box. Do not edit.
+# This file is re-generated on updates.
+
+[DEFAULT]
+# Whitelist our own IP addresses. 127.0.0.1/8 is the default. But our status checks
+# ping services over the public interface so we should whitelist that address of
+# ours too. The string is substituted during installation.
+ignoreip = 127.0.0.1/8 PUBLIC_IP
+
+[dovecot]
+enabled = true
+filter  = dovecotimap
+logpath = /var/log/mail.log
+findtime = 30
+maxretry = 20
+
+[miab-management]
+enabled = true
+filter = miab-management-daemon
+port = http,https
+logpath = /var/log/syslog
+maxretry = 20
+findtime = 30
+
+[miab-munin]
+enabled  = true
+port     = http,https
+filter   = miab-munin
+logpath  = /var/log/nginx/access.log
+maxretry = 20
+findtime = 30
+
+[miab-postfix587]
+enabled  = true
+port     = 587
+filter   = miab-postfix-submission
+logpath  = /var/log/mail.log
+maxretry = 20
+findtime = 30
+
+[miab-roundcube]
+enabled  = true
+port     = http,https
+filter   = miab-roundcube
+logpath  = /var/log/roundcubemail/errors
+maxretry = 20
+findtime = 30
+
+[recidive]
+enabled  = true
+maxretry = 10
+action   = iptables-allports[name=recidive]
+# In the recidive section of jail.conf the action contains:
+#
+# action   = iptables-allports[name=recidive]
+#            sendmail-whois-lines[name=recidive, logpath=/var/log/fail2ban.log]
+#
+# The last line on the action will sent an email to the configured address. This mail will
+# notify the administrator that someone has been repeatedly triggering one of the other jails.
+# By default we don't configure this address and no action is required from the admin anyway.
+# So the notification is ommited. This will prevent message appearing in the mail.log that mail
+# can't be delivered to fail2ban@$HOSTNAME.
+
+[postfix-sasl]
+enabled  = true
+
+[sshd]
+enabled = true
+maxretry = 7
+bantime = 3600

--- a/conf/nginx-primaryonly-no-nextcloud.conf
+++ b/conf/nginx-primaryonly-no-nextcloud.conf
@@ -1,0 +1,17 @@
+	# Control Panel
+	# Proxy /admin to our Python based control panel daemon. It is
+	# listening on IPv4 only so use an IP address and not 'localhost'.
+	location /admin/assets {
+		alias /usr/local/lib/mailinabox/vendor/assets;
+	}
+	rewrite ^/admin$ /admin/;
+	rewrite ^/admin/munin$ /admin/munin/ redirect;
+	location /admin/ {
+		proxy_pass http://127.0.0.1:10222/;
+		proxy_set_header X-Forwarded-For $remote_addr;
+		add_header X-Frame-Options "DENY";
+		add_header X-Content-Type-Options nosniff;
+		add_header Content-Security-Policy "frame-ancestors 'none';";
+	}
+
+	# ADDITIONAL DIRECTIVES HERE

--- a/management/templates/sync-guide.html
+++ b/management/templates/sync-guide.html
@@ -1,7 +1,7 @@
 <div>
 	<h2>Contacts &amp; Calendar Synchronization</h2>
 
-	<p>This box can hold your contacts and calendar, just like it holds your email.</p>
+	<p>If you chose to install Nextcloud, then this box can hold your contacts and calendar, just like it holds your email.</p>
 
 	<hr>
 

--- a/management/web_update.py
+++ b/management/web_update.py
@@ -8,6 +8,7 @@ from mailconfig import get_mail_domains
 from dns_update import get_custom_dns_config, get_dns_zones
 from ssl_certificates import get_ssl_certificates, get_domain_ssl_files, check_certificate
 from utils import shell, safe_domain_name, sort_domains
+from os import environ
 
 def get_web_domains(env, include_www_redirects=True, exclude_dns_elsewhere=True):
 	# What domains should we serve HTTP(S) for?
@@ -77,7 +78,11 @@ def do_web_update(env):
 	# Load the templates.
 	template0 = open(os.path.join(os.path.dirname(__file__), "../conf/nginx.conf")).read()
 	template1 = open(os.path.join(os.path.dirname(__file__), "../conf/nginx-alldomains.conf")).read()
-	template2 = open(os.path.join(os.path.dirname(__file__), "../conf/nginx-primaryonly.conf")).read()
+        # Check if the user doesn't want Nextcloud.
+        if environ.get('DISABLE_NEXTCLOUD') == '1':
+	    template2 = open(os.path.join(os.path.dirname(__file__), "../conf/nginx-primaryonly-no-nextcloud.conf")).read()
+        else:
+	    template2 = open(os.path.join(os.path.dirname(__file__), "../conf/nginx-primaryonly.conf")).read()
 	template3 = "\trewrite ^(.*) https://$REDIRECT_DOMAIN$1 permanent;\n"
 
 	# Add the PRIMARY_HOST configuration first so it becomes nginx's default server.

--- a/setup/start.sh
+++ b/setup/start.sh
@@ -106,7 +106,13 @@ source setup/dkim.sh
 source setup/spamassassin.sh
 source setup/web.sh
 source setup/webmail.sh
-source setup/nextcloud.sh
+
+if [ "${DISABLE_NEXTCLOUD} == "1" ]; then
+	echo Skipping Nextcloud installation
+else 
+	source setup/nextcloud.sh
+fi
+
 source setup/zpush.sh
 source setup/management.sh
 source setup/munin.sh

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -340,10 +340,20 @@ systemctl restart systemd-resolved
 # Configure the Fail2Ban installation to prevent dumb bruce-force attacks against dovecot, postfix, ssh, etc.
 rm -f /etc/fail2ban/jail.local # we used to use this file but don't anymore
 rm -f /etc/fail2ban/jail.d/defaults-debian.conf # removes default config so we can manage all of fail2ban rules in one config
-cat conf/fail2ban/jails.conf \
-	| sed "s/PUBLIC_IP/$PUBLIC_IP/g" \
-	| sed "s#STORAGE_ROOT#$STORAGE_ROOT#" \
-	> /etc/fail2ban/jail.d/mailinabox.conf
+
+if [ ${DISABLE_NEXTCLOUD} != "1"]; then
+
+	cat conf/fail2ban/jails.conf \
+		| sed "s/PUBLIC_IP/$PUBLIC_IP/g" \
+		| sed "s#STORAGE_ROOT#$STORAGE_ROOT#" \
+		> /etc/fail2ban/jail.d/mailinabox.conf
+else
+	cat conf/fail2ban/jails_no_nextcloud.conf \
+		| sed "s/PUBLIC_IP/$PUBLIC_IP/g" \
+		| sed "s#STORAGE_ROOT#$STORAGE_ROOT#" \
+		> /etc/fail2ban/jail.d/mailinabox.conf
+fi	
+
 cp -f conf/fail2ban/filter.d/* /etc/fail2ban/filter.d/
 
 # On first installation, the log files that the jails look at don't all exist.

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -131,25 +131,28 @@ cat > $RCM_CONFIG <<EOF;
 EOF
 
 # Configure CardDav
-cat > ${RCM_PLUGIN_DIR}/carddav/config.inc.php <<EOF;
-<?php
-/* Do not edit. Written by Mail-in-a-Box. Regenerated on updates. */
-\$prefs['_GLOBAL']['hide_preferences'] = true;
-\$prefs['_GLOBAL']['suppress_version_warning'] = true;
-\$prefs['ownCloud'] = array(
-	 'name'         =>  'ownCloud',
-	 'username'     =>  '%u', // login username
-	 'password'     =>  '%p', // login password
-	 'url'          =>  'https://${PRIMARY_HOSTNAME}/cloud/remote.php/carddav/addressbooks/%u/contacts',
-	 'active'       =>  true,
-	 'readonly'     =>  false,
-	 'refresh_time' => '02:00:00',
-	 'fixed'        =>  array('username','password'),
-	 'preemptive_auth' => '1',
-	 'hide'        =>  false,
-);
-?>
-EOF
+if [ "${DISABLE_NEXTCLOUD}" != "1" ]; then
+
+	cat > ${RCM_PLUGIN_DIR}/carddav/config.inc.php <<EOF;
+	<?php
+	/* Do not edit. Written by Mail-in-a-Box. Regenerated on updates. */
+	\$prefs['_GLOBAL']['hide_preferences'] = true;
+	\$prefs['_GLOBAL']['suppress_version_warning'] = true;
+	\$prefs['ownCloud'] = array(
+		 'name'         =>  'ownCloud',
+		 'username'     =>  '%u', // login username
+		 'password'     =>  '%p', // login password
+		 'url'          =>  'https://${PRIMARY_HOSTNAME}/cloud/remote.php/carddav/addressbooks/%u/contacts',
+		 'active'       =>  true,
+		 'readonly'     =>  false,
+		 'refresh_time' => '02:00:00',
+		 'fixed'        =>  array('username','password'),
+		 'preemptive_auth' => '1',
+		 'hide'        =>  false,
+	);
+	?>
+	EOF
+fi
 
 # Create writable directories.
 mkdir -p /var/log/roundcubemail /var/tmp/roundcubemail $STORAGE_ROOT/mail/roundcube

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -127,7 +127,7 @@ cat > $RCM_CONFIG <<EOF;
 \$config['des_key'] = '$SECRET_KEY';
 EOF
 
-if [ "${DISABLE_NEXTCLOUD}" != "1" ]; then
+if [ "${DISABLE_NEXTCLOUD}" == "1" ]; then
 	cat >> $RCM_CONFIG <<EOF;
 	\$config['plugins'] = array('html5_notifier', 'archive', 'zipdownload', 'password', 'managesieve', 'jqueryui', 'persistent_login');
 	\$config['skin'] = 'larry';

--- a/setup/zpush.sh
+++ b/setup/zpush.sh
@@ -64,13 +64,16 @@ rm -f /usr/local/lib/z-push/backend/imap/config.php
 cp conf/zpush/backend_imap.php /usr/local/lib/z-push/backend/imap/config.php
 sed -i "s%STORAGE_ROOT%$STORAGE_ROOT%" /usr/local/lib/z-push/backend/imap/config.php
 
-# Configure CardDav
-rm -f /usr/local/lib/z-push/backend/carddav/config.php
-cp conf/zpush/backend_carddav.php /usr/local/lib/z-push/backend/carddav/config.php
-
-# Configure CalDav
-rm -f /usr/local/lib/z-push/backend/caldav/config.php
-cp conf/zpush/backend_caldav.php /usr/local/lib/z-push/backend/caldav/config.php
+if [ "${DISABLE_NEXTCLOUD}" != "1" ]; then
+	
+	# Configure CardDav
+	rm -f /usr/local/lib/z-push/backend/carddav/config.php
+	cp conf/zpush/backend_carddav.php /usr/local/lib/z-push/backend/carddav/config.php
+	
+	# Configure CalDav
+	rm -f /usr/local/lib/z-push/backend/caldav/config.php
+	cp conf/zpush/backend_caldav.php /usr/local/lib/z-push/backend/caldav/config.php
+fi
 
 # Configure Autodiscover
 rm -f /usr/local/lib/z-push/autodiscover/config.php


### PR DESCRIPTION
This pull request will add the ability to skip installing Nextcloud if the DISABLE_NEXTCLOUD environment variable is set to "1".

Even though Nextcloud's contacts and calendar features can be useful to some, Nextcloud adds an additional attack surface to a MiaB server, when you combine that with the fact that not everyone needs these features in the first place, making Nextcloud an optional feature starts becoming a logical decision to make.

Thanks for taking the time to review this PR, feel free to suggest improvements/fixes. 