### PR TITLE
fix(docs): set a schema for /logout responses

### DIFF
--- a/api/mailinabox.yml
+++ b/api/mailinabox.yml
@@ -110,6 +110,8 @@ paths:
           description: Successful operation
           content:
             application/json:
+              schema:
+                $ref: '#/components/schemas/LogoutResponse'
   /system/status:
     post:
       tags:
@@ -2723,3 +2725,8 @@ components:
           nullable: true
     MfaDisableSuccessResponse:
       type: string
+    LogoutResponse:
+      type: object
+      properties:
+        status:
+          type: string


### PR DESCRIPTION
This remedies an OpenAPI syntax violation resulting in a `redoc-cli` crash when generating docs, see #2050. The command now works again.

The hosted [swagger editor](https://editor.swagger.io/) has a good linter to identify potential issues with OpenAPI specs and immediately located the issue.