### PR TITLE
Don't check mfa for /munin/* admin routes

### DIFF
--- a/management/mfa.py
+++ b/management/mfa.py
@@ -110,6 +110,14 @@ def validate_auth_mfa(email, request, env):
 	if len(mfa_state) == 0:
 		return (True, [])
 
+	# munin routes are proxied by our control panel. We do not have
+	# full control over their routes so credentials are supplied via
+	# a basic HTTP authentication prompt.
+	# There is neither a way to input a mfa credential there nor can we pass
+	# the user_api_key from localStorage so mfa should be disabled for these routes.
+	if request.full_path.startswith("/munin"):
+		return (True, [])
+
 	# Try the enabled MFA modes.
 	hints = set()
 	for mfa_mode in mfa_state:


### PR DESCRIPTION
This excludes routes starting with `/munin` from mfa checks. I decided to add the conditional in `mfa.py` rather than `auth.py` to keep the control flow in `auth.py` clear. There is less risk to inadvertently introduce a bug this way imo.

closes #1865
