### PR TITLE
status_checks.py: Properly terminate the process pools

### DIFF
--- a/management/daemon.py
+++ b/management/daemon.py
@@ -437,9 +437,8 @@ def system_status():
 			self.items[-1]["extra"].append({ "text": message, "monospace": monospace })
 	output = WebOutput()
 	# Create a temporary pool of processes for the status checks
-	pool = multiprocessing.pool.Pool(processes=5)
-	run_checks(False, env, output, pool)
-	pool.terminate()
+	with multiprocessing.pool.Pool(processes=5) as pool:
+		run_checks(False, env, output, pool)
 	return json_response(output.items)
 
 @app.route('/system/updates')

--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -1023,12 +1023,12 @@ if __name__ == "__main__":
 	env = load_environment()
 
 	if len(sys.argv) == 1:
-		pool = multiprocessing.pool.Pool(processes=10)
-		run_checks(False, env, ConsoleOutput(), pool)
+		with multiprocessing.pool.Pool(processes=10) as pool:
+			run_checks(False, env, ConsoleOutput(), pool)
 
 	elif sys.argv[1] == "--show-changes":
-		pool = multiprocessing.pool.Pool(processes=10)
-		run_and_output_changes(env, pool)
+		with multiprocessing.pool.Pool(processes=10) as pool:
+			run_and_output_changes(env, pool)
 
 	elif sys.argv[1] == "--check-primary-hostname":
 		# See if the primary hostname appears resolvable and has a signed certificate.

--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -1021,12 +1021,13 @@ if __name__ == "__main__":
 	from utils import load_environment
 
 	env = load_environment()
-	pool = multiprocessing.pool.Pool(processes=10)
 
 	if len(sys.argv) == 1:
+		pool = multiprocessing.pool.Pool(processes=10)
 		run_checks(False, env, ConsoleOutput(), pool)
 
 	elif sys.argv[1] == "--show-changes":
+		pool = multiprocessing.pool.Pool(processes=10)
 		run_and_output_changes(env, pool)
 
 	elif sys.argv[1] == "--check-primary-hostname":


### PR DESCRIPTION
We're currently relying on Python's garbage collector to clean the process pools (we don't explicitly discard them in some situations):

> Note that is **not correct** to rely on the garbage colletor to destroy the pool as CPython does not assure that the finalizer of the pool will be called

[Source](https://docs.python.org/3.8/library/multiprocessing.html#module-multiprocessing.pool)

While at the moment (fortunately) the Python's GC *does* finalize the pool even if we do not (in Ubuntu 18.04), in Ubuntu 20.04 this is no longer the case. (so this is kinda fixing the bug before it happens) **Issues include:**

- Configuration hanging at the very end when the setup tries to determine whether to show `https://fqdn/admin` or `https://ip/admin`;
- The daily tasks cronjob will never actually finish because processes are never cleaned up. Over the days this will basically cause an huge memory leak.

**Addendum:** The source/warning I linked is technically only valid for Python 3.7 and later (MiaB runs on Ubuntu 18.04, which comes with Python 3.6). However, the patch is still valid for this version (and that's one less headache we need to deal with two years from now)