### PR TITLE
handle query dns timeout

### DIFF
--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -621,6 +621,8 @@ def check_mail_domain(domain, env, output):
 
 	if mx is None:
 		mxhost = None
+	elif mx == "[timeout]":
+        mxhost = None
 	else:
 		# query_dns returns a semicolon-delimited list
 		# of priority-host pairs.


### PR DESCRIPTION
This PR handle exception when query_dns return a timeout
fix https://github.com/mail-in-a-box/mailinabox/issues/1011 and https://github.com/mail-in-a-box/mailinabox/issues/1904