### PR TITLE
Backup page info - S3-compatible

### DIFF
--- a/management/templates/system-backup.html
+++ b/management/templates/system-backup.html
@@ -5,7 +5,7 @@
 
 <h2>Backup Status</h2>
 
-<p>The box makes an incremental backup each night. By default the backup is stored on the machine itself, but you can also have it stored on Amazon S3.</p>
+<p>The box makes an incremental backup each night. By default the backup is stored on the machine itself, but you can also have it stored S3-compatible services like Amazon Web Services (AWS).</p>
 
 <h3>Configuration</h3>
 
@@ -17,7 +17,7 @@
         <option value="off">Nowhere (Disable Backups)</option>
         <option value="local">{{hostname}}</option>
         <option value="rsync">rsync</option>
-        <option value="s3">Amazon S3</option>
+        <option value="s3">S3 (Amazon or compatible) </option>
         <option value="b2">Backblaze B2</option>
       </select>
     </div>
@@ -73,8 +73,8 @@
   <!-- S3 BACKUP -->
   <div class="form-group backup-target-s3">
     <div class="col-sm-10 col-sm-offset-2">
-      <p>Backups are stored in an Amazon Web Services S3 bucket. You must have an AWS account already.</p>
-      <p>You MUST manually copy the encryption password from <tt class="backup-encpassword-file"></tt> to a safe and secure location. You will need this file to decrypt backup files. It is NOT stored in your Amazon S3 bucket.</p>
+      <p>Backups are stored in an S3-compatible bucket. You must have an AWS or other S3 service account already.</p>
+      <p>You MUST manually copy the encryption password from <tt class="backup-encpassword-file"></tt> to a safe and secure location. You will need this file to decrypt backup files. It is <b>NOT</b> stored in your S3 bucket.</p>
     </div>
   </div>
   <div class="form-group backup-target-s3">
@@ -84,7 +84,7 @@
         {% for name, host in backup_s3_hosts %}
           <option value="{{host}}">{{name}}</option>
         {% endfor %}
-        <option value="other">Other</option>
+        <option value="other">Other (non AWS)</option>
       </select>
     </div>
   </div>

--- a/management/templates/system-backup.html
+++ b/management/templates/system-backup.html
@@ -5,7 +5,7 @@
 
 <h2>Backup Status</h2>
 
-<p>The box makes an incremental backup each night. By default the backup is stored on the machine itself, but you can also have it stored S3-compatible services like Amazon Web Services (AWS).</p>
+<p>The box makes an incremental backup each night. By default the backup is stored on the machine itself, but you can also store in on S3-compatible services like Amazon Web Services (AWS).</p>
 
 <h3>Configuration</h3>
 


### PR DESCRIPTION
A couple of text changes to make it clearer that you can use other S3-compatible backup services as well as AWS. 

Prompted by discussion on MIAB discourse. 