### PR TITLE
Include rsync in the installed basic packages

### DIFF
--- a/setup/management.sh
+++ b/setup/management.sh
@@ -25,7 +25,7 @@ done
 #
 # certbot installs EFF's certbot which we use to
 # provision free TLS certificates.
-apt_install duplicity python-pip virtualenv certbot
+apt_install duplicity python-pip virtualenv certbot rsync
 
 # b2sdk is used for backblaze backups.
 # boto is used for amazon aws backups.


### PR DESCRIPTION
Some VPS providers strip this package from their Ubuntu 18.04 VM images. This will help avoid errors.