### PR TITLE
Add 'always' modifier to the HSTS add_header directive

### DIFF
--- a/management/web_update.py
+++ b/management/web_update.py
@@ -188,9 +188,9 @@ def make_domain_config(domain, templates, ssl_certificates, env):
 
 	# Add the HSTS header.
 	if hsts == "yes":
-		nginx_conf_extra += "add_header Strict-Transport-Security max-age=15768000;\n"
+		nginx_conf_extra += "add_header Strict-Transport-Security \"max-age=15768000\" always;\n"
 	elif hsts == "preload":
-		nginx_conf_extra += "add_header Strict-Transport-Security \"max-age=15768000; includeSubDomains; preload\";\n"
+		nginx_conf_extra += "add_header Strict-Transport-Security \"max-age=15768000; includeSubDomains; preload\" always;\n"
 
 	# Add in any user customizations in the includes/ folder.
 	nginx_conf_custom_include = os.path.join(env["STORAGE_ROOT"], "www", safe_domain_name(domain) + ".conf")


### PR DESCRIPTION
This will make it so that the HSTS header is sent regardless of the request status code (until this point it would only be sent if "the response code equals 200, 201, 206, 301, 302, 303, 307, or 308." - according to the [relevant documentation](http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header))