### PR TITLE
Replace Spamhaus Zen Postfix blacklisting with stronger SpamAssassin scoring

### DIFF
--- a/setup/mail-postfix.sh
+++ b/setup/mail-postfix.sh
@@ -202,10 +202,8 @@ tools/editconf.py /etc/postfix/main.cf lmtp_destination_recipient_limit=1
 # * `reject_non_fqdn_sender`: Reject not-nice-looking return paths.
 # * `reject_unknown_sender_domain`: Reject return paths with invalid domains.
 # * `reject_authenticated_sender_login_mismatch`: Reject if mail FROM address does not match the client SASL login
-# * `reject_rhsbl_sender`: Reject return paths that use blacklisted domains.
 # * `permit_sasl_authenticated`: Authenticated users (i.e. on port 587) can skip further checks.
 # * `permit_mynetworks`: Mail that originates locally can skip further checks.
-# * `reject_rbl_client`: Reject connections from IP addresses blacklisted in zen.spamhaus.org
 # * `reject_unlisted_recipient`: Although Postfix will reject mail to unknown recipients, it's nicer to reject such mail ahead of greylisting rather than after.
 # * `check_policy_service`: Apply greylisting using postgrey.
 #
@@ -215,8 +213,8 @@ tools/editconf.py /etc/postfix/main.cf lmtp_destination_recipient_limit=1
 # whitelisted) then postfix does a DEFER_IF_REJECT, which results in all "unknown user" sorts of messages turning into #NODOC
 # "450 4.7.1 Client host rejected: Service unavailable". This is a retry code, so the mail doesn't properly bounce. #NODOC
 tools/editconf.py /etc/postfix/main.cf \
-	smtpd_sender_restrictions="reject_non_fqdn_sender,reject_unknown_sender_domain,reject_authenticated_sender_login_mismatch,reject_rhsbl_sender dbl.spamhaus.org" \
-	smtpd_recipient_restrictions=permit_sasl_authenticated,permit_mynetworks,"reject_rbl_client zen.spamhaus.org",reject_unlisted_recipient,"check_policy_service inet:127.0.0.1:10023"
+	smtpd_sender_restrictions="reject_non_fqdn_sender,reject_unknown_sender_domain,reject_authenticated_sender_login_mismatch" \
+	smtpd_recipient_restrictions=permit_sasl_authenticated,permit_mynetworks,reject_unlisted_recipient,"check_policy_service inet:127.0.0.1:10023"
 
 # Postfix connects to Postgrey on the 127.0.0.1 interface specifically. Ensure that
 # Postgrey listens on the same interface (and not IPv6, for instance).

--- a/setup/spamassassin.sh
+++ b/setup/spamassassin.sh
@@ -117,6 +117,24 @@ describe SPF_FAIL SPF check failed
 score SPF_FAIL 5.0
 EOF
 
+# SpamAssassin Spamhaus Zen blacklist scores
+# ------------------------------------------
+# MiaB installs spamassassin configured to check against Spamhaus Zen 
+# blacklists, but the default score is too low to guarantee blacklisted
+# email as spam. The below score is intended to send all Spamhaus Zen blacklist
+# email received to the spam folder.
+
+cat > /etc/spamassassin/miab_spamhaus_zen_scores.cf << EOF
+score RCVD_IN_PBL 10.0
+score RCVD_IN_SBL 10.0
+score RCVD_IN_SBL_CSS 10.0
+score RCVD_IN_XBL 10.0
+score URIBL_CSS 10.0
+score URIBL_CSS_A 10.0
+score URIBL_SBL 10.0
+score URIBL_SBL_A 10.0
+EOF
+
 # Bayesean learning
 # -----------------
 #


### PR DESCRIPTION
This PR removes `reject_rhsbl_sender dbl.spamhaus.org` and `reject_rbl_client zen.spamhaus.org` from `main.cf` so the emails will be received by the server and adds custom score values to `spamassassin` so it always marks Spamhaus Zen blacklisted emails as spam.

I realize this is potentially a contentious PR...

In the process of adding DMARC checks for a recent PR, it was communicated that the project prefers receiving email and marking it as spam to rejecting emails. In the example of DMARC, this means receiving email even when the administrators of a domain configure their policies to instruct other admins to reject the email, which is how the server is now configured.

In the case of blacklists, blocking the receipt of blacklisted email is the equivalent of granting strangers the ability to control what can be received by a server, essentially creating an externally managed gateway. This seems arbitrary as there are legitimate real-world complaints about Spamhaus refusing to remove blacklisted servers that do not send spam.

More reasonable seems to be to configure MiaB to receive blacklisted emails but always send them to the spam folder.

I have been running with the Spamhaus Zen blacklist disabled for a long time (two or three years) and I have not observed an appreciable increase in the quantity of spam received by the server. Initially, I ran without using any custom `spamasassin` rules, and in that time a total of one Spamhaus Zen blacklisted spam arrived in an inbox because the blacklisted spam has so many other problems that even without special rules, `spamassassin` will do its job of sending the spam to the spam folder.

Typical Spamhaus Zen listed email (without custom rules): 

```
X-Spam-Report: 
	*  3.5 BAYES_99 BODY: Bayes spam probability is 99 to 100%
	*      [score: 1.0000]
	*  0.2 BAYES_999 BODY: Bayes spam probability is 99.9 to 100%
	*      [score: 1.0000]
	*  3.3 RCVD_IN_SBL_CSS RBL: Received via a relay in Spamhaus SBL-CSS
	*      [212.116.113.179 listed in zen.spamhaus.org]
	*  0.1 RCVD_IN_SBL RBL: Received via a relay in Spamhaus SBL
	*  0.1 URIBL_CSS_A Contains URL's A record listed in the Spamhaus CSS
	*      blocklist
	*      [URIs: s18.pandaoo.ru]
	*  0.1 URIBL_SBL_A Contains URL's A record listed in the Spamhaus SBL
	*      blocklist
	*      [URIs: s18.pandaoo.ru]
	*  1.6 URIBL_SBL Contains an URL's NS IP listed in the Spamhaus SBL
	*      blocklist
	*      [URIs: s18.pandaoo.ru]
	*  0.1 URIBL_CSS Contains an URL's NS IP listed in the Spamhaus CSS
	*      blocklist
	*      [URIs: s18.pandaoo.ru]
	*  2.5 URIBL_DBL_SPAM Contains a spam URL listed in the Spamhaus DBL
	*      blocklist
	*      [URIs: pandaoo.ru]
	*  1.7 URIBL_BLACK Contains an URL listed in the URIBL blacklist
	*      [URIs: pandaoo.ru]
	* -0.1 DMARC_PASS DMARC check passed
	* -0.1 SPF_PASS SPF check passed
	*  0.0 RCVD_IN_MSPIKE_L3 RBL: Low reputation (-3)
	*      [212.116.113.179 listed in bl.mailspike.net]
	* -0.0 SPF_HELO_PASS SPF: HELO matches SPF record
	*  0.0 HTML_MESSAGE BODY: HTML included in message
	* -0.1 DKIM_VALID_AU Message has a valid DKIM or DK signature from
	*      author's domain
	* -0.1 DKIM_VALID Message has at least one valid DKIM or DK signature
	*  0.1 DKIM_SIGNED Message has a DKIM or DK signature, not necessarily
	*       valid
	*  1.4 PYZOR_CHECK Listed in Pyzor
	*      (https://pyzor.readthedocs.io/en/latest/)
	*  2.0 RAND_MKTG_HEADER Has partially-randomized marketing/tracking
	*      header(s)
	*  0.0 RCVD_IN_MSPIKE_BL Mailspike blacklisted
X-Spam-Score: 16.4
```

One time, the spamscore was below 5.0: 

```
X-Spam-Report: 
	* -0.5 BAYES_05 BODY: Bayes spam probability is 1 to 5%
	*      [score: 0.0391]
	* -0.1 DMARC_PASS DMARC check passed
	* -0.1 SPF_PASS SPF check passed
	* -0.0 SPF_HELO_PASS SPF: HELO matches SPF record
	*  3.3 RCVD_IN_SBL_CSS RBL: Received via a relay in Spamhaus SBL-CSS
	*      [109.236.88.21 listed in zen.spamhaus.org]
	*  0.1 URIBL_CSS_A Contains URL's A record listed in the Spamhaus CSS
	*      blocklist
	*      [URIs: df.nevada-land-sales.com]
	*  0.1 URIBL_CSS Contains an URL's NS IP listed in the Spamhaus CSS
	*      blocklist
	*      [URIs: df.nevada-land-sales.com]
	*  0.0 HTML_MESSAGE BODY: HTML included in message
	*  0.1 DKIM_SIGNED Message has a DKIM or DK signature, not necessarily
	*       valid
	* -0.1 DKIM_VALID Message has at least one valid DKIM or DK signature
	* -0.1 DKIM_VALID_AU Message has a valid DKIM or DK signature from
	*      author's domain
X-Spam-Score: 2.7
```

With the score values in this PR, the above score would have been: 

```
X-Spam-Report: 
	* -0.5 BAYES_05 BODY: Bayes spam probability is 1 to 5%
	*      [score: 0.0391]
	* -0.1 DMARC_PASS DMARC check passed
	* -0.1 SPF_PASS SPF check passed
	* -0.0 SPF_HELO_PASS SPF: HELO matches SPF record
	*   10 RCVD_IN_SBL_CSS RBL: Received via a relay in Spamhaus SBL-CSS
	*      [109.236.88.21 listed in zen.spamhaus.org]
	*   10 URIBL_CSS_A Contains URL's A record listed in the Spamhaus CSS
	*      blocklist
	*      [URIs: df.nevada-land-sales.com]
	*   10 URIBL_CSS Contains an URL's NS IP listed in the Spamhaus CSS
	*      blocklist
	*      [URIs: df.nevada-land-sales.com]
	*  0.0 HTML_MESSAGE BODY: HTML included in message
	*  0.1 DKIM_SIGNED Message has a DKIM or DK signature, not necessarily
	*       valid
	* -0.1 DKIM_VALID Message has at least one valid DKIM or DK signature
	* -0.1 DKIM_VALID_AU Message has a valid DKIM or DK signature from
	*      author's domain
X-Spam-Score: 29.2
```