### PR TITLE
installation error after add b2

### DIFF
--- a/setup/management.sh
+++ b/setup/management.sh
@@ -30,7 +30,7 @@ apt_install duplicity python-pip virtualenv certbot
 # b2sdk is used for backblaze backups.
 # boto is used for amazon aws backups.
 # Both are installed outside the pipenv, so they can be used by duplicity
-hide_output pip3 install --upgrade setuptools
+hide_output pip3 install setuptools wheel
 hide_output pip3 install --upgrade b2sdk boto
 
 # Create a virtualenv for the installation of Python 3 packages

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -30,7 +30,7 @@ apt_install duplicity python-pip virtualenv certbot
 # b2sdk is used for backblaze backups.
 # boto is used for amazon aws backups.
 # Both are installed outside the pipenv, so they can be used by duplicity
-hide_output pip3 install setuptools wheel
+hide_output pip3 install --upgrade setuptools wheel
 hide_output pip3 install --upgrade b2sdk boto
 
 # Create a virtualenv for the installation of Python 3 packages

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -30,6 +30,7 @@ apt_install duplicity python-pip virtualenv certbot
 # b2sdk is used for backblaze backups.
 # boto is used for amazon aws backups.
 # Both are installed outside the pipenv, so they can be used by duplicity
+hide_output pip3 install --upgrade setuptools
 hide_output pip3 install --upgrade b2sdk boto
 
 # Create a virtualenv for the installation of Python 3 packages

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -131,7 +131,7 @@ apt_get_quiet autoremove
 # * openssh-client: provides ssh-keygen
 
 echo Installing system packages...
-apt_install python3 python3-dev python3-pip \
+apt_install python3 python3-dev python3-pip python3-setuptools \
 	netcat-openbsd wget curl git sudo coreutils bc \
 	haveged pollinate openssh-client unzip \
 	unattended-upgrades cron ntp fail2ban rsyslog

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -131,7 +131,7 @@ apt_get_quiet autoremove
 # * openssh-client: provides ssh-keygen
 
 echo Installing system packages...
-apt_install python3 python3-dev python3-pip python3-setuptools \
+apt_install python3 python3-dev python3-pip \
 	netcat-openbsd wget curl git sudo coreutils bc \
 	haveged pollinate openssh-client unzip \
 	unattended-upgrades cron ntp fail2ban rsyslog


### PR DESCRIPTION
Hi.
On clean install from master I had error
```
FAILED: pip3 install --upgrade b2sdk boto
-----------------------------------------
The directory '/home/***/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
The directory '/home/***/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
Collecting b2sdk
  Downloading https://files.pythonhosted.org/packages/50/4c/2e00d4f1e45692f66132c539edb3f9f3fc0a8938c6d49c151d1f72bb6fc2/b2sdk-1.2.0.tar.gz (172kB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
    ModuleNotFoundError: No module named 'setuptools'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-l1dici5k/b2sdk/
```

This PR fix it