### PR TITLE
add numeric flag value to DNSSEC DS status message

### DIFF
--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -646,7 +646,7 @@ def check_dnssec(domain, env, output, dns_zonefiles, is_checking_primary=False):
 		output.print_line("Option " + str(i+1) + ":")
 		output.print_line("----------")
 		output.print_line("Key Tag: " + ds_suggestion['keytag'])
-		output.print_line("Key Flags: KSK")
+		output.print_line("Key Flags: KSK (256)")
 		output.print_line("Algorithm: %s / %s" % (ds_suggestion['alg'], ds_suggestion['alg_name']))
 		output.print_line("Digest Type: %s / %s" % (ds_suggestion['digalg'], ds_suggestion['digalg_name']))
 		output.print_line("Digest: " + ds_suggestion['digest'])


### PR DESCRIPTION
Some registrars (e.g. Porkbun) accept Key Data when creating a DS RR, but accept only a numeric flags value to indicate the key type (256 for KSK, 257 for ZSK).

[RFC 5910, section 4.3 has an example](https://datatracker.ietf.org/doc/html/rfc5910#section-4.3)

Adding the numeric value to the status message shown on the Status page would save people a few minutes searching.