### PR TITLE
Move postgrey database under $STORAGE_ROOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ No features of Mail-in-a-Box have changed in this release, but with the newer ve
 Also:
 
 * Roundcube's login session cookie was tightened. Existing sessions may require a manual logout.
+* Move Postgrey's database under $STORAGE_ROOT
 
 Version 57a (June 19, 2022)
 ---------------------------

--- a/management/backup.py
+++ b/management/backup.py
@@ -281,6 +281,7 @@ def perform_backup(full_backup):
 	service_command("php8.0-fpm", "stop", quit=True)
 	service_command("postfix", "stop", quit=True)
 	service_command("dovecot", "stop", quit=True)
+	service_command("postgrey", "stop", quit=True)
 
 	# Execute a pre-backup script that copies files outside the homedir.
 	# Run as the STORAGE_USER user, not as root. Pass our settings in
@@ -310,6 +311,7 @@ def perform_backup(full_backup):
 			get_duplicity_env_vars(env))
 	finally:
 		# Start services again.
+		service_command("postgrey", "start", quit=False)
 		service_command("dovecot", "start", quit=False)
 		service_command("postfix", "start", quit=False)
 		service_command("php8.0-fpm", "start", quit=False)

--- a/setup/mail-postfix.sh
+++ b/setup/mail-postfix.sh
@@ -252,8 +252,10 @@ mkdir -p $STORAGE_ROOT/mail/postgrey
 if [ ! "$(ls -A $STORAGE_ROOT/mail/postgrey)" ]; then
 	# Stop the service
 	service postgrey stop
-	# Copy over the databse, we didn't cp -p to preserve perms since we have to chown the newly created directory above anyway
-	cp /var/lib/postgrey/* $STORAGE_ROOT/mail/postgrey/
+	# Copy over the databse.
+	# We didn't cp -p to preserve perms since we have to chown the newly created directory above anyway.
+	# There really shouldn't be any folders in this path, but if there are for any reason cp fails without -r (recursive).
+	cp -r /var/lib/postgrey/* $STORAGE_ROOT/mail/postgrey/
 fi
 # Fix permissions
 chown -R postgrey:postgrey $STORAGE_ROOT/mail/postgrey/

--- a/setup/mail-postfix.sh
+++ b/setup/mail-postfix.sh
@@ -250,10 +250,10 @@ tools/editconf.py /etc/default/postgrey \
 if [ ! -d $STORAGE_ROOT/mail/postgrey/db ]; then
 	# Stop the service
 	service postgrey stop
-	# Ensure the new base path for postgrey exists
-	mkdir -p $STORAGE_ROOT/mail/postgrey
-	# Move over database
-	mv /var/lib/postgrey $STORAGE_ROOT/mail/postgrey/db
+	# Ensure the new paths for postgrey db exists
+	mkdir -p $STORAGE_ROOT/mail/postgrey $STORAGE_ROOT/mail/postgrey/db
+	# Move over database files
+	mv /var/lib/postgrey/* $STORAGE_ROOT/mail/postgrey/db/ || true
 fi
 # Ensure permissions are set
 chown -R postgrey:postgrey $STORAGE_ROOT/mail/postgrey/

--- a/setup/mail-postfix.sh
+++ b/setup/mail-postfix.sh
@@ -243,19 +243,19 @@ tools/editconf.py /etc/postfix/main.cf \
 # symlink without spaces that can point to a folder with spaces).  We'll just assume
 # $STORAGE_ROOT won't have spaces to simplify things.
 tools/editconf.py /etc/default/postgrey \
-	POSTGREY_OPTS=\""--inet=127.0.0.1:10023 --delay=180 --dbdir=$STORAGE_ROOT/mail/postgrey"\"
+	POSTGREY_OPTS=\""--inet=127.0.0.1:10023 --delay=180 --dbdir=$STORAGE_ROOT/mail/postgrey/db"\"
 
 # Make destination postgrey database directory under $STORAGE_ROOT
-mkdir -p $STORAGE_ROOT/mail/postgrey
+mkdir -p $STORAGE_ROOT/mail/postgrey/db
 
 # If the $STORAGE_ROOT/mail/postgrey is empty, copy the postgrey database over from the old location
-if [ ! "$(ls -A $STORAGE_ROOT/mail/postgrey)" ]; then
+if [ ! "$(ls -A $STORAGE_ROOT/mail/postgrey/db)" ]; then
 	# Stop the service
 	service postgrey stop
 	# Copy over the databse.
 	# We didn't cp -p to preserve perms since we have to chown the newly created directory above anyway.
 	# There really shouldn't be any folders in this path, but if there are for any reason cp fails without -r (recursive).
-	cp -r /var/lib/postgrey/* $STORAGE_ROOT/mail/postgrey/
+	cp -r /var/lib/postgrey/* $STORAGE_ROOT/mail/postgrey/db
 fi
 # Fix permissions
 chown -R postgrey:postgrey $STORAGE_ROOT/mail/postgrey/

--- a/setup/mail-postfix.sh
+++ b/setup/mail-postfix.sh
@@ -251,7 +251,7 @@ if [ ! -d $STORAGE_ROOT/mail/postgrey/db ]; then
 	# Stop the service
 	service postgrey stop
 	# Ensure the new paths for postgrey db exists
-	mkdir -p $STORAGE_ROOT/mail/postgrey $STORAGE_ROOT/mail/postgrey/db
+	mkdir -p $STORAGE_ROOT/mail/postgrey/db
 	# Move over database files
 	mv /var/lib/postgrey/* $STORAGE_ROOT/mail/postgrey/db/ || true
 fi


### PR DESCRIPTION
As suggested in #2073, MR creates $STORAGE_ROOT/mail/postgrey and copies the existing database to that path.

It is assumed that $STORAGE_ROOT is a path without spaces, this is due to the way /etc/init.d/postgrey deals with arguments to starting postgrey. There is an upstream comment in /etc/default/postgrey for POSTGREY_TEXT.   $STORAGE_ROOT with spaces would break way earlier in an install, but if we ever allowed it, we would need to use a symlink that didn't have spaces.

Give it a spin and let me know


