### PR TITLE
Update "Remove Alias" modal title

### DIFF
--- a/management/templates/aliases.html
+++ b/management/templates/aliases.html
@@ -288,7 +288,7 @@ function aliases_remove(elem) {
         },
         function(r) {
           // Responses are multiple lines of pre-formatted text.
-          show_modal_error("Remove User", $("<pre/>").text(r));
+          show_modal_error("Remove Alias", $("<pre/>").text(r));
           show_aliases();
         });
     });


### PR DESCRIPTION
After removing a mail alias, the response is displayed within a modal titled "Remove User".

This change updates the modal title so that it reads "Remove Alias".