### PR TITLE
Adjust max-recursion-queries to fix alternating reverse DNS status

### DIFF
--- a/setup/system.sh
+++ b/setup/system.sh
@@ -320,12 +320,19 @@ fi #NODOC
 #   name server, on IPV6.
 # * The listen-on directive in named.conf.options restricts `bind9` to
 #   binding to the loopback interface instead of all interfaces.
+# * The max-recursion-queries directive increases the maximum number of iterative queries.
+#  	If more queries than specified are sent, bind9 returns SERVFAIL. After flushing the cache during system checks,
+#	we ran into the limit thus we are increasing it from 75 (default value) to 100.
 apt_install bind9
 tools/editconf.py /etc/default/bind9 \
 	"OPTIONS=\"-u bind -4\""
 if ! grep -q "listen-on " /etc/bind/named.conf.options; then
 	# Add a listen-on directive if it doesn't exist inside the options block.
 	sed -i "s/^}/\n\tlisten-on { 127.0.0.1; };\n}/" /etc/bind/named.conf.options
+fi
+if ! grep -q "max-recursion-queries " /etc/bind/named.conf.options; then
+	# Add a max-recursion-queries directive if it doesn't exist inside the options block.
+	sed -i "s/^}/\n\tmax-recursion-queries 100;\n}/" /etc/bind/named.conf.options
 fi
 
 # First we'll disable systemd-resolved's management of resolv.conf and its stub server.


### PR DESCRIPTION
**Problem** Users (including me) have encountered an alternating Reverse DNS status in their nightly status mail. It would switch from working to not working and vice versa - seemingly without any reason.

**Underlying problem** (my best guess) The problems occurs after bind9's cache has been flushed. Doing a reverse DNS query requires lots of "subqueries" to finally reach the server which can tell about the rdns entry. For security reasons, bind9 implemented a max-recursion-queries which is set to 75 by default. If the cache is empty, this limit is sometimes exceeded and bind9 quits with a SERVFAIL. I found [traces](https://lists.isc.org/pipermail/bind-users/2014-December/094240.html) of this problem going back until 2014 (when max-recursion-queries was introduced):

> However, in this case I think it's because you had an empty cache, and
> sending a second query will clear the problem up.  In a future release, we
> may want to lift the restrictions temporarily while priming.

(This is exactly our situation and also explains why the status if fine if checking again in the control panel or sending the same query again - the cache has been filled and the second query does not exceed the limits because some information exist in cache already).

The limit of 75 is being discussed and in the newest release of bind9 the [limit will be increased to 100](https://gitlab.isc.org/isc-projects/bind9/-/issues/2305) since other user have the same problem as we have.

**Solution** I propose to catch up with the new limit of 100 to make it less more likely to exceed the limit. I am not saying that the problem will never occur again, but hopefully it will occur less often. 

**Fixes**  #628 #1270 etc.

**Further Information** I installed this fix on my production server. Dry-runs look good, but I recommend to integrate this pull request not now but in a few days/weeks to find out if there are any side effects or if the problem is still not fixed.