### PR TITLE
Check if xfr is subnet, then do not create _notify_ entry

### DIFF
--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -523,9 +523,11 @@ zone:
 """ % (domain, zonefile)
 
 		# If custom secondary nameservers have been set, allow zone transfers
-		# and notifies to them.
+		# and, if not a subnet, notifies to them.
 		for ipaddr in get_secondary_dns(additional_records, mode="xfr"):
-			nsdconf += "\n\tnotify: %s NOKEY\n\tprovide-xfr: %s NOKEY\n" % (ipaddr, ipaddr)
+			if "/" not in ipaddr:
+				nsdconf += "\n\tnotify: %s NOKEY" % (ipaddr)
+			nsdconf += "\n\tprovide-xfr: %s NOKEY\n" % (ipaddr)
 
 	# Check if the file is changing. If it isn't changing,
 	# return False to flag that no change was made.


### PR DESCRIPTION
Simple check to make sure that no invalid notify entry is created. This should fix #1658 in a simple way, just as the [small text](https://github.com/mail-in-a-box/mailinabox/blob/50e9e8af30ee8392d4afd1a8b6564d149fde803d/management/templates/custom-dns.html#L93) suggests.

It checkes in the same way as [this check](https://github.com/mail-in-a-box/mailinabox/blob/fa792f664ec8da60539862c846c12bbe9fead7a7/management/dns_update.py#L909).

This works in my case where my ISP uses an /27 for xfr requests but does not support the notify services. Since notify addresses are single IPs, this can be also added as an extra entry, I guess.

If there is any need to support other notations, someone can read the [nsd.conf documentation](https://nlnetlabs.nl/documentation/nsd/nsd.conf/) as a reference.