### PR TITLE
allowing adding aliases to the proxies domain

### DIFF
--- a/management/web_update.py
+++ b/management/web_update.py
@@ -159,6 +159,10 @@ def make_domain_config(domain, templates, ssl_certificates, env):
 				nginx_conf_extra += "\n\t\tproxy_pass %s;" % url
 				nginx_conf_extra += "\n\t\tproxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;"
 				nginx_conf_extra += "\n\t}\n"
+			for path, alias in yaml.get("aliases", {}).items():
+				nginx_conf_extra += "\tlocation %s {" % path
+				nginx_conf_extra += "\n\t\talias %s;" % alias
+				nginx_conf_extra += "\n\t}\n"
 			for path, url in yaml.get("redirects", {}).items():
 				nginx_conf_extra += "\trewrite %s %s permanent;\n" % (path, url)
 


### PR DESCRIPTION
with this nginx will keep on proxying requests and serve static content
instead of passing this responsibility to proxied server

Without this the one needs to run an additional server to server static
content on the proxied url