### PR TITLE
Delete unused function

### DIFF
--- a/setup/functions.sh
+++ b/setup/functions.sh
@@ -57,15 +57,6 @@ function apt_install {
 	apt_get_quiet install $PACKAGES
 }
 
-function apt_add_repository_to_unattended_upgrades {
-	if [ -f /etc/apt/apt.conf.d/50unattended-upgrades ]; then
-		if ! grep -q "$1" /etc/apt/apt.conf.d/50unattended-upgrades; then
-			sed -i "/Allowed-Origins/a \
-	    \"$1\";" /etc/apt/apt.conf.d/50unattended-upgrades
-		fi
-	fi
-}
-
 function get_default_hostname {
 	# Guess the machine's hostname. It should be a fully qualified
 	# domain name suitable for DNS. None of these calls may provide


### PR DESCRIPTION
The function apt_add_repository_to_unattended_upgrades is defined
but never called anywhere. It appears that automatic apt updates
are handled in setup/system.sh where the file 

`/etc/apt/apt.conf.d/02periodic` 

is created and configured so that apt will update the system daily.
