### PR TITLE
#1946: fixing envelope-from on sieve redirecting

### DIFF
--- a/setup/mail-dovecot.sh
+++ b/setup/mail-dovecot.sh
@@ -183,7 +183,7 @@ plugin {
   sieve_after = $STORAGE_ROOT/mail/sieve/global_after
   sieve = $STORAGE_ROOT/mail/sieve/%d/%n.sieve
   sieve_dir = $STORAGE_ROOT/mail/sieve/%d/%n
-  sieve_redirect_envelope_from = orig_recipient'
+  sieve_redirect_envelope_from = recipient
 }
 EOF
 

--- a/setup/mail-dovecot.sh
+++ b/setup/mail-dovecot.sh
@@ -183,6 +183,7 @@ plugin {
   sieve_after = $STORAGE_ROOT/mail/sieve/global_after
   sieve = $STORAGE_ROOT/mail/sieve/%d/%n.sieve
   sieve_dir = $STORAGE_ROOT/mail/sieve/%d/%n
+  sieve_redirect_envelope_from = orig_recipient'
 }
 EOF
 
@@ -191,12 +192,6 @@ EOF
 # permission later.
 cp conf/sieve-spam.txt /etc/dovecot/sieve-spam.sieve
 sievec /etc/dovecot/sieve-spam.sieve
-
-# Adjust sieve to use local account's address as envelope-from in forwarding
-# mails to external MTAs (#1946).
-grep sieve_redirect_envelope_from /etc/dovecot/conf.d/99-local-sieve.conf  &>/dev/null || \
-	sed -i /etc/dovecot/conf.d/99-local-sieve.conf -e '/^}$/ i\
-  sieve_redirect_envelope_from = orig_recipient'
 
 # PERMISSIONS
 

--- a/setup/mail-dovecot.sh
+++ b/setup/mail-dovecot.sh
@@ -192,6 +192,12 @@ EOF
 cp conf/sieve-spam.txt /etc/dovecot/sieve-spam.sieve
 sievec /etc/dovecot/sieve-spam.sieve
 
+# Adjust sieve to use local account's address as envelope-from in forwarding
+# mails to external MTAs (#1946).
+grep sieve_redirect_envelope_from /etc/dovecot/conf.d/99-local-sieve.conf  &>/dev/null || \
+	sed -i /etc/dovecot/conf.d/99-local-sieve.conf -e '/^}$/ i\
+  sieve_redirect_envelope_from = orig_recipient'
+
 # PERMISSIONS
 
 # Ensure configuration files are owned by dovecot and not world readable.


### PR DESCRIPTION
adjusting dovecot configuration to use original recipient's address as envelope-from on redirecting mails to external MTA via sieve