### PR TITLE
Add rate limiting of SSH in the firewall, see #1767

### DIFF
--- a/setup/functions.sh
+++ b/setup/functions.sh
@@ -136,7 +136,14 @@ function get_default_privateip {
 function ufw_allow {
 	if [ -z "${DISABLE_FIREWALL:-}" ]; then
 		# ufw has completely unhelpful output
-		ufw allow $1 > /dev/null;
+		ufw allow "$1" > /dev/null;
+	fi
+}
+
+function ufw_limit {
+	if [ -z "${DISABLE_FIREWALL:-}" ]; then
+		# ufw has completely unhelpful output
+		ufw limit "$1" > /dev/null;
 	fi
 }
 

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -256,7 +256,7 @@ if [ -z "${DISABLE_FIREWALL:-}" ]; then
 	apt_install ufw
 
 	# Allow incoming connections to SSH.
-	ufw_allow ssh;
+	ufw_limit ssh;
 
 	# ssh might be running on an alternate port. Use sshd -T to dump sshd's #NODOC
 	# settings, find the port it is supposedly running on, and open that port #NODOC
@@ -266,7 +266,7 @@ if [ -z "${DISABLE_FIREWALL:-}" ]; then
 	if [ "$SSH_PORT" != "22" ]; then
 
 	echo Opening alternate SSH port $SSH_PORT. #NODOC
-	ufw_allow $SSH_PORT #NODOC
+	ufw_limit $SSH_PORT #NODOC
 
 	fi
 	fi

--- a/tools/readable_bash.py
+++ b/tools/readable_bash.py
@@ -58,7 +58,7 @@ def generate_documentation():
 	    	}
 
 	    	.prose {
-	    		padding-top: 1em;    	
+	    		padding-top: 1em;
 	    		padding-bottom: 1em;
 	    	}
 	    	.terminal {
@@ -261,6 +261,10 @@ class UfwAllow(Grammar):
 	grammar = (ZERO_OR_MORE(SPACE), L("ufw_allow "), REST_OF_LINE, EOL)
 	def value(self):
 		return shell_line("ufw allow " + self[2].string)
+class UfwLimit(Grammar):
+	grammar = (ZERO_OR_MORE(SPACE), L("ufw_limit "), REST_OF_LINE, EOL)
+	def value(self):
+		return shell_line("ufw limit " + self[2].string)
 class RestartService(Grammar):
 	grammar = (ZERO_OR_MORE(SPACE), L("restart_service "), REST_OF_LINE, EOL)
 	def value(self):
@@ -275,7 +279,7 @@ class OtherLine(Grammar):
 		return "<pre class='shell'><div>" + recode_bash(self.string.strip()) + "</div></pre>\n"
 
 class BashElement(Grammar):
-	grammar = Comment | CatEOF | EchoPipe | EchoLine | HideOutput | EditConf | SedReplace | AptGet | UfwAllow | RestartService | OtherLine
+	grammar = Comment | CatEOF | EchoPipe | EchoLine | HideOutput | EditConf | SedReplace | AptGet | UfwAllow | UfwLimit | RestartService | OtherLine
 	def value(self):
 		return self[0].value()
 


### PR DESCRIPTION
This change adds a way to allow firewall ports with rate limiting, and then uses it for SSH, see #1767 for more info.

One other minor change is that I double-quoted the param passed to ufw for both the allow and limit variants; this was flagged by my IDE as a way to avoid problems with globbing and multi-word arguments, which I can see being a possible security issue otherwise. There are many other shell calls that should probably do the same thing, but that's not what this PR is about!