### PR TITLE
Raise Dovecot per user connection limit

### DIFF
--- a/setup/mail-dovecot.sh
+++ b/setup/mail-dovecot.sh
@@ -144,7 +144,7 @@ service imap-login {
   }
 }
 protocol imap {
-  mail_max_userip_connections = 20
+  mail_max_userip_connections = 40
 }
 EOF
 


### PR DESCRIPTION
I have several users (including me) that run into a problem with Dovecot connection limits like this in Apple Mail (possibly other clients too):

    The server returned the error: Maximum number of connections from user+IP exceeded (mail_max_userip_connections=20)

In these cases, the users typically have several accounts on the same server, and multiple devices connecting to all of them (e.g. desktop, iPad, iPhone) from within the same NATed network, resulting in relatively large connection counts for the same IP. While that's understandable, it suffers from two other problems:

1. If the limit is exceeded, *all* connections from that IP start to fail, not just new ones over the limit, and affected users can't fetch any mail at all.
2. If I update the limit manually (as I have done in the past), updating MIAB resets the the limit to its original value.

So this PR doubles the user+IP connection limit for Dovecot in order to try to avoid this problem, but it's still low enough to be unlikely to cause overall connection limit issues.