### PR TITLE
OCSP Stapling Support for NGINX

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -42,6 +42,8 @@ server {
 
 	ssl_certificate $SSL_CERTIFICATE;
 	ssl_certificate_key $SSL_KEY;
+    ssl_stapling on;
+    ssl_stapling_verify on;
 
 	# ADDITIONAL DIRECTIVES HERE
 }


### PR DESCRIPTION
Added support for OCSP Stapling.  Will not cause a problem if the cert does not have `--must-staple` 
#1792 