### PR TITLE
Update mail.py - correct reference to replacement.

### DIFF
--- a/tools/mail.py
+++ b/tools/mail.py
@@ -1,3 +1,3 @@
 #!/bin/bash
 # This script has moved.
-management/cli.py "$@"
+../management/cli.py "$@"


### PR DESCRIPTION
make this script usable again.

this change added the ability to include this script again without touching all scripts that include this - like `owncloud-unlockadmin.sh`. I guess without this change those scripts would harm more than that it helps.