### PR TITLE
Upgraded Nextcloud to 16.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Under Development
 
 Software updates:
 
-* Upgraded Nextcloud from 15.0.8 to 16.0.5 (with Contacts from 3.1.1 to 3.1.4 and Calendar from 1.6.5 to 1.7.1)
+* Upgraded Nextcloud from 15.0.8 to 16.0.6 (with Contacts from 3.1.1 to 3.1.6 and Calendar from 1.6.5 to 1.7.1)
 * Upgraded Z-Push to 2.5.1.
 
 Control panel:

--- a/setup/nextcloud.sh
+++ b/setup/nextcloud.sh
@@ -40,7 +40,7 @@ InstallNextcloud() {
 	# their github repositories.
 	mkdir -p /usr/local/lib/owncloud/apps
 
-	wget_verify https://github.com/nextcloud/contacts/releases/download/v3.1.4/contacts.tar.gz 297cb38c0ba9ba7ad7b8b61108033af8d7eccd96 /tmp/contacts.tgz
+	wget_verify https://github.com/nextcloud/contacts/releases/download/v3.1.6/contacts.tar.gz d331dc6db2ecf7c8e6166926a055dfa3b59722c3 /tmp/contacts.tgz
 	tar xf /tmp/contacts.tgz -C /usr/local/lib/owncloud/apps/
 	rm /tmp/contacts.tgz
 
@@ -91,8 +91,8 @@ InstallNextcloud() {
 }
 
 # Nextcloud Version to install. Checks are done down below to step through intermediate versions.
-nextcloud_ver=16.0.5
-nextcloud_hash=46e8ec989de9aad9967a5a54ddb84ce8b8e2c54c
+nextcloud_ver=16.0.6
+nextcloud_hash=0bb3098455ec89f5af77a652aad553ad40a88819
 
 # Current Nextcloud Version, #1623
 # Checking /usr/local/lib/owncloud/version.php shows version of the Nextcloud application, not the DB


### PR DESCRIPTION
Upgrade Nextcloud 16.05 to 16.06 and contacts from 3.1.4 to 3.1.6.

Based on https://github.com/mail-in-a-box/mailinabox/commit/889118aeb65ded96df76d43e67a7bae8a81ac387

probs to @yodax 

Needed version 16.0.6 due to a bug fix.
Then I can immediately send in the code so that everyone can benefit from it.

