### PR TITLE
Upgrade RoundCube to 1.4.1 and set the default skin to elastic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Software updates:
 
 * Upgraded Nextcloud from 15.0.8 to 16.0.5 (with Contacts from 3.1.1 to 3.1.4 and Calendar from 1.6.5 to 1.7.1)
 * Upgraded Z-Push to 2.5.1.
-* Upgraded Roundcube from 1.3.10 to 1.4.0.
+* Upgraded Roundcube from 1.3.10 to 1.4.1.
 
 Control panel:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ CHANGELOG
 Under Development
 -----------------
 
+WebMail:
+* Set the default Roundcube skin to the new "Elastic" theme.
+
 Software updates:
 
 * Upgraded Nextcloud from 15.0.8 to 16.0.5 (with Contacts from 3.1.1 to 3.1.4 and Calendar from 1.6.5 to 1.7.1)
 * Upgraded Z-Push to 2.5.1.
+* Upgraded Roundcube from 1.3.10 to 1.4.0.
 
 Control panel:
 

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -51,6 +51,11 @@ elif [[ "$UPDATE_KEY" != `cat /usr/local/lib/roundcubemail/version` ]]; then
 	needs_update=1 #NODOC
 fi
 if [ $needs_update == 1 ]; then
+  # if upgrading from 1.3.x, clear the temp_dir
+  if [ "$(cat /usr/local/lib/roundcubemail/version | cut -c1-3)" == '1.3' ]; then
+    find /var/tmp/roundcubemail/ -type f ! -name 'RCMTEMP*' -delete
+  fi
+
 	# install roundcube
 	wget_verify \
 		https://github.com/roundcube/roundcubemail/releases/download/$VERSION/roundcubemail-$VERSION-complete.tar.gz \

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -115,9 +115,6 @@ cat > $RCM_CONFIG <<EOF;
  );
 \$config['imap_timeout'] = 15;
 \$config['smtp_server'] = 'tls://127.0.0.1';
-\$config['smtp_port'] = 587;
-\$config['smtp_user'] = '%u';
-\$config['smtp_pass'] = '%p';
 \$config['smtp_conn_options'] = array(
   'ssl'         => array(
      'verify_peer'  => false,

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -28,8 +28,8 @@ apt_install \
 # Install Roundcube from source if it is not already present or if it is out of date.
 # Combine the Roundcube version number with the commit hash of plugins to track
 # whether we have the latest version of everything.
-VERSION=1.4.0
-HASH=9fc48d47a9ba89ce02e1aab38e01cf3ff6838c68
+VERSION=1.4.1
+HASH=f4ecc63185b8f7b4ce5bccdc9fc689571e82c489
 PERSISTENT_LOGIN_VERSION=dc5ca3d3f4415cc41edb2fde533c8a8628a94c76
 HTML5_NOTIFIER_VERSION=4b370e3cd60dabd2f428a26f45b677ad1b7118d5
 CARDDAV_VERSION=3.0.3

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -28,8 +28,8 @@ apt_install \
 # Install Roundcube from source if it is not already present or if it is out of date.
 # Combine the Roundcube version number with the commit hash of plugins to track
 # whether we have the latest version of everything.
-VERSION=1.3.10
-HASH=431625fc737e301f9b7e502cccc61e50a24786b8
+VERSION=1.4.0
+HASH=9fc48d47a9ba89ce02e1aab38e01cf3ff6838c68
 PERSISTENT_LOGIN_VERSION=dc5ca3d3f4415cc41edb2fde533c8a8628a94c76
 HTML5_NOTIFIER_VERSION=4b370e3cd60dabd2f428a26f45b677ad1b7118d5
 CARDDAV_VERSION=3.0.3
@@ -123,7 +123,7 @@ cat > $RCM_CONFIG <<EOF;
 \$config['product_name'] = '$PRIMARY_HOSTNAME Webmail';
 \$config['des_key'] = '$SECRET_KEY';
 \$config['plugins'] = array('html5_notifier', 'archive', 'zipdownload', 'password', 'managesieve', 'jqueryui', 'persistent_login', 'carddav');
-\$config['skin'] = 'larry';
+\$config['skin'] = 'elastic';
 \$config['login_autocomplete'] = 2;
 \$config['password_charset'] = 'UTF-8';
 \$config['junk_mbox'] = 'Spam';

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -52,8 +52,10 @@ elif [[ "$UPDATE_KEY" != `cat /usr/local/lib/roundcubemail/version` ]]; then
 fi
 if [ $needs_update == 1 ]; then
   # if upgrading from 1.3.x, clear the temp_dir
-  if [ "$(cat /usr/local/lib/roundcubemail/version | cut -c1-3)" == '1.3' ]; then
-    find /var/tmp/roundcubemail/ -type f ! -name 'RCMTEMP*' -delete
+  if [ -f /usr/local/lib/roundcubemail/version ]; then
+    if [ "$(cat /usr/local/lib/roundcubemail/version | cut -c1-3)" == '1.3' ]; then
+      find /var/tmp/roundcubemail/ -type f ! -name 'RCMTEMP*' -delete
+    fi
   fi
 
 	# install roundcube

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -194,4 +194,5 @@ chmod 664 $STORAGE_ROOT/mail/roundcube/roundcube.sqlite
 
 # Enable PHP modules.
 phpenmod -v php mcrypt imap
+apt install -y php7.2-ldap
 restart_service php7.2-fpm

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -22,7 +22,7 @@ source /etc/mailinabox.conf # load global vars
 echo "Installing Roundcube (webmail)..."
 apt_install \
 	dbconfig-common \
-	php-cli php-sqlite3 php-intl php-json php-common php-curl \
+	php-cli php-sqlite3 php-intl php-json php-common php-curl php-ldap \
 	php-gd php-pspell tinymce libjs-jquery libjs-jquery-mousewheel libmagic1 php-mbstring
 
 # Install Roundcube from source if it is not already present or if it is out of date.
@@ -194,5 +194,4 @@ chmod 664 $STORAGE_ROOT/mail/roundcube/roundcube.sqlite
 
 # Enable PHP modules.
 phpenmod -v php mcrypt imap
-apt install -y php7.2-ldap
 restart_service php7.2-fpm


### PR DESCRIPTION
RoundCube 1.4 has been released.
The most notable feature is a new skin, responsive and with a much more modern look.

It has been in release candidate for 9 months, with hundreds of commits, so I think we can consider it stable and set it by default.