### PR TITLE
AXFR Transfers (for secondary DNS servers): Allow IPv6 addresses

### DIFF
--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -967,6 +967,8 @@ def set_secondary_dns(hostnames, env):
 				try:
 					response = resolver.query(item, "A")
 				except (dns.resolver.NoNameservers, dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
+					pass
+				try:
 					response = resolver.query(item, "AAAA")
 				except (dns.resolver.NoNameservers, dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
 					raise ValueError("Could not resolve the IP address of %s." % item)

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -976,12 +976,8 @@ def set_secondary_dns(hostnames, env):
 				try:
 					if "/" in item[4:]:
 						v = ipaddress.ip_network(item[4:]) # raises a ValueError if there's a problem
-						if not isinstance(v, ipaddress.IPv4Network) and not isinstance(v, ipaddress.IPv6Network):
-							raise ValueError("That's neither an IPv4 or IPv6 subnet.")
 					else:
 						v = ipaddress.ip_address(item[4:]) # raises a ValueError if there's a problem
-						if not isinstance(v, ipaddress.IPv4Address) and not isinstance(v, ipaddress.IPv6Address):
-							raise ValueError("That's neither an IPv4 or IPv6 address.")
 				except ValueError:
 					raise ValueError("'%s' is not an IPv4 or IPv6 address or subnet." % item[4:])
 

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -967,11 +967,10 @@ def set_secondary_dns(hostnames, env):
 				try:
 					response = resolver.query(item, "A")
 				except (dns.resolver.NoNameservers, dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
-					pass
-				try:
-					response = resolver.query(item, "AAAA")
-				except (dns.resolver.NoNameservers, dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
-					raise ValueError("Could not resolve the IP address of %s." % item)
+					try:
+						response = resolver.query(item, "AAAA")
+					except (dns.resolver.NoNameservers, dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
+						raise ValueError("Could not resolve the IP address of %s." % item)
 			else:
 				# Validate IP address.
 				try:

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -979,7 +979,7 @@ def set_secondary_dns(hostnames, env):
 							raise ValueError("That's neither an IPv4 or IPv6 subnet.")
 					else:
 						v = ipaddress.ip_address(item[4:]) # raises a ValueError if there's a problem
-						if not isinstance(v, ipaddress.IPv4Network) and not isinstance(v, ipaddress.IPv6Network):
+						if not isinstance(v, ipaddress.IPv4Address) and not isinstance(v, ipaddress.IPv6Address):
 							raise ValueError("That's neither an IPv4 or IPv6 address.")
 				except ValueError:
 					raise ValueError("'%s' is not an IPv4 or IPv6 address or subnet." % item[4:])

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -967,18 +967,22 @@ def set_secondary_dns(hostnames, env):
 				try:
 					response = resolver.query(item, "A")
 				except (dns.resolver.NoNameservers, dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
+					response = resolver.query(item, "AAAA")
+				except (dns.resolver.NoNameservers, dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
 					raise ValueError("Could not resolve the IP address of %s." % item)
 			else:
 				# Validate IP address.
 				try:
 					if "/" in item[4:]:
 						v = ipaddress.ip_network(item[4:]) # raises a ValueError if there's a problem
-						if not isinstance(v, ipaddress.IPv4Network): raise ValueError("That's an IPv6 subnet.")
+						if not isinstance(v, ipaddress.IPv4Network) and not isinstance(v, ipaddress.IPv6Network):
+							raise ValueError("That's neither an IPv4 or IPv6 subnet.")
 					else:
 						v = ipaddress.ip_address(item[4:]) # raises a ValueError if there's a problem
-						if not isinstance(v, ipaddress.IPv4Address): raise ValueError("That's an IPv6 address.")
+						if not isinstance(v, ipaddress.IPv4Network) and not isinstance(v, ipaddress.IPv6Network):
+							raise ValueError("That's neither an IPv4 or IPv6 address.")
 				except ValueError:
-					raise ValueError("'%s' is not an IPv4 address or subnet." % item[4:])
+					raise ValueError("'%s' is not an IPv4 or IPv6 address or subnet." % item[4:])
 
 		# Set.
 		set_custom_dns_record("_secondary_nameserver", "A", " ".join(hostnames), "set", env)

--- a/management/templates/custom-dns.html
+++ b/management/templates/custom-dns.html
@@ -90,7 +90,7 @@
     <div class="col-sm-offset-1 col-sm-11">
       <p class="small">
         Multiple secondary servers can be separated with commas or spaces (i.e., <code>ns2.hostingcompany.com ns3.hostingcompany.com</code>). 
-        To enable zone transfers to additional servers without listing them as secondary nameservers, add an IP address or subnet using <code>xfr:10.20.30.40</code> or <code>xfr:10.20.30.40/24</code>.
+        To enable zone transfers to additional servers without listing them as secondary nameservers, add an IP address or subnet using <code>xfr:10.20.30.40</code> or <code>xfr:10.0.0.0/8</code>.
       </p>
       <p id="secondarydns-clear-instructions" style="display: none" class="small">
         Clear the input field above and click Update to use this machine itself as secondary DNS, which is the default/normal setup.


### PR DESCRIPTION
I don't see the reasoning behind not allowing to designate IPv6 servers to receive XFR transfers.
(For example, `xfr:2001:470:600::2`)