### PR TITLE
Show backup retention period form when configuring B2 backups

### DIFF
--- a/management/templates/system-backup.html
+++ b/management/templates/system-backup.html
@@ -138,7 +138,7 @@
       </div>
   </div>
   <!-- Common -->
-  <div class="form-group backup-target-local backup-target-rsync backup-target-s3">
+  <div class="form-group backup-target-local backup-target-rsync backup-target-s3 backup-target-b2">
     <label for="min-age" class="col-sm-2 control-label">Retention Days:</label>
     <div class="col-sm-8">
       <input type="number" class="form-control" rows="1" id="min-age">


### PR DESCRIPTION
Probably due to an oversight, the `backup-target-b2` class was not added to the backup retention period form. That way, it wouldn't be displayed if you tried to configure backups using Backblaze B2.