### PR TITLE
Publish MTA-STS policy for incoming mail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+MTA-STS:
+
+* Added support for client side MTA-STS when there is a valid SSL Certificate on the primary domain
+* Automatically adds reporting when alias "tlsrpt@<primary-domain>" is added.
+* Starts default on 'testing', but changes will be kept between MiaB Upgrades.
+
 v0.44 (February 15, 2020)
 -------------------------
 

--- a/conf/mta-sts.txt
+++ b/conf/mta-sts.txt
@@ -1,4 +1,4 @@
 version: STSv1
-mode: testing
+mode: MODE
 mx: PRIMARY_HOSTNAME
 max_age: 86400

--- a/conf/mta-sts.txt
+++ b/conf/mta-sts.txt
@@ -1,0 +1,4 @@
+version: STSv1
+mode: testing
+mx: PRIMARY_HOSTNAME
+max_age: 86400

--- a/conf/nginx-alldomains.conf
+++ b/conf/nginx-alldomains.conf
@@ -21,6 +21,9 @@
 	location = /mail/config-v1.1.xml {
 		alias /var/lib/mailinabox/mozilla-autoconfig.xml;
 	}
+	location = /.well-known/mta-sts.txt {
+		alias /var/lib/mailinabox/mta-sts.txt;
+	}
 
 	# Roundcube Webmail configuration.
 	rewrite ^/mail$ /mail/ redirect;

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -308,12 +308,12 @@ def build_zone(domain, all_domains, additional_records, www_redirect_domains, en
 	# autodiscover.* - Z-Push ActiveSync Autodiscover
 	# autoconfig.* - Thunderbird Autoconfig
 	mta_sts_records = [
-		("mta-sts", "A", env["PUBLIC_IP"], "Provides mta-sts support"),
-		("mta-sts", "AAAA", env["PUBLIC_IPV6"], "Provides mta-sts support"),
-		("_mta-sts", "TXT", "v=STSv1; id=202022022043", "Provides mta-sts support"),
-		("_smtp._tls", "TXT", "v=TLSRPTv1;", "extend with rua=mailto:email@addres for reporting")
-
+		("mta-sts", "A", env["PUBLIC_IP"], "Provides MTA-STS support"),
+		("mta-sts", "AAAA", env["PUBLIC_IPV6"], "Provides MTA-STS support"),
+		("_mta-sts", "TXT", "v=STSv1; id="+datetime.datetime.now().strftime("%Y%m%d%H%M%S")+"Z", "Enables MTA-STS support"),
+		("_smtp._tls", "TXT", "v=TLSRPTv1", "change to  with v=TLSRPTv1; rua=mailto:email@addres for reporting")
 	]
+
 	for qname, rtype, value, explanation in mta_sts_records:
 		if value is None or value.strip() == "": continue # skip IPV6 if not set
 		if not has_rec(qname, rtype):

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -308,12 +308,11 @@ def build_zone(domain, all_domains, additional_records, www_redirect_domains, en
 	mta_sts_records = [
 		("mta-sts", "A", env["PUBLIC_IP"], "Provides MTA-STS support"),
 		("mta-sts", "AAAA", env.get('PUBLIC_IPV6'), "Provides MTA-STS support"),
-		("_mta-sts", "TXT", "v=STSv1; id="+datetime.datetime.now().strftime("%Y%m%d%H%M%S")+"Z", "Enables MTA-STS support")
+		("_mta-sts", "TXT", "v=STSv1; id=%sZ" % datetime.datetime.now().strftime("%Y%m%d%H%M%S"), "Enables MTA-STS support")
 	]
-
 	# Skip if the user has set a custom _smtp._tls record.
 	if not has_rec("_smtp._tls", "TXT", prefix="v=TLSRPTv1;"):
-		mta_sts_records.append(("_smtp._tls",  "TXT", "v=TLSRPTv1;", "change to a custom record like 'v=TLSRPTv1; rua=mailto:email@address' for reporting"))
+		mta_sts_records.append(("_smtp._tls",  "TXT", "v=TLSRPTv1;", "For reporting, add an mail alias, for example 'tlsrpt@%s' and a custom TXT record like 'v=TLSRPTv1; rua=mailto:tlsrpt@%s' for reporting" % (env["PRIMARY_HOSTNAME"], env["PRIMARY_HOSTNAME"]) ))
 
 	for qname, rtype, value, explanation in mta_sts_records:
 		if value is None or value.strip() == "": continue # skip IPV6 if not set

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -318,8 +318,7 @@ def build_zone(domain, all_domains, additional_records, www_redirect_domains, en
 	# valid (e.g. because it is self-signed and a valid certificate has not yet been provisioned).
 	get_prim_cert = get_ssl_certificates(env)[env['PRIMARY_HOSTNAME']]
 	response = check_certificate(env['PRIMARY_HOSTNAME'], get_prim_cert['certificate'],get_prim_cert['private-key'])
-	# we don't want those records on the primary hostname 
-	# and we only want these records if the certificate is valid
+	
 	if response[0] == 'OK' and domain in get_mail_domains(env):
 		mta_sts_records = [
 			("mta-sts", "A", env["PUBLIC_IP"], "Provides MTA-STS support"),

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -320,7 +320,7 @@ def build_zone(domain, all_domains, additional_records, www_redirect_domains, en
 	response = check_certificate(env['PRIMARY_HOSTNAME'], get_prim_cert['certificate'],get_prim_cert['private-key'])
 	# we don't want those records on the primary hostname 
 	# and we only want these records if the certificate is valid
-	if response[0] == 'OK':
+	if response[0] == 'OK' and domain in get_mail_domains(env):
 		mta_sts_records = [
 			("mta-sts", "A", env["PUBLIC_IP"], "Provides MTA-STS support"),
 			("mta-sts", "AAAA", env.get('PUBLIC_IPV6'), "Provides MTA-STS support"),

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -335,7 +335,7 @@ def build_zone(domain, all_domains, additional_records, www_redirect_domains, en
 			for alias in get_mail_aliases(env):
 				if alias[0] == tls_rpt_email: 
 					tls_rpt_string = " rua=mailto:%s" % tls_rpt_email
-			mta_sts_records.append(("_smtp._tls",  "TXT", "v=TLSRPTv1;%s" % tls_rpt_string, "For reporting, add an mail alias: 'tlsrpt@%s' or add a custom TXT record like 'v=TLSRPTv1; rua=mailto:[youremail]@%s' for reporting" % (env["PRIMARY_HOSTNAME"], env["PRIMARY_HOSTNAME"]) ))
+			mta_sts_records.append(("_smtp._tls", "TXT", "v=TLSRPTv1;%s" % tls_rpt_string, "For reporting, add an email alias: 'tlsrpt@%s' or add a custom TXT record like 'v=TLSRPTv1; rua=mailto:[youremail]@%s' for reporting" % (env["PRIMARY_HOSTNAME"], env["PRIMARY_HOSTNAME"])))
 		for qname, rtype, value, explanation in mta_sts_records:
 			if value is None or value.strip() == "": continue # skip IPV6 if not set
 			if not has_rec(qname, rtype):

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -303,6 +303,22 @@ def build_zone(domain, all_domains, additional_records, www_redirect_domains, en
 		if not has_rec(qname, rtype):
 			records.append((qname, rtype, value, explanation))
 
+	# Adds autoconfiguration A records for all domains.
+	# This allows the following clients to automatically configure email addresses in the respective applications.
+	# autodiscover.* - Z-Push ActiveSync Autodiscover
+	# autoconfig.* - Thunderbird Autoconfig
+	mta_sts_records = [
+		("mta-sts", "A", env["PUBLIC_IP"], "Provides mta-sts support"),
+		("mta-sts", "AAAA", env["PUBLIC_IPV6"], "Provides mta-sts support"),
+		("_mta-sts", "TXT", "v=STSv1; id=202022022043", "Provides mta-sts support"),
+		("_smtp._tls", "TXT", "v=TLSRPTv1;", "extend with rua=mailto:email@addres for reporting")
+
+	]
+	for qname, rtype, value, explanation in mta_sts_records:
+		if value is None or value.strip() == "": continue # skip IPV6 if not set
+		if not has_rec(qname, rtype):
+			records.append((qname, rtype, value, explanation))
+
 	# Sort the records. The None records *must* go first in the nsd zone file. Otherwise it doesn't matter.
 	records.sort(key = lambda rec : list(reversed(rec[0].split(".")) if rec[0] is not None else ""))
 

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -9,7 +9,7 @@ import ipaddress
 import rtyaml
 import dns.resolver
 
-from mailconfig import get_mail_domains
+from mailconfig import get_mail_domains, get_mail_aliases
 from utils import shell, load_env_vars_from_file, safe_domain_name, sort_domains
 
 # From https://stackoverflow.com/questions/3026957/how-to-validate-a-domain-name-using-regex-php/16491074#16491074
@@ -305,6 +305,8 @@ def build_zone(domain, all_domains, additional_records, www_redirect_domains, en
 
 	# Adds autoconfiguration A records for all domains.
 	# mta-sts.* - required A record for mta-sts (serving the policy)
+
+
 	mta_sts_records = [
 		("mta-sts", "A", env["PUBLIC_IP"], "Provides MTA-STS support"),
 		("mta-sts", "AAAA", env.get('PUBLIC_IPV6'), "Provides MTA-STS support"),
@@ -312,7 +314,12 @@ def build_zone(domain, all_domains, additional_records, www_redirect_domains, en
 	]
 	# Skip if the user has set a custom _smtp._tls record.
 	if not has_rec("_smtp._tls", "TXT", prefix="v=TLSRPTv1;"):
-		mta_sts_records.append(("_smtp._tls",  "TXT", "v=TLSRPTv1;", "For reporting, add an mail alias, for example 'tlsrpt@%s' and a custom TXT record like 'v=TLSRPTv1; rua=mailto:tlsrpt@%s' for reporting" % (env["PRIMARY_HOSTNAME"], env["PRIMARY_HOSTNAME"]) ))
+		tls_rpt_email = "tlsrpt@%s" % env['PRIMARY_HOSTNAME'] 
+		tls_rpt_string = "";
+		for alias in get_mail_aliases(env):
+			if alias[0] == tls_rpt_email: tls_rpt_string = " rua:%s" % tls_rpt_email
+
+		mta_sts_records.append(("_smtp._tls",  "TXT", "v=TLSRPTv1;%s" % tls_rpt_string, "For reporting, add an mail alias, for example 'tlsrpt@%s' and a custom TXT record like 'v=TLSRPTv1; rua=mailto:tlsrpt@%s' for reporting" % (env["PRIMARY_HOSTNAME"], env["PRIMARY_HOSTNAME"]) ))
 
 	for qname, rtype, value, explanation in mta_sts_records:
 		if value is None or value.strip() == "": continue # skip IPV6 if not set

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -319,7 +319,7 @@ def build_zone(domain, all_domains, additional_records, www_redirect_domains, en
 		for alias in get_mail_aliases(env):
 			if alias[0] == tls_rpt_email: tls_rpt_string = " rua:%s" % tls_rpt_email
 
-		mta_sts_records.append(("_smtp._tls",  "TXT", "v=TLSRPTv1;%s" % tls_rpt_string, "For reporting, add an mail alias, for example 'tlsrpt@%s' and a custom TXT record like 'v=TLSRPTv1; rua=mailto:tlsrpt@%s' for reporting" % (env["PRIMARY_HOSTNAME"], env["PRIMARY_HOSTNAME"]) ))
+		mta_sts_records.append(("_smtp._tls",  "TXT", "v=TLSRPTv1;%s" % tls_rpt_string, "For reporting, add an mail alias: 'tlsrpt@%s' or add a custom TXT record like 'v=TLSRPTv1; rua=mailto:[youremail]@%s' for reporting" % (env["PRIMARY_HOSTNAME"], env["PRIMARY_HOSTNAME"]) ))
 
 	for qname, rtype, value, explanation in mta_sts_records:
 		if value is None or value.strip() == "": continue # skip IPV6 if not set

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -307,7 +307,7 @@ def build_zone(domain, all_domains, additional_records, www_redirect_domains, en
 	# mta-sts.* - required A record for mta-sts (serving the policy)
 	mta_sts_records = [
 		("mta-sts", "A", env["PUBLIC_IP"], "Provides MTA-STS support"),
-		("mta-sts", "AAAA", env["PUBLIC_IPV6"], "Provides MTA-STS support"),
+		("mta-sts", "AAAA", env.get('PUBLIC_IPV6'), "Provides MTA-STS support"),
 		("_mta-sts", "TXT", "v=STSv1; id="+datetime.datetime.now().strftime("%Y%m%d%H%M%S")+"Z", "Enables MTA-STS support")
 	]
 

--- a/management/web_update.py
+++ b/management/web_update.py
@@ -27,9 +27,10 @@ def get_web_domains(env, include_www_redirects=True, exclude_dns_elsewhere=True)
 	# Add Autoconfiguration domains, allowing us to serve correct SSL certs.
 	# 'autoconfig.' for Mozilla Thunderbird auto setup.
 	# 'autodiscover.' for Activesync autodiscovery.
-	# 'mta-sts.' for MTA-STS support.
 	domains |= set('autoconfig.' + maildomain for maildomain in get_mail_domains(env))
 	domains |= set('autodiscover.' + maildomain for maildomain in get_mail_domains(env))
+
+	# 'mta-sts.' for MTA-STS support.
 	domains |= set('mta-sts.' + maildomain for maildomain in get_mail_domains(env))
 
 	if exclude_dns_elsewhere:

--- a/management/web_update.py
+++ b/management/web_update.py
@@ -27,8 +27,10 @@ def get_web_domains(env, include_www_redirects=True, exclude_dns_elsewhere=True)
 	# Add Autoconfiguration domains, allowing us to serve correct SSL certs.
 	# 'autoconfig.' for Mozilla Thunderbird auto setup.
 	# 'autodiscover.' for Activesync autodiscovery.
+	# 'mta-sts.' for MTA-STS support.
 	domains |= set('autoconfig.' + maildomain for maildomain in get_mail_domains(env))
 	domains |= set('autodiscover.' + maildomain for maildomain in get_mail_domains(env))
+	domains |= set('mta-sts.' + maildomain for maildomain in get_mail_domains(env))
 
 	if exclude_dns_elsewhere:
 		# ...Unless the domain has an A/AAAA record that maps it to a different

--- a/security.md
+++ b/security.md
@@ -98,7 +98,12 @@ While domain policy records prevent other servers from sending mail with a "From
 
 The box restricts the envelope sender address (also called the return path or MAIL FROM address --- this is different from the "From:" header) that users may put into outbound mail. The envelope sender address must be either their own email address (their SMTP login username) or any alias that they are listed as a permitted sender of. (There is currently no restriction on the contents of the "From:" header.)
 
-Incoming Mail
+### MTA-STS
+
+SMTP MTA Strict Transport Security ([SMTP MTA-STS for short](https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol#SMTP_MTA_Strict_Transport_Security)). 
+
+MTA-STS is a mechanism that instructs an SMTP server that the communication with the other SMTP server MUST be encrypted and that the domain name on the certificate should match the domain in the policy. It uses a combination of DNS and HTTPS to publish a policy that tells the sending party what to do when an encrypted channel can not be negotiated.
+
 -------------
 
 ### Encryption

--- a/security.md
+++ b/security.md
@@ -99,7 +99,6 @@ While domain policy records prevent other servers from sending mail with a "From
 The box restricts the envelope sender address (also called the return path or MAIL FROM address --- this is different from the "From:" header) that users may put into outbound mail. The envelope sender address must be either their own email address (their SMTP login username) or any alias that they are listed as a permitted sender of. (There is currently no restriction on the contents of the "From:" header.)
 
 Incoming Mail
-
 -------------
 
 ### Encryption

--- a/security.md
+++ b/security.md
@@ -98,11 +98,7 @@ While domain policy records prevent other servers from sending mail with a "From
 
 The box restricts the envelope sender address (also called the return path or MAIL FROM address --- this is different from the "From:" header) that users may put into outbound mail. The envelope sender address must be either their own email address (their SMTP login username) or any alias that they are listed as a permitted sender of. (There is currently no restriction on the contents of the "From:" header.)
 
-### MTA-STS
-
-SMTP MTA Strict Transport Security ([SMTP MTA-STS for short](https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol#SMTP_MTA_Strict_Transport_Security)). 
-
-MTA-STS is a mechanism that instructs an SMTP server that the communication with the other SMTP server MUST be encrypted and that the domain name on the certificate should match the domain in the policy. It uses a combination of DNS and HTTPS to publish a policy that tells the sending party what to do when an encrypted channel can not be negotiated.
+Incoming Mail
 
 -------------
 
@@ -113,6 +109,12 @@ As discussed above, there is no way to require on-the-wire encryption of mail. W
 ### DANE
 
 When DNSSEC is enabled at the box's domain name's registrar, [DANE TLSA](https://en.wikipedia.org/wiki/DNS-based_Authentication_of_Named_Entities) records are automatically published in DNS. Senders supporting DANE will enforce encryption on-the-wire between them and the box --- see the section on DANE for outgoing mail above. ([source](management/dns_update.py))
+
+### MTA-STS
+
+SMTP MTA Strict Transport Security ([SMTP MTA-STS for short](https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol#SMTP_MTA_Strict_Transport_Security)). 
+
+MTA-STS is a mechanism that instructs an SMTP server that the communication with the other SMTP server MUST be encrypted and that the domain name on the certificate should match the domain in the policy. It uses a combination of DNS and HTTPS to publish a policy that tells the sending party what to do when an encrypted channel can not be negotiated.
 
 ### Filters
 

--- a/setup/start.sh
+++ b/setup/start.sh
@@ -82,6 +82,11 @@ if [ ! -f $STORAGE_ROOT/mailinabox.version ]; then
 	chown $STORAGE_USER.$STORAGE_USER $STORAGE_ROOT/mailinabox.version
 fi
 
+# Default policy (initial) for MTA_STS = testing in the current state of inclusion.
+# it can be changed to "none", "testing" or "enforce". With this extention, this is preserved by
+# future upgrades
+
+MTA_STS="${DEFAULT_MTA_STS:-testing}"
 
 # Save the global options in /etc/mailinabox.conf so that standalone
 # tools know where to look for data.
@@ -93,6 +98,7 @@ PUBLIC_IP=$PUBLIC_IP
 PUBLIC_IPV6=$PUBLIC_IPV6
 PRIVATE_IP=$PRIVATE_IP
 PRIVATE_IPV6=$PRIVATE_IPV6
+MTA_STS=$MTA_STS
 EOF
 
 # Start service configuration.

--- a/setup/web.sh
+++ b/setup/web.sh
@@ -129,7 +129,7 @@ chmod a+r /var/lib/mailinabox/mozilla-autoconfig.xml
 
 cat conf/mta-sts.txt \
         | sed "s/MODE/$MTA_STS/" \
-        | sed "s/PRIMARY_HOSTNAME/$PRIMARY_HOSTNAME/" \
+        | sed "s/PRIMARY_HOSTNAME/$PUNY_PRIMARY_HOSTNAME/" \
          > /var/lib/mailinabox/mta-sts.txt
 chmod a+r /var/lib/mailinabox/mta-sts.txt
 
@@ -148,4 +148,3 @@ restart_service php7.2-fpm
 # Open ports.
 ufw_allow http
 ufw_allow https
-

--- a/setup/web.sh
+++ b/setup/web.sh
@@ -19,7 +19,7 @@ fi
 
 echo "Installing Nginx (web server)..."
 
-apt_install nginx php-cli php-fpm
+apt_install nginx php-cli php-fpm idn2
 
 rm -f /etc/nginx/sites-enabled/default
 

--- a/setup/web.sh
+++ b/setup/web.sh
@@ -126,6 +126,9 @@ chmod a+r /var/lib/mailinabox/mozilla-autoconfig.xml
 # nginx configuration at /.well-known/mta-sts.txt
 # more documentation is available on: 
 # https://www.uriports.com/blog/mta-sts-explained/
+# default mode is "testing", which means: "Messages will be delivered as 
+# though there was no failure but a report will be sent if TLS-RPT is configured"
+# other valid modes are: "enforce" and "none".
 PUNY_PRIMARY_HOSTNAME=$(echo "$PRIMARY_HOSTNAME" | idn2)
 cat conf/mta-sts.txt \
         | sed "s/MODE/$MTA_STS/" \

--- a/setup/web.sh
+++ b/setup/web.sh
@@ -126,7 +126,7 @@ chmod a+r /var/lib/mailinabox/mozilla-autoconfig.xml
 # nginx configuration at /.well-known/mta-sts.txt
 # more documentation is available on: 
 # https://www.uriports.com/blog/mta-sts-explained/
-
+PUNY_PRIMARY_HOSTNAME=$(echo "$PRIMARY_HOSTNAME" | idn2)
 cat conf/mta-sts.txt \
         | sed "s/MODE/$MTA_STS/" \
         | sed "s/PRIMARY_HOSTNAME/$PUNY_PRIMARY_HOSTNAME/" \

--- a/setup/web.sh
+++ b/setup/web.sh
@@ -122,6 +122,16 @@ cat conf/mozilla-autoconfig.xml \
 	 > /var/lib/mailinabox/mozilla-autoconfig.xml
 chmod a+r /var/lib/mailinabox/mozilla-autoconfig.xml
 
+# Create a generic mta-sts.txt file which is exposed via the
+# nginx configuration at /.well-known/mta-sts.txt
+# more documentation is available on: 
+# https://www.digitalocean.com/community/tutorials/how-to-configure-mta-sts-and-tls-reporting-for-your-domain-using-apache-on-ubuntu-18-04
+
+cat conf/mta-sts.txt \
+        | sed "s/PRIMARY_HOSTNAME/$PRIMARY_HOSTNAME/" \
+         > /var/lib/mailinabox/mta-sts.txt
+chmod a+r /var/lib/mailinabox/mta-sts.txt
+
 # make a default homepage
 if [ -d $STORAGE_ROOT/www/static ]; then mv $STORAGE_ROOT/www/static $STORAGE_ROOT/www/default; fi # migration #NODOC
 mkdir -p $STORAGE_ROOT/www/default

--- a/setup/web.sh
+++ b/setup/web.sh
@@ -125,8 +125,7 @@ chmod a+r /var/lib/mailinabox/mozilla-autoconfig.xml
 # Create a generic mta-sts.txt file which is exposed via the
 # nginx configuration at /.well-known/mta-sts.txt
 # more documentation is available on: 
-# https://www.digitalocean.com/community/tutorials/how-to-configure-mta-sts-and-tls-reporting-for-your-domain-using-apache-on-ubuntu-18-04
-
+# https://www.uriports.com/blog/mta-sts-explained/
 cat conf/mta-sts.txt \
         | sed "s/PRIMARY_HOSTNAME/$PRIMARY_HOSTNAME/" \
          > /var/lib/mailinabox/mta-sts.txt

--- a/setup/web.sh
+++ b/setup/web.sh
@@ -126,7 +126,9 @@ chmod a+r /var/lib/mailinabox/mozilla-autoconfig.xml
 # nginx configuration at /.well-known/mta-sts.txt
 # more documentation is available on: 
 # https://www.uriports.com/blog/mta-sts-explained/
+
 cat conf/mta-sts.txt \
+        | sed "s/MODE/$MTA_STS/" \
         | sed "s/PRIMARY_HOSTNAME/$PRIMARY_HOSTNAME/" \
          > /var/lib/mailinabox/mta-sts.txt
 chmod a+r /var/lib/mailinabox/mta-sts.txt


### PR DESCRIPTION
Hello,

I added basic MTA-STS support to all the domains with this merge request.

It adds an A and AAAA record (and web host) for mta-sts.DOMAINNAME
It extends the nginx config for getting the file mat-sts.DOMAINNAME/.well-known/mta-sts.txt 
it generates te MTA-STS.txt as testing

This is my first commit, hope it helps.

Regards,

Sander