### PR TITLE
Run nightly tasks on a random minute after 03:00 to avoid overload

### DIFF
--- a/setup/management.sh
+++ b/setup/management.sh
@@ -101,10 +101,11 @@ hide_output systemctl enable mailinabox.service
 # Perform nightly tasks at 3am in system time: take a backup, run
 # status checks and email the administrator any changes.
 
+minute=$((RANDOM % 60))  # avoid overloading mailinabox.email
 cat > /etc/cron.d/mailinabox-nightly << EOF;
 # Mail-in-a-Box --- Do not edit / will be overwritten on update.
 # Run nightly tasks: backup, status checks.
-0 3 * * *	root	(cd `pwd` && management/daily_tasks.sh)
+$minute 3 * * *	root	(cd `pwd` && management/daily_tasks.sh)
 EOF
 
 # Start the management server.


### PR DESCRIPTION
Every couple days I get this email:
```
System -- Previously:
=====================
✓  Mail-in-a-Box is up to date. You are running version v0.44.

System -- Currently:
====================
✖  Latest Mail-in-a-Box version could not be determined. You are running version v0.44.
```
and the reverse mail a day later when the check succeeded.

Since the version is checked again mailinabox.email and that apparently runs on a mailinabox VM, I assume that MIAB now has sufficient users in UTC+01:00/+02:00 to overload the central server. Congratulations!

The implemented fix would be to configure (at installation time) the time of the nightly clock to
  run at a random minute after 03:00, but before 04:00.

Unfortunately, this breaks reproducibility of the installation process, not sure, if you would be OK with that. 

This might also break existing installations where the users wants to run something custom after the backup.

Alternatives:
- don't randomize between 03:00 and 04:00, a 15min window might be enough
- don't randomize at install time, instead add a random sleep before the cronjob
- increase the timeout of the version check (it's just 5s atm)