### PR TITLE
Fixes #1909  unbound variable when upgrading from Nextcloud 13

### DIFF
--- a/setup/nextcloud.sh
+++ b/setup/nextcloud.sh
@@ -24,8 +24,8 @@ InstallNextcloud() {
 	hash_contacts=$4
 	version_calendar=$5
 	hash_calendar=$6
-	version_user_external=$7
-	hash_user_external=$8
+	version_user_external=${7:-}
+	hash_user_external=${8:-}
 
 	echo
 	echo "Upgrading to Nextcloud version $version"


### PR DESCRIPTION
Should fix #1909 as the upgrade from Nextcloud 13 to 14 does not use user_external during the upgrade, the InstallNextcloud function already skips doing an install of user_external if user_external variable aka $7 is empty.