### PR TITLE
Increase mta-sts max_age to one week

### DIFF
--- a/conf/mta-sts.txt
+++ b/conf/mta-sts.txt
@@ -1,4 +1,4 @@
 version: STSv1
 mode: MODE
 mx: PRIMARY_HOSTNAME
-max_age: 86400
+max_age: 604800


### PR DESCRIPTION
This aligns the policy with the example policy found in the spec. See: https://tools.ietf.org/html/rfc8461#section-3.2

references #1828 