### PR TITLE
Specify b2sdk version 1.14.1

### DIFF
--- a/setup/management.sh
+++ b/setup/management.sh
@@ -30,7 +30,7 @@ apt_install duplicity python-pip virtualenv certbot rsync
 # b2sdk is used for backblaze backups.
 # boto is used for amazon aws backups.
 # Both are installed outside the pipenv, so they can be used by duplicity
-hide_output pip3 install --upgrade b2sdk boto
+hide_output pip3 install --upgrade b2sdk==1.14.1 boto
 
 # Create a virtualenv for the installation of Python 3 packages
 # used by the management daemon.


### PR DESCRIPTION
pin b2sdk version to 1.14.1 to resolve exception that occurs when attempting to use backblaze backups. See https://github.com/mail-in-a-box/mailinabox/issues/2124 for details.