### PR TITLE
Conditional error text in SSL notification email subject

### DIFF
--- a/management/daily_tasks.sh
+++ b/management/daily_tasks.sh
@@ -19,7 +19,7 @@ fi
 management/backup.py | management/email_administrator.py "Backup Status"
 
 # Provision any new certificates for new domains or domains with expiring certificates.
-management/ssl_certificates.py -q | management/email_administrator.py "Error Provisioning TLS Certificate"
+management/ssl_certificates.py -q | management/email_administrator.py "TLS Certificate Provisioning Result"
 
 # Run status checks and email the administrator if anything changed.
 management/status_checks.py --show-changes | management/email_administrator.py "Status Checks Change Notice"


### PR DESCRIPTION
Previously the notification email sent when a box's SSL certificate
is automatically updated said, "Error Provisioning TLS Certificate"
even when there was no error. ~~This makes the "Error" portion of the
subject line conditional - only displayed if an error occurred. So
in non-error cases the email subject will now be "Provisioning TLS
Certificate".~~  This changes the subject line to "TLS Certificate
Provisioning Results".

Resolves https://github.com/mail-in-a-box/mailinabox/issues/1604