### PR TITLE
Update jails.conf

### DIFF
--- a/conf/fail2ban/jails.conf
+++ b/conf/fail2ban/jails.conf
@@ -50,7 +50,7 @@ findtime = 30
 enabled  = true
 port     = http,https
 filter   = miab-roundcube
-logpath  = /var/log/roundcubemail/errors
+logpath  = /var/log/roundcubemail/errors.log
 maxretry = 20
 findtime = 30
 


### PR DESCRIPTION
In the config file /etc/fail2ban/jail.d/mailinabox.conf

In the roundcube section logpath is incorrect. It should be /var/log/roundcubemail/errors.log

The default config file is missing the .log extension.

I just tested this, the file /var/log/roundcubemail/error is empty. Also tested to see if fail2ban would ban a user per the settings in the file and yes it does work as intended.