### PR TITLE
Examples use GET instead of POST

### DIFF
--- a/api/mailinabox.yml
+++ b/api/mailinabox.yml
@@ -71,7 +71,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X GET "https://{host}/admin/login" \
+            curl -X POST "https://{host}/admin/login" \
               -u "<email>:<password>"
       responses:
         200:
@@ -103,7 +103,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X GET "https://{host}/admin/logout" \
+            curl -X POST "https://{host}/admin/logout" \
               -u "<email>:<session_key>"
       responses:
         200:


### PR DESCRIPTION
The examples for login and logout use GET instead of POST. GET gives me an error when using it, while POST seems to work.