### PR TITLE
Ignore bad encoding in email addresses when parsing maillog files

### DIFF
--- a/management/mail_log.py
+++ b/management/mail_log.py
@@ -586,7 +586,7 @@ def scan_postfix_submission_line(date, log, collector):
 def readline(filename):
     """ A generator that returns the lines of a file
     """
-    with open(filename) as file:
+    with open(filename, errors='replace') as file:
         while True:
           line = file.readline()
           if not line:


### PR DESCRIPTION
local/domain parts of email address should be standard ASCII or
UTF-8. Some email addresses contain extended ASCII, leading to
decode failure by the UTF-8 codec (and thus failure of the
Usage-Report script)

This change allows maillog parsing to continue over lines
containing such addresses