### PR TITLE
Enable sending DMARC failure reports

### DIFF
--- a/setup/dkim.sh
+++ b/setup/dkim.sh
@@ -63,7 +63,7 @@ chmod go-rwx $STORAGE_ROOT/mail/dkim
 tools/editconf.py /etc/opendmarc.conf -s \
 	"Syslog=true" \
 	"Socket=inet:8893@[127.0.0.1]" \
-    "FailureReports=true"
+	"FailureReports=true"
 
 # SPFIgnoreResults causes the filter to ignore any SPF results in the header
 # of the message. This is useful if you want the filter to perfrom SPF checks

--- a/setup/dkim.sh
+++ b/setup/dkim.sh
@@ -62,7 +62,8 @@ chmod go-rwx $STORAGE_ROOT/mail/dkim
 
 tools/editconf.py /etc/opendmarc.conf -s \
 	"Syslog=true" \
-	"Socket=inet:8893@[127.0.0.1]"
+	"Socket=inet:8893@[127.0.0.1]" \
+    "FailureReports=true"
 
 # SPFIgnoreResults causes the filter to ignore any SPF results in the header
 # of the message. This is useful if you want the filter to perfrom SPF checks
@@ -80,6 +81,12 @@ tools/editconf.py /etc/opendmarc.conf -s \
 
 tools/editconf.py /etc/opendmarc.conf -s \
         "SPFSelfValidate=true"
+
+# Enables generation of failure reports for sending domains that publish a
+# "none" policy.
+
+tools/editconf.py /etc/opendmarc.conf -s \
+        "FailureReportsOnNone=true"
 
 # AlwaysAddARHeader Adds an "Authentication-Results:" header field even to
 # unsigned messages from domains with no "signs all" policy. The reported DKIM


### PR DESCRIPTION
Configures `opendmarc` to send failure reports for domains that request them, including when p=none.

The emails are sent as the package default name and user@hostname: OpenDMARC Filter \<opendmarc[]()@box.example.com\>

Note I have been running this for several months with a configuration I did not include in the PR to have reports BCC'd to me (`FailureReportsBcc postmaster@example.com`). Very low load for my personal server of rarely more than a dozen emails sent out per day.

I am not familiar with editing scripts, so apologies in advance and please feel free to correct errors.