### PR TITLE
Add noindex to www_default meta tags

### DIFF
--- a/conf/www_default.html
+++ b/conf/www_default.html
@@ -1,7 +1,7 @@
 <html>
 	<head>
 		<title>this is a mail-in-a-box</title>
-        	<meta name="robots" content="noindex, nofollow">
+        	<meta name="robots" content="noindex">
 	</head>
 	<body>
 		<h1>this is a mail-in-a-box</h1>

--- a/conf/www_default.html
+++ b/conf/www_default.html
@@ -1,6 +1,7 @@
 <html>
 	<head>
 		<title>this is a mail-in-a-box</title>
+        <meta name="robots" content="noindex, nofollow">
 	</head>
 	<body>
 		<h1>this is a mail-in-a-box</h1>

--- a/conf/www_default.html
+++ b/conf/www_default.html
@@ -1,7 +1,7 @@
 <html>
 	<head>
 		<title>this is a mail-in-a-box</title>
-        	<meta name="robots" content="noindex">
+		<meta name="robots" content="noindex">
 	</head>
 	<body>
 		<h1>this is a mail-in-a-box</h1>

--- a/conf/www_default.html
+++ b/conf/www_default.html
@@ -1,7 +1,7 @@
 <html>
 	<head>
 		<title>this is a mail-in-a-box</title>
-        <meta name="robots" content="noindex, nofollow">
+        	<meta name="robots" content="noindex, nofollow">
 	</head>
 	<body>
 		<h1>this is a mail-in-a-box</h1>


### PR DESCRIPTION
Hi there,

first of all: Thanks for the great product :) I really like the idea of self hosting mail :)
During the setup, I came up with one way to improve the mail-in-a-box security.

In my opinion there is no reason for a mail-in-a-box owner to have a searchengine to follow* or index the default website of mail in a box.

By indexing the default page, you make your box more vulnerable to Google Dorks (see https://securitytrails.com/blog/google-hacking-techniques).
Thus, I would suggest to put in a nofollow\* and noindex meta tag to the default www page.

Example Google Query to find a good amount of vulnerable boxes, iff a 0day is found:
https://www.google.de/search?q=%22this+is+a+mail-in-a-box%22

\* I think we could discuss about the nofollow tag, since mail-in-a-box propably wants to get some traffic and a good page rank. 