### PR TITLE
fail2ban now supports ipv6

### DIFF
--- a/security.md
+++ b/security.md
@@ -69,8 +69,6 @@ The following services are protected: SSH, IMAP (dovecot), SMTP submission (post
 
 Some other services running on the box may be missing fail2ban filters.
 
-`fail2ban` only blocks IPv4 addresses, however. If the box has a public IPv6 address, it is not protected from these attacks.
-
 Outbound Mail
 -------------
 


### PR DESCRIPTION
Since fail2ban 0.10.0, ipv6 support has been added. The current Ubuntu 18.04 repository has fail2ban 0.10.2, which does have ipv6 protection.