### PR TITLE
`custom.yaml`: add support for X-Frame-Options header and proxy_redirect off

### DIFF
--- a/management/web_update.py
+++ b/management/web_update.py
@@ -176,7 +176,7 @@ def make_domain_config(domain, templates, ssl_certificates, env):
 				nginx_conf_extra += "\tlocation %s {" % path
 				nginx_conf_extra += "\n\t\tproxy_pass %s;" % url
 				if proxy_redirect_off:
-                                	nginx_conf_extra += "\n\t\tproxy_redirect off;"
+					nginx_conf_extra += "\n\t\tproxy_redirect off;"
 				if pass_http_host_header:
 					nginx_conf_extra += "\n\t\tproxy_set_header Host $http_host;"
 				if frame_options_header_sameorigin:

--- a/management/web_update.py
+++ b/management/web_update.py
@@ -160,17 +160,27 @@ def make_domain_config(domain, templates, ssl_certificates, env):
 			for path, url in yaml.get("proxies", {}).items():
 				# Parse some flags in the fragment of the URL.
 				pass_http_host_header = False
+				proxy_redirect_off = False
+				frame_options_header_sameorigin = False
 				m = re.search("#(.*)$", url)
 				if m:
 					for flag in m.group(1).split(","):
 						if flag == "pass-http-host":
 							pass_http_host_header = True
+						elif flag == "no-proxy-redirect":
+							proxy_redirect_off = True
+						elif flag == "frame-options-sameorigin":
+							frame_options_header_sameorigin = True
 					url = re.sub("#(.*)$", "", url)
 
 				nginx_conf_extra += "\tlocation %s {" % path
 				nginx_conf_extra += "\n\t\tproxy_pass %s;" % url
+				if proxy_redirect_off:
+                                	nginx_conf_extra += "\n\t\tproxy_redirect off;"
 				if pass_http_host_header:
 					nginx_conf_extra += "\n\t\tproxy_set_header Host $http_host;"
+				if frame_options_header_sameorigin:
+					nginx_conf_extra += "\n\t\tproxy_set_header X-Frame-Options SAMEORIGIN;"
 				nginx_conf_extra += "\n\t\tproxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;"
 				nginx_conf_extra += "\n\t\tproxy_set_header X-Forwarded-Host $http_host;"
 				nginx_conf_extra += "\n\t\tproxy_set_header X-Forwarded-Proto $scheme;"
@@ -251,3 +261,4 @@ def get_web_domains_info(env):
 		}
 		for domain in get_web_domains(env)
 	]
+


### PR DESCRIPTION
I needed to add `proxy_redirect off;` and `proxy_set_header X-Frame-Options SAMEORIGIN;` directives for my custom domain handled by the `custom.yaml` file.

This is what my `custom.yaml` file looks like following the changes:
```
mydomain.com:
  proxies:
    /: http://127.0.0.1:8080#pass-http-host,no-proxy-redirect,frame-options-sameorigin
```