### PR TITLE
Implement nextcloud php-fpm recommended performance tuning settings

### DIFF
--- a/setup/nextcloud.sh
+++ b/setup/nextcloud.sh
@@ -299,9 +299,47 @@ tools/editconf.py /etc/php/7.2/cli/conf.d/10-opcache.ini -c ';' \
 	opcache.save_comments=1 \
 	opcache.revalidate_freq=1
 
-# Configure the path environment for php-fpm
-tools/editconf.py /etc/php/7.2/fpm/pool.d/www.conf -c ';' \
-		env[PATH]=/usr/local/bin:/usr/bin:/bin
+# Configure php-fpm based on the amount of memory the machine has
+# This is based on the nextcloud manual for performance tuning: https://docs.nextcloud.com/server/17/admin_manual/installation/server_tuning.html
+# Some synchronisation issues can occur when many people access the site at once.
+# The pm=ondemand setting is used for memory constrained machines < 2GB, this is copied over from PR: 1216
+TOTAL_PHYSICAL_MEM=$(head -n 1 /proc/meminfo | awk '{print $2}' || /bin/true)
+if [ $TOTAL_PHYSICAL_MEM -lt 1000000 ]
+then
+        tools/editconf.py /etc/php/7.2/fpm/pool.d/www.conf -c ';' \
+                env[PATH]=/usr/local/bin:/usr/bin:/bin \
+                pm=ondemand \
+                pm.max_children=8 \
+                pm.start_servers=2 \
+                pm.min_spare_servers=1 \
+                pm.max_spare_servers=3
+elif [ $TOTAL_PHYSICAL_MEM -lt 2000000 ]
+then
+        tools/editconf.py /etc/php/7.2/fpm/pool.d/www.conf -c ';' \
+                env[PATH]=/usr/local/bin:/usr/bin:/bin \
+                pm=ondemand \
+                pm.max_children=16 \
+                pm.start_servers=4 \
+                pm.min_spare_servers=1 \
+                pm.max_spare_servers=6
+elif [ $TOTAL_PHYSICAL_MEM -lt 3000000 ]
+then
+        tools/editconf.py /etc/php/7.2/fpm/pool.d/www.conf -c ';' \
+                env[PATH]=/usr/local/bin:/usr/bin:/bin \
+                pm=dynamic \
+                pm.max_children=60 \
+                pm.start_servers=6 \
+                pm.min_spare_servers=3 \
+                pm.max_spare_servers=9
+else
+        tools/editconf.py /etc/php/7.2/fpm/pool.d/www.conf -c ';' \
+                env[PATH]=/usr/local/bin:/usr/bin:/bin \
+                pm=dynamic \
+                pm.max_children=120 \
+                pm.start_servers=12 \
+                pm.min_spare_servers=6 \
+                pm.max_spare_servers=18
+fi
 
 # If apc is explicitly disabled we need to enable it
 if grep -q apc.enabled=0 /etc/php/7.2/mods-available/apcu.ini; then

--- a/setup/nextcloud.sh
+++ b/setup/nextcloud.sh
@@ -299,48 +299,6 @@ tools/editconf.py /etc/php/7.2/cli/conf.d/10-opcache.ini -c ';' \
 	opcache.save_comments=1 \
 	opcache.revalidate_freq=1
 
-# Configure php-fpm based on the amount of memory the machine has
-# This is based on the nextcloud manual for performance tuning: https://docs.nextcloud.com/server/17/admin_manual/installation/server_tuning.html
-# Some synchronisation issues can occur when many people access the site at once.
-# The pm=ondemand setting is used for memory constrained machines < 2GB, this is copied over from PR: 1216
-TOTAL_PHYSICAL_MEM=$(head -n 1 /proc/meminfo | awk '{print $2}' || /bin/true)
-if [ $TOTAL_PHYSICAL_MEM -lt 1000000 ]
-then
-        tools/editconf.py /etc/php/7.2/fpm/pool.d/www.conf -c ';' \
-                env[PATH]=/usr/local/bin:/usr/bin:/bin \
-                pm=ondemand \
-                pm.max_children=8 \
-                pm.start_servers=2 \
-                pm.min_spare_servers=1 \
-                pm.max_spare_servers=3
-elif [ $TOTAL_PHYSICAL_MEM -lt 2000000 ]
-then
-        tools/editconf.py /etc/php/7.2/fpm/pool.d/www.conf -c ';' \
-                env[PATH]=/usr/local/bin:/usr/bin:/bin \
-                pm=ondemand \
-                pm.max_children=16 \
-                pm.start_servers=4 \
-                pm.min_spare_servers=1 \
-                pm.max_spare_servers=6
-elif [ $TOTAL_PHYSICAL_MEM -lt 3000000 ]
-then
-        tools/editconf.py /etc/php/7.2/fpm/pool.d/www.conf -c ';' \
-                env[PATH]=/usr/local/bin:/usr/bin:/bin \
-                pm=dynamic \
-                pm.max_children=60 \
-                pm.start_servers=6 \
-                pm.min_spare_servers=3 \
-                pm.max_spare_servers=9
-else
-        tools/editconf.py /etc/php/7.2/fpm/pool.d/www.conf -c ';' \
-                env[PATH]=/usr/local/bin:/usr/bin:/bin \
-                pm=dynamic \
-                pm.max_children=120 \
-                pm.start_servers=12 \
-                pm.min_spare_servers=6 \
-                pm.max_spare_servers=18
-fi
-
 # If apc is explicitly disabled we need to enable it
 if grep -q apc.enabled=0 /etc/php/7.2/mods-available/apcu.ini; then
 	tools/editconf.py /etc/php/7.2/mods-available/apcu.ini -c ';' \

--- a/setup/web.sh
+++ b/setup/web.sh
@@ -48,14 +48,6 @@ tools/editconf.py /etc/php/7.2/fpm/php.ini -c ';' \
 tools/editconf.py /etc/php/7.2/fpm/php.ini -c ';' \
         default_charset="UTF-8"
 
-# Switch from the dynamic process manager to the ondemand manager see #1216
-tools/editconf.py /etc/php/7.2/fpm/pool.d/www.conf -c ';' \
-	pm=ondemand
-
-# Bump up PHP's max_children to support more concurrent connections
-tools/editconf.py /etc/php/7.2/fpm/pool.d/www.conf -c ';' \
-	pm.max_children=8
-
 # Other nginx settings will be configured by the management service
 # since it depends on what domains we're serving, which we don't know
 # until mail accounts have been created.

--- a/setup/web.sh
+++ b/setup/web.sh
@@ -48,6 +48,48 @@ tools/editconf.py /etc/php/7.2/fpm/php.ini -c ';' \
 tools/editconf.py /etc/php/7.2/fpm/php.ini -c ';' \
         default_charset="UTF-8"
 
+# Configure the path environment for php-fpm
+tools/editconf.py /etc/php/7.2/fpm/pool.d/www.conf -c ';' \
+	env[PATH]=/usr/local/bin:/usr/bin:/bin \
+
+# Configure php-fpm based on the amount of memory the machine has
+# This is based on the nextcloud manual for performance tuning: https://docs.nextcloud.com/server/17/admin_manual/installation/server_tuning.html
+# Some synchronisation issues can occur when many people access the site at once.
+# The pm=ondemand setting is used for memory constrained machines < 2GB, this is copied over from PR: 1216
+TOTAL_PHYSICAL_MEM=$(head -n 1 /proc/meminfo | awk '{print $2}' || /bin/true)
+if [ $TOTAL_PHYSICAL_MEM -lt 1000000 ]
+then
+        tools/editconf.py /etc/php/7.2/fpm/pool.d/www.conf -c ';' \
+                pm=ondemand \
+                pm.max_children=8 \
+                pm.start_servers=2 \
+                pm.min_spare_servers=1 \
+                pm.max_spare_servers=3
+elif [ $TOTAL_PHYSICAL_MEM -lt 2000000 ]
+then
+        tools/editconf.py /etc/php/7.2/fpm/pool.d/www.conf -c ';' \
+                pm=ondemand \
+                pm.max_children=16 \
+                pm.start_servers=4 \
+                pm.min_spare_servers=1 \
+                pm.max_spare_servers=6
+elif [ $TOTAL_PHYSICAL_MEM -lt 3000000 ]
+then
+        tools/editconf.py /etc/php/7.2/fpm/pool.d/www.conf -c ';' \
+                pm=dynamic \
+                pm.max_children=60 \
+                pm.start_servers=6 \
+                pm.min_spare_servers=3 \
+                pm.max_spare_servers=9
+else
+        tools/editconf.py /etc/php/7.2/fpm/pool.d/www.conf -c ';' \
+                pm=dynamic \
+                pm.max_children=120 \
+                pm.start_servers=12 \
+                pm.min_spare_servers=6 \
+                pm.max_spare_servers=18
+fi
+
 # Other nginx settings will be configured by the management service
 # since it depends on what domains we're serving, which we don't know
 # until mail accounts have been created.


### PR DESCRIPTION
I have been having some synchronization issues under load. The php-fpm constraints prevents many users/sessions from being handled efficiently. 

These settings have been based on the [server tuning](https://docs.nextcloud.com/server/17/admin_manual/installation/server_tuning.html) manual from nextcloud. I've scaled the example down from the 4G example based on previous PR's and common sense.