### PR TITLE
Local dns config2

### DIFF
--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -604,7 +604,7 @@ def get_dns_zonefile(zone, env):
 
 def write_nsd_conf(zonefiles, additional_records, env):
 	# Write the list of zones to a configuration file.
-	nsd_conf_file = "/etc/nsd/zones.conf"
+	nsd_conf_file = "/etc/nsd/nsd.conf.d/zones.conf"
 	nsdconf = ""
 
 	# Append the zones.

--- a/setup/dns.sh
+++ b/setup/dns.sh
@@ -62,7 +62,13 @@ for ip in $PRIVATE_IP $PRIVATE_IPV6; do
 	echo "  ip-address: $ip" >> /etc/nsd/nsd.conf;
 done
 
+# Create a directory for additional configuration directives, including
+# the zones.conf file written out by our management daemon.
 echo "include: /etc/nsd/nsd.conf.d/*.conf" >> /etc/nsd/nsd.conf;
+
+# Remove the old location of zones.conf that we generate. It will
+# now be stored in /etc/nsd/nsd.conf.d.
+rm -f /etc/nsd/zones.conf
 
 # Create DNSSEC signing keys.
 

--- a/setup/dns.sh
+++ b/setup/dns.sh
@@ -62,7 +62,7 @@ for ip in $PRIVATE_IP $PRIVATE_IPV6; do
 	echo "  ip-address: $ip" >> /etc/nsd/nsd.conf;
 done
 
-echo "include: /etc/nsd/zones.conf" >> /etc/nsd/nsd.conf;
+echo "include: /etc/nsd/nsd.conf.d/*.conf" >> /etc/nsd/nsd.conf;
 
 # Create DNSSEC signing keys.
 


### PR DESCRIPTION
Better and cleaner version of local-dns-config, which permits local dns zone info (eg. for IPv6 reverse lookups)
    dns_update.py writes MIAB zones.conf into /etc/nsd/nsd.conf.d
    dns.sh writes "include: /etc/nsd/nsd.conf.d/*.conf" into /etc/nsd/nsd.conf
No need to handle any local.conf specially, just put extra config in /etc/nsd/nsd.conf.d and it gets included in *.conf
Will leave any existing /etc/nsd/zones.conf file (from previous MIAB) in place, but not use it.