### PR TITLE
Display dates in ISO format

### DIFF
--- a/management/backup.py
+++ b/management/backup.py
@@ -51,7 +51,7 @@ def backup_status(env):
 		date = dateutil.parser.parse(keys[1]).astimezone(dateutil.tz.tzlocal())
 		return {
 			"date": keys[1],
-			"date_str": date.isoformat() + " (" + now.tzname() + ")",
+			"date_str": date.strftime("%Y-%m-%d %X") + " " + now.tzname(),
 			"date_delta": reldate(date, now, "the future?"),
 			"full": keys[0] == "full",
 			"size": 0, # collection-status doesn't give us the size

--- a/management/backup.py
+++ b/management/backup.py
@@ -51,7 +51,7 @@ def backup_status(env):
 		date = dateutil.parser.parse(keys[1]).astimezone(dateutil.tz.tzlocal())
 		return {
 			"date": keys[1],
-			"date_str": date.strftime("%Y-%m-%d %X") + " " + now.tzname(),
+			"date_str": date.isoformat() + " (" + now.tzname() + ")",
 			"date_delta": reldate(date, now, "the future?"),
 			"full": keys[0] == "full",
 			"size": 0, # collection-status doesn't give us the size

--- a/management/ssl_certificates.py
+++ b/management/ssl_certificates.py
@@ -216,12 +216,12 @@ def get_certificates_to_provision(env, limit_domains=None, show_valid_certs=True
 				response = query_dns(domain, rtype)
 				if response != normalize_ip(value):
 					bad_dns.append("%s (%s)" % (response, rtype))
-	
+
 			if bad_dns:
 				domains_cant_provision[domain] = "The domain name does not resolve to this machine: " \
 					+ (", ".join(bad_dns)) \
 					+ "."
-			
+
 			else:
 				# DNS is all good.
 
@@ -606,10 +606,10 @@ def check_certificate(domain, ssl_certificate, ssl_private_key, warn_if_expiring
 		ndays = (cert_expiration_date-now).days
 		if not rounded_time or ndays <= 10:
 			# Yikes better renew soon!
-			expiry_info = "The certificate expires in %d days on %s." % (ndays, cert_expiration_date.strftime("%x"))
+			expiry_info = "The certificate expires in %d days on %s." % (ndays, cert_expiration_date.date().isoformat())
 		else:
 			# We'll renew it with Lets Encrypt.
-			expiry_info = "The certificate expires on %s." % cert_expiration_date.strftime("%x")
+			expiry_info = "The certificate expires on %s." % cert_expiration_date.date().isoformat()
 
 		if warn_if_expiring_soon and ndays <= warn_if_expiring_soon:
 			# Warn on day 10 to give 4 days for us to automatically renew the


### PR DESCRIPTION
Fixes #1831.

For the sake of consistency, I also changed the backups page to use `.isoformat()` as opposed to `.strftime()` - which slightly changes how the date is displayed. Screenshots below.

![image](https://user-images.githubusercontent.com/45321798/96144706-5ecd6a80-0efc-11eb-9cb0-2b748dd42545.png)
![image](https://user-images.githubusercontent.com/45321798/96144772-70af0d80-0efc-11eb-8111-a17be1889629.png)
![image](https://user-images.githubusercontent.com/45321798/96144880-8cb2af00-0efc-11eb-988d-c16aa1fb33cb.png)
