### PR TITLE
Fix Nextcloud Contacts search

### DIFF
--- a/conf/nginx-primaryonly.conf
+++ b/conf/nginx-primaryonly.conf
@@ -18,6 +18,8 @@
 	rewrite ^/cloud$ /cloud/ redirect;
 	rewrite ^/cloud/$ /cloud/index.php;
 	rewrite ^/cloud/(contacts|calendar|files)$ /cloud/index.php/apps/$1/ redirect;
+	# Fixes Nextcloud Contacts search:
+	rewrite "^/cloud/apps/contacts/All contacts/(.*)$" /cloud/index.php/apps/contacts/All%20contacts/$1 redirect;
 	rewrite ^(/cloud/core/doc/[^\/]+/)$ $1/index.html;
 	rewrite ^(/cloud/oc[sm]-provider)/$ $1/index.php redirect;
 	location /cloud/ {


### PR DESCRIPTION
Using the search functionality within Nextcloud Contacs, the user will see a drop-down listing the matched results.

Each one of the results has a link in this format:

`https://{MIAB-domain}/cloud/index.php/apps/contacts/direct/{record-id}`

once the URL above is visited, it redirects to:

`https://{MIAB-domain}/cloud/apps/contacts/All contacts/{record-id}`

and the user gets a 404 message.

This PR fixes that.