### PR TITLE
Ensure the universe repository is enabled

### DIFF
--- a/setup/system.sh
+++ b/setup/system.sh
@@ -89,6 +89,9 @@ fi
 # Install the certbot PPA.
 hide_output add-apt-repository -y ppa:certbot/certbot
 
+# Ensure the universe repository is enabled
+hide_output add-apt-repository -y universe
+
 # ### Update Packages
 
 # Update system packages to make sure we have the latest upstream versions


### PR DESCRIPTION
A minimal Ubuntu server installation might not have universe enabled by
default. By adding it, we ensure we can install packages only available
in universe, such as python3-pip

Note that if universe is already enabled, add-apt-repository simply prints a notice to indicate as much and exits with success.