### PR TITLE
Use "smart invert" for dark mode

### DIFF
--- a/management/templates/index.html
+++ b/management/templates/index.html
@@ -62,6 +62,29 @@
 	    ol li {
 	       margin-bottom: 1em;
 	    }
+      /* The below only gets used if it is supported */
+      @media (prefers-color-scheme: dark) {
+        /* Invert invert lightness but not hue */
+        html {
+          filter: invert(100%) hue-rotate(180deg);
+        }
+
+        /* Set explicit background color (necessary for Firefox) */
+        html {
+          background-color: #111;
+        }
+
+        /* Revert the invert for the navbar */
+        button, div.navbar {
+          filter: invert(100%) hue-rotate(180deg);
+        }
+          
+        /* Revert the revert for the dropdowns */
+        ul.dropdown-menu {
+          filter: invert(100%) hue-rotate(180deg);
+        }
+      }
+
         </style>
         <link rel="stylesheet" href="/admin/assets/bootstrap/css/bootstrap-theme.min.css">
     </head>

--- a/management/templates/index.html
+++ b/management/templates/index.html
@@ -73,6 +73,11 @@
         html {
           background-color: #111;
         }
+          
+        /* Override Boostrap theme here to give more contrast. The black turns to white by the filter. */
+        .form-control {
+          color: black !important;
+        }          
 
         /* Revert the invert for the navbar */
         button, div.navbar {


### PR DESCRIPTION
I have a visual disability that leads me to use Dark Mode 24/7, and Dark Mode software support is a major focus area for me.

All modern web browsers support [the `prefers-color-scheme` CSS media feature](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) for automatically choosing between Light Mode and Dark Mode CSS styles.

Right now using any sort of Dark Mode in the Mail-in-a-Box web interface requires the use of a custom-CSS browser extension, which isn’t particularly discoverable or user-friendly. The small set of CSS filters in this pull request should make Dark Mode “just work” in the Mail-in-a-Box web interface when Dark Mode is enabled through the operating system or the web browser.

This is a very simple intervention and should just be ignored by browsers that don’t support it. I have tested this in Firefox, but I haven’t tested it in any other browsers, yet.

Two remaining issues are:

1. Creating a manual toggle for Dark Mode in JavaScript is a bit beyond me at this point, so Dark Mode just follows the `prefers-color-scheme` CSS media feature from the browser. I would just borrow one from somewhere else, but I don’t know where I would find one that would be compatible with MiaB’s [CC0 licensing](https://github.com/mail-in-a-box/mailinabox/blob/main/LICENSE). Regardless, following the platform setting is a more sensible default than just always using Light Mode.
2. The `<select>` `<option>` dropdowns use some sort of custom coloring that I couldn’t figure out disabling. (It’s buried somewhere in the bootstrap CSS, so it might be an upstream thing, and simply using `unset` doesn’t work for reverting to native—and consequently correctly colored—dropdowns.) I was able to get the correct appearance when I disabled it in the web inspector, though.

Here’s what the `<select>` `<option>` dropdowns look like:

<img width="620" alt="bright dropdown" src="https://user-images.githubusercontent.com/9206310/133122309-1a7368c2-2473-4cea-97a6-7dc44e809a93.png">

If I disable these two properties in the web inspector:

<img width="248" alt="first property" src="https://user-images.githubusercontent.com/9206310/133122412-98083f6d-5867-4cd2-9ce6-411a010a3b53.png">
<img width="246" alt="second property" src="https://user-images.githubusercontent.com/9206310/133122419-784ee048-452d-41d6-ade0-27c101264b62.png">

Then the dropdowns look like this:

<img width="602" alt="dark dropdown" src="https://user-images.githubusercontent.com/9206310/133122476-e47277d7-e201-4997-b7cb-c2607d7f5d88.png">
