### PR TITLE
Roundcube 1.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ DNS:
 
 * autoconfig and autodiscover subdomains and CalDAV/CardDAV SRV records are no longer generated for domains that don't have user accounts since they are unnecessary.
 
+
+v0.47 (July 26, 2020)
+---------------------
+
+Security fixes:
+
+* Roundcube is updated to version 1.4.7 (https://roundcube.net/news/2020/07/05/security-updates-1.4.7-1.3.14-and-1.2.11).
+
 v0.46 (June 11, 2020)
 ---------------------
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ by him:
 	$ curl -s https://keybase.io/joshdata/key.asc | gpg --import
 	gpg: key C10BDD81: public key "Joshua Tauberer <jt@occams.info>" imported
 
-	$ git verify-tag v0.46
+	$ git verify-tag v0.47
 	gpg: Signature made ..... using RSA key ID C10BDD81
 	gpg: Good signature from "Joshua Tauberer <jt@occams.info>"
 	gpg: WARNING: This key is not certified with a trusted signature!
@@ -76,7 +76,7 @@ and on his [personal homepage](https://razor.occams.info/). (Of course, if this 
 
 Checkout the tag corresponding to the most recent release:
 
-	$ git checkout v0.46
+	$ git checkout v0.47
 
 Begin the installation.
 

--- a/setup/bootstrap.sh
+++ b/setup/bootstrap.sh
@@ -20,7 +20,7 @@ if [ -z "$TAG" ]; then
 	# want to display in status checks.
 	if [ "`lsb_release -d | sed 's/.*:\s*//' | sed 's/18\.04\.[0-9]/18.04/' `" == "Ubuntu 18.04 LTS" ]; then
 		# This machine is running Ubuntu 18.04.
-		TAG=v0.46
+		TAG=v0.47
 
 	elif [ "`lsb_release -d | sed 's/.*:\s*//' | sed 's/14\.04\.[0-9]/14.04/' `" == "Ubuntu 14.04 LTS" ]; then
 		# This machine is running Ubuntu 14.04.

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -28,8 +28,8 @@ apt_install \
 # Install Roundcube from source if it is not already present or if it is out of date.
 # Combine the Roundcube version number with the commit hash of plugins to track
 # whether we have the latest version of everything.
-VERSION=1.4.6
-HASH=44961ef62bb9c9875141ca34704bbc7d6f36373d
+VERSION=1.4.7
+HASH=49F194D25AC7B9BF175BD52285BB61CDE7BAED44
 PERSISTENT_LOGIN_VERSION=6b3fc450cae23ccb2f393d0ef67aa319e877e435
 HTML5_NOTIFIER_VERSION=4b370e3cd60dabd2f428a26f45b677ad1b7118d5
 CARDDAV_VERSION=3.0.3


### PR DESCRIPTION
This pull request updates roundcube to 1.4.7 as proposed by #1797. 

I did test the change by installing the patched version on a fresh ubuntu machine. I checked if webmail shows 1.4.7 version and it does. I did not link a domain to the machine and thus I did not perform extensive testing.

Is there any guideline on how much to test new versions? According to the [changelog](https://github.com/roundcube/roundcubemail/releases/tag/1.4.7), no change happened which could apply mailinabox (imho) - except for the security part of course.