### PR TITLE
Send emails about daily script errors (i.e redirect stderr to stdout)

### DIFF
--- a/management/daily_tasks.sh
+++ b/management/daily_tasks.sh
@@ -16,10 +16,10 @@ if [ `date "+%u"` -eq 1 ]; then
 fi
 
 # Take a backup.
-management/backup.py | management/email_administrator.py "Backup Status"
+management/backup.py 2>&1 | management/email_administrator.py "Backup Status"
 
 # Provision any new certificates for new domains or domains with expiring certificates.
-management/ssl_certificates.py -q | management/email_administrator.py "TLS Certificate Provisioning Result"
+management/ssl_certificates.py -q  2>&1 | management/email_administrator.py "TLS Certificate Provisioning Result"
 
 # Run status checks and email the administrator if anything changed.
-management/status_checks.py --show-changes | management/email_administrator.py "Status Checks Change Notice"
+management/status_checks.py --show-changes  2>&1 | management/email_administrator.py "Status Checks Change Notice"


### PR DESCRIPTION
When the management commands fail, they can print something to the standard error output.
The administrator would never notice, because it wouldn't be send to him with the usual emails.
Fixes #1763