### PR TITLE
Api spec cleanup

### DIFF
--- a/api/mailinabox.yml
+++ b/api/mailinabox.yml
@@ -744,30 +744,30 @@ paths:
               schema:
                 type: string
   /dns/zonefile/{zone}:
-      get:
-          tags:
-              - DNS
-          summary: Get DNS zonefile
-          description: Returns an array of all managed top-level domains.
-          operationId: getDnsZonefile
-          x-codeSamples:
-              - lang: curl
-                source: |
-                    curl -X GET "https://{host}/admin/dns/zonefile/<zone>" \
-                      -u "<email>:<password>"
-          responses:
-              200:
-                  description: Successful operation
-                  content:
-                      application/json:
-                          schema:
-                              $ref: '#/components/schemas/DNSZonefileResponse'
-              403:
-                  description: Forbidden
-                  content:
-                      text/html:
-                          schema:
-                              type: string
+    get:
+      tags:
+        - DNS
+      summary: Get DNS zonefile
+      description: Returns an array of all managed top-level domains.
+      operationId: getDnsZonefile
+      x-codeSamples:
+        - lang: curl
+          source: |
+            curl -X GET "https://{host}/admin/dns/zonefile/<zone>" \
+              -u "<email>:<password>"
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DNSZonefileResponse'
+        403:
+          description: Forbidden
+          content:
+            text/html:
+              schema:
+                type: string
   /dns/update:
     post:
       tags:

--- a/api/mailinabox.yml
+++ b/api/mailinabox.yml
@@ -1813,7 +1813,7 @@ components:
         text/plain:
           schema:
             type: string
-            example: 1.2.3.4
+            example: '1.2.3.4'
             description: The value of the DNS record.
           example: '1.2.3.4'
   schemas:

--- a/api/mailinabox.yml
+++ b/api/mailinabox.yml
@@ -744,11 +744,18 @@ paths:
               schema:
                 type: string
   /dns/zonefile/{zone}:
+    parameters:
+      - in: path
+        name: zone
+        schema:
+          $ref: '#/components/schemas/Hostname'
+        required: true
+        description: Hostname
     get:
       tags:
         - DNS
       summary: Get DNS zonefile
-      description: Returns an array of all managed top-level domains.
+      description: Returns a DNS zone file for a hostname.
       operationId: getDnsZonefile
       x-codeSamples:
         - lang: curl
@@ -2690,13 +2697,6 @@ components:
           type: string
     MfaEnableSuccessResponse:
       type: string
-    MfaEnableBadRequestResponse:
-      type: object
-      required:
-        - error
-      properties:
-        error:
-          type: string
     MfaDisableRequest:
       type: object
       properties:

--- a/api/mailinabox.yml
+++ b/api/mailinabox.yml
@@ -15,7 +15,7 @@ info:
   license:
     name: CC0 1.0 Universal
     url: https://creativecommons.org/publicdomain/zero/1.0/legalcode
-  version: 0.47.0
+  version: 0.51.0
   x-logo:
     url: https://mailinabox.email/static/logo.png
     altText: Mail-in-a-Box logo


### PR DESCRIPTION
I validated the API spec with https://github.com/OpenAPITools/openapi-generator-cli and noticed a couple of issues. 

With these changes the validation passes

```sh
> mailinabox-api@0.0.0 validate /Users/richardwillis/Projects/badsyntax/mailinabox-api
> openapi-generator-cli validate -i schema/mailinabox.yml

Validating spec (schema/mailinabox.yml)
No validation issues detected.
```