### PR TITLE
Upgrade to Roundcube 1.4.0

### DIFF
--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -28,8 +28,8 @@ apt_install \
 # Install Roundcube from source if it is not already present or if it is out of date.
 # Combine the Roundcube version number with the commit hash of plugins to track
 # whether we have the latest version of everything.
-VERSION=1.3.10
-HASH=431625fc737e301f9b7e502cccc61e50a24786b8
+VERSION=1.4.0
+HASH=9fc48d47a9ba89ce02e1aab38e01cf3ff6838c68
 PERSISTENT_LOGIN_VERSION=dc5ca3d3f4415cc41edb2fde533c8a8628a94c76
 HTML5_NOTIFIER_VERSION=4b370e3cd60dabd2f428a26f45b677ad1b7118d5
 CARDDAV_VERSION=3.0.3


### PR DESCRIPTION
Roundcube has finally been updated to 1.4.0.  You can view the change log [here](https://github.com/roundcube/roundcubemail/releases).

Some points to note:

- This is a big improvement on the Roundcube interface.  It introduces a new theme which works well on all mobile devices.  Personally I have been using this since the first release candidate and it works fantastically well and makes Roundcube look more modern and up-to-date.
- Email Bounce feature
- Improved Mailvelope integration
- The previous stable release branches 1.3.x used in mailinabox will change into LTS low maintenance mode