### PR TITLE
Warn when connection to Spamhaus times out

### DIFF
--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -293,6 +293,8 @@ def run_network_checks(env, output):
 	zen = query_dns(rev_ip4+'.zen.spamhaus.org', 'A', nxdomain=None)
 	if zen is None:
 		output.print_ok("IP address is not blacklisted by zen.spamhaus.org.")
+	elif zen == "[timeout]":
+		output.print_warning("Connection to zen.spamhaus.org timed out. We could not determine whether your server's IP address {} is blacklisted. Please try again later.".format(rev_ip4))
 	else:
 		output.print_error("""The IP address of this machine %s is listed in the Spamhaus Block List (code %s),
 			which may prevent recipients from receiving your email. See http://www.spamhaus.org/query/ip/%s."""
@@ -675,9 +677,12 @@ def check_mail_domain(domain, env, output):
 	# Stop if the domain is listed in the Spamhaus Domain Block List.
 	# The user might have chosen a domain that was previously in use by a spammer
 	# and will not be able to reliably send mail.
-	dbl = query_dns(domain+'.dbl.spamhaus.org', "A", nxdomain=None)
+	dbl = query_dns(domain+".dbl.spamhaus.org", "A", nxdomain=None)
+
 	if dbl is None:
 		output.print_ok("Domain is not blacklisted by dbl.spamhaus.org.")
+	elif dbl == "[timeout]":
+		output.print_warning("Connection to dbl.spamhaus.org timed out. We could not determine whether the domain {} is blacklisted. Please try again later.".format(domain))
 	else:
 		output.print_error("""This domain is listed in the Spamhaus Domain Block List (code %s),
 			which may prevent recipients from receiving your mail.

--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -294,7 +294,7 @@ def run_network_checks(env, output):
 	if zen is None:
 		output.print_ok("IP address is not blacklisted by zen.spamhaus.org.")
 	elif zen == "[timeout]":
-		output.print_warning("Connection to zen.spamhaus.org timed out. We could not determine whether your server's IP address {} is blacklisted. Please try again later.".format(rev_ip4))
+		output.print_warning("Connection to zen.spamhaus.org timed out. We could not determine whether your server's IP address is blacklisted. Please try again later.")
 	else:
 		output.print_error("""The IP address of this machine %s is listed in the Spamhaus Block List (code %s),
 			which may prevent recipients from receiving your email. See http://www.spamhaus.org/query/ip/%s."""

--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -678,7 +678,6 @@ def check_mail_domain(domain, env, output):
 	# The user might have chosen a domain that was previously in use by a spammer
 	# and will not be able to reliably send mail.
 	dbl = query_dns(domain+".dbl.spamhaus.org", "A", nxdomain=None)
-
 	if dbl is None:
 		output.print_ok("Domain is not blacklisted by dbl.spamhaus.org.")
 	elif dbl == "[timeout]":

--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -677,7 +677,7 @@ def check_mail_domain(domain, env, output):
 	# Stop if the domain is listed in the Spamhaus Domain Block List.
 	# The user might have chosen a domain that was previously in use by a spammer
 	# and will not be able to reliably send mail.
-	dbl = query_dns(domain+".dbl.spamhaus.org", "A", nxdomain=None)
+	dbl = query_dns(domain+'.dbl.spamhaus.org', "A", nxdomain=None)
 	if dbl is None:
 		output.print_ok("Domain is not blacklisted by dbl.spamhaus.org.")
 	elif dbl == "[timeout]":


### PR DESCRIPTION
This prints a warning rather than an error when a `Timeout` is raised and `query_dns()` then returns `"[timeout]"`.
Decided against explicit checks for Spamhaus error codes ([zen](https://www.spamhaus.org/zen/) [dbl](https://www.spamhaus.org/faq/section/Spamhaus%20DBL#291)) for now to keep it simple.

closes #1816