### PR TITLE
Drop requirement for passwords to have no spaces

### DIFF
--- a/management/mailconfig.py
+++ b/management/mailconfig.py
@@ -605,8 +605,6 @@ def validate_password(pw):
 	# validate password
 	if pw.strip() == "":
 		raise ValueError("No password provided.")
-	if re.search(r"[\s]", pw):
-		raise ValueError("Passwords cannot contain spaces.")
 	if len(pw) < 8:
 		raise ValueError("Passwords must be at least eight characters.")
 

--- a/tools/mail.py
+++ b/tools/mail.py
@@ -33,9 +33,6 @@ def read_password():
         if len(first) < 8:
             print("Passwords must be at least eight characters.")
             continue
-        if re.search(r'[\s]', first):
-            print("Passwords cannot contain spaces.")
-            continue
         second = getpass.getpass(' (again): ')
         if first != second:
             print("Passwords not the same. Try again.")


### PR DESCRIPTION
There does not seem to be a reasonable reason to keep this constraint in place. Password/phrase generation techniques like [Diceware](https://theworld.com/~reinhold/diceware.html) make use of spaces, so I don't think it's any worth it to keep this restriction in place.

I have done some testing and it doesn't seem like passwords containing spaces affect anything really - correct me if I'm wrong!

See also: https://discourse.mailinabox.email/t/6612