### PR TITLE
Allow user_external for Nextcloud 16 (and eventually 17)

### DIFF
--- a/setup/nextcloud.sh
+++ b/setup/nextcloud.sh
@@ -50,7 +50,7 @@ InstallNextcloud() {
 
 	# Starting with Nextcloud 15, the app user_external is no longer included in Nextcloud core,
 	# we will install from their github repository.
-	if [[ $version =~ ^15 ]]; then
+	if [[ $version =~ ^1[567] ]]; then
 		wget_verify https://github.com/nextcloud/user_external/releases/download/v0.7.0/user_external-0.7.0.tar.gz 555a94811daaf5bdd336c5e48a78aa8567b86437 /tmp/user_external.tgz
 		tar -xf /tmp/user_external.tgz -C /usr/local/lib/owncloud/apps/
 		rm /tmp/user_external.tgz


### PR DESCRIPTION
I tested master today (with the upgrade to Nextcloud 16). Everything worked fine but I noticed that user_external was not being installed from wget_verify, I believe it was being installed because owncloud.db has a reference to it and it updated to the latest version during the upgrade process.

PR expands the check from Version 15, to 15 16 and 17.  This (https://github.com/nextcloud/user_external/blob/3b06887cbd84370d82fda771a1b943d63fb18739/appinfo/info.xml#L35) confirms support for all three versions.

I haven't tested a clean install of 18.04 with master, but I might foresee that fresh installs may not get user_external without the PR.