### PR TITLE
capture_stderr to prevent stderr syslog/console output from ssh-keyscan

### DIFF
--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -382,7 +382,7 @@ def build_sshfp_records():
 				except ValueError:
 					pass
 				break
-	keys = shell("check_output", ["ssh-keyscan", "-t", "rsa,dsa,ecdsa,ed25519", "-p", str(port), "localhost"])
+	keys = shell("check_output", ["ssh-keyscan", "-t", "rsa,dsa,ecdsa,ed25519", "-p", str(port), "localhost"], capture_stderr=True)
 	for key in sorted(keys.split("\n")):
 		if key.strip() == "" or key[0] == "#": continue
 		try:


### PR DESCRIPTION
dns_update.py does not capture stderr when this command is run causing stderr to display to console (if running ./dns_update.py or to syslog if an update is done via web/api)

No real issue, just a cosmetic fix really.

Pre PR
```
root@m:~/mailinabox/management# ./dns_update.py | grep SSHFP
# localhost:22 SSH-2.0-OpenSSH_7.6p1 Ubuntu-4ubuntu0.3
# localhost:22 SSH-2.0-OpenSSH_7.6p1 Ubuntu-4ubuntu0.3
# localhost:22 SSH-2.0-OpenSSH_7.6p1 Ubuntu-4ubuntu0.3
# localhost:22 SSH-2.0-OpenSSH_7.6p1 Ubuntu-4ubuntu0.3
domain.com       SSHFP   3 2 ( A67B7D4660044FF4DE0AD98F38CC44E035201D19A28B05F5781C7B9EC6234181 )
domain.com       SSHFP   4 2 ( ED8962C985A0EBF2B8E27C33ACACB0CED9356FEB8F11EFAFA341841130C69B2A )
domain.com       SSHFP   1 2 ( CC6827FF163114DFFAB3D040652323489CE3E977E73C1AF7F657B74D21991E30 )
```

Also in /var/log/syslog
```
Feb 21 14:03:43 m start[23190]: # localhost:22 SSH-2.0-OpenSSH_7.6p1 Ubuntu-4ubuntu0.3
Feb 21 14:03:43 m start[23190]: # localhost:22 SSH-2.0-OpenSSH_7.6p1 Ubuntu-4ubuntu0.3
Feb 21 14:03:43 m start[23190]: # localhost:22 SSH-2.0-OpenSSH_7.6p1 Ubuntu-4ubuntu0.3
Feb 21 14:03:43 m start[23190]: # localhost:22 SSH-2.0-OpenSSH_7.6p1 Ubuntu-4ubuntu0.3
```

with PR Added
```
root@m:~/mailinabox/management# ./dns_update.py | grep SSHFP
domain.com       SSHFP   3 2 ( A67B7D4660044FF4DE0AD98F38CC44E035201D19A28B05F5781C7B9EC6234181 )
domain.com       SSHFP   4 2 ( ED8962C985A0EBF2B8E27C33ACACB0CED9356FEB8F11EFAFA341841130C69B2A )
domain.com       SSHFP   1 2 ( CC6827FF163114DFFAB3D040652323489CE3E977E73C1AF7F657B74D21991E30 )
```

No messages in /var/log/syslog after PR


Code for build_sshfp_records() already has a mechanism to deal with comment lines
https://github.com/mail-in-a-box/mailinabox/blob/30c2c60f596ab972e496234cb5378c667125a973/management/dns_update.py#L387

