### PR TITLE
sieve-spam.txt do not stop evaluation

### DIFF
--- a/conf/sieve-spam.txt
+++ b/conf/sieve-spam.txt
@@ -2,6 +2,5 @@ require ["regex", "fileinto", "imap4flags"];
 
 if allof (header :regex "X-Spam-Status" "^Yes") {
   fileinto "Spam";
-  stop;
 }
 


### PR DESCRIPTION
Hi 

I want to be able to discard messages with "X-Spam-Status" = ^YES

To do that I create a sieve in roundcube mail. 

But since the evaluation of Spam e-mails is stopped at a very early step of the processing the roundcube dovecot filter does not apply.

To make that possible the `stop;`command is removed.