### PR TITLE
regex change to exclude comma from sasl_username

### DIFF
--- a/management/mail_log.py
+++ b/management/mail_log.py
@@ -549,8 +549,9 @@ def scan_postfix_submission_line(date, log, collector):
     """
 
     # Match both the 'plain' and 'login' sasl methods, since both authentication methods are
-    # allowed by Dovecot
-    m = re.match("([A-Z0-9]+): client=(\S+), sasl_method=(PLAIN|LOGIN), sasl_username=(\S+)", log)
+    # allowed by Dovecot. Exclude trailing comma after the username when additional fields 
+	# follow after.
+    m = re.match("([A-Z0-9]+): client=(\S+), sasl_method=(PLAIN|LOGIN), sasl_username=(\S+)(?<!,)", log)
 
     if m:
         _, client, method, user = m.groups()


### PR DESCRIPTION
as proposed in #2071 by @jvolkenant