### PR TITLE
Include en_US.UTF-8 locale in daemon startup

### DIFF
--- a/setup/management.sh
+++ b/setup/management.sh
@@ -90,6 +90,12 @@ rm -f /tmp/bootstrap.zip
 # running after a reboot.
 cat > $inst_dir/start <<EOF;
 #!/bin/bash
+# Set character encoding flags to ensure that any non-ASCII don't cause problems.
+export LANGUAGE=en_US.UTF-8
+export LC_ALL=en_US.UTF-8
+export LANG=en_US.UTF-8
+export LC_TYPE=en_US.UTF-8
+
 source $venv/bin/activate
 exec python `pwd`/management/daemon.py
 EOF


### PR DESCRIPTION
Fixes: #1881

How I tested:

* Created this PR --> Works!
* Created a smiliar patch but with "C" as locales (https://github.com/hija/mailinabox/blob/daemon-locales-broken/setup/management.sh#L94) --> Did not work!

So I think this should fix the bugs related to wrong locales when starting the daemon.