### PR TITLE
Add token authentication for munin routes (when TOTP enabled)

### DIFF
--- a/management/auth.py
+++ b/management/auth.py
@@ -117,7 +117,7 @@ class KeyAuthService:
 					"/usr/bin/doveadm", "pw",
 					"-p", pw,
 					"-t", pw_hash,
-					])
+				])
 			except:
 				# Login failed.
 				raise ValueError("Invalid password.")

--- a/management/daemon.py
+++ b/management/daemon.py
@@ -93,7 +93,7 @@ def authorized_personnel_only(viewfunc):
 			return Response(json.dumps({
 				"status": "error",
 				"reason": error,
-				})+"\n", status=status, mimetype='application/json', headers=headers)
+			})+"\n", status=status, mimetype='application/json', headers=headers)
 
 	return newview
 
@@ -235,7 +235,7 @@ def mail_aliases_add():
 		request.form.get('permitted_senders', ''),
 		env,
 		update_if_exists=(request.form.get('update_if_exists', '') == '1')
-		)
+	)
 
 @app.route('/mail/aliases/remove', methods=['POST'])
 @authorized_personnel_only
@@ -245,7 +245,7 @@ def mail_aliases_remove():
 @app.route('/mail/domains')
 @authorized_personnel_only
 def mail_domains():
-    return "".join(x+"\n" for x in get_mail_domains(env))
+	return "".join(x+"\n" for x in get_mail_domains(env))
 
 # DNS
 
@@ -293,12 +293,12 @@ def dns_get_records(qname=None, rtype=None):
 
 	# Make a better data structure.
 	records = [
-        {
-                "qname": r[0],
-                "rtype": r[1],
-                "value": r[2],
-		"sort-order": { },
-        } for r in records ]
+		{
+			"qname": r[0],
+			"rtype": r[1],
+			"value": r[2],
+			"sort-order": { },
+		} for r in records ]
 
 	# To help with grouping by zone in qname sorting, label each record with which zone it is in.
 	# There's an inconsistency in how we handle zones in get_dns_zones and in sort_domains, so
@@ -319,9 +319,9 @@ def dns_get_records(qname=None, rtype=None):
 		r["sort-order"]["created"] = i
 	domain_sort_order = utils.sort_domains([r["qname"] for r in records], env)
 	for i, r in enumerate(sorted(records, key = lambda r : (
-			zones.index(r["zone"]),
-			domain_sort_order.index(r["qname"]),
-			r["rtype"]))):
+		zones.index(r["zone"]),
+		domain_sort_order.index(r["qname"]),
+		r["rtype"]))):
 		r["sort-order"]["qname"] = i
 
 	# Return.

--- a/management/mfa.py
+++ b/management/mfa.py
@@ -110,6 +110,12 @@ def validate_auth_mfa(email, request, env):
 	if len(mfa_state) == 0:
 		return (True, [])
 
+	# Try token authentication first for munin routes.
+	if request.full_path.startswith("/munin"):
+		from daemon import auth_service
+		if auth_service.validate_user_token(email, request, env):
+			return (True, [])
+
 	# Try the enabled MFA modes.
 	hints = set()
 	for mfa_mode in mfa_state:

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -51,7 +51,7 @@ hide_output $venv/bin/pip install --upgrade \
 	rtyaml "email_validator>=1.0.0" "exclusiveprocess" \
 	flask dnspython python-dateutil \
   qrcode[pil] pyotp \
-	"idna>=2.0.0" "cryptography==2.2.2" boto psutil postfix-mta-sts-resolver b2sdk
+	"idna>=2.0.0" "cryptography==2.2.2" boto psutil postfix-mta-sts-resolver b2sdk expiringdict
 
 # CONFIGURATION
 


### PR DESCRIPTION
Currently, with TOTP enabled, any route within `/admin` becomes inaccessiable without the proper `x-auth-token` header or `master API key`. However, the munin monitoring pages does not carry the header or the API key, making them in fact unusable.

Thie pull request purposes to add a token authentication system for the munin routes. When a user logins, the `/me` API will assign a random token to the user's cookie storage. The 2FA system will check for the token if the path is under munin, and allow skipping `x-auth-token` authentication if the token is valid (and not expired). The token will automatically expire after 600 seconds (10 minutes) by default.

This pull request will close #1865.