### PR TITLE
Replace Flask built-in WSGI server with gunicorn

### DIFF
--- a/conf/mailinabox.service
+++ b/conf/mailinabox.service
@@ -4,6 +4,7 @@ After=multi-user.target
 
 [Service]
 Type=idle
+IgnoreSIGPIPE=False
 ExecStart=/usr/local/lib/mailinabox/start
 
 [Install]

--- a/management/auth.py
+++ b/management/auth.py
@@ -36,6 +36,8 @@ class AuthService:
 
 		# with create_file_with_mode(self.key_path, 0o640) as key_file:
 		# 	key_file.write(self.key + '\n')
+		with open(self.key_path, 'r') as file:
+			self.key = file.read()
 
 	def authenticate(self, request, env, login_only=False, logout=False):
 		"""Test if the HTTP Authorization header's username matches the system key, a session key,

--- a/management/auth.py
+++ b/management/auth.py
@@ -1,4 +1,7 @@
 import base64, os, os.path, hmac, json, secrets
+from datetime import timedelta
+
+from expiringdict import ExpiringDict
 
 import utils
 from mailconfig import get_mail_password, get_mail_user_privileges
@@ -8,12 +11,13 @@ DEFAULT_KEY_PATH   = '/var/lib/mailinabox/api.key'
 DEFAULT_AUTH_REALM = 'Mail-in-a-Box Management Server'
 
 class AuthService:
-	def __init__(self, session):
+	def __init__(self):
 		self.auth_realm = DEFAULT_AUTH_REALM
 		self.key_path = DEFAULT_KEY_PATH
+		self.max_session_duration = timedelta(days=2)
 
 		self.init_system_api_key()
-		self.sessions = session
+		self.sessions = ExpiringDict(max_len=64, max_age_seconds=self.max_session_duration.total_seconds())
 
 	def init_system_api_key(self):
 		"""Write an API key to a local file so local processes can use the API"""

--- a/management/auth.py
+++ b/management/auth.py
@@ -22,20 +22,20 @@ class AuthService:
 	def init_system_api_key(self):
 		"""Write an API key to a local file so local processes can use the API"""
 
-		def create_file_with_mode(path, mode):
-			# Based on answer by A-B-B: http://stackoverflow.com/a/15015748
-			old_umask = os.umask(0)
-			try:
-				return os.fdopen(os.open(path, os.O_WRONLY | os.O_CREAT, mode), 'w')
-			finally:
-				os.umask(old_umask)
+		# def create_file_with_mode(path, mode):
+		# 	# Based on answer by A-B-B: http://stackoverflow.com/a/15015748
+		# 	old_umask = os.umask(0)
+		# 	try:
+		# 		return os.fdopen(os.open(path, os.O_WRONLY | os.O_CREAT, mode), 'w')
+		# 	finally:
+		# 		os.umask(old_umask)
 
-		self.key = secrets.token_hex(32)
+		# self.key = secrets.token_hex(32)
 
-		os.makedirs(os.path.dirname(self.key_path), exist_ok=True)
+		# os.makedirs(os.path.dirname(self.key_path), exist_ok=True)
 
-		with create_file_with_mode(self.key_path, 0o640) as key_file:
-			key_file.write(self.key + '\n')
+		# with create_file_with_mode(self.key_path, 0o640) as key_file:
+		# 	key_file.write(self.key + '\n')
 
 	def authenticate(self, request, env, login_only=False, logout=False):
 		"""Test if the HTTP Authorization header's username matches the system key, a session key,

--- a/management/auth.py
+++ b/management/auth.py
@@ -1,7 +1,4 @@
 import base64, os, os.path, hmac, json, secrets
-from datetime import timedelta
-
-from expiringdict import ExpiringDict
 
 import utils
 from mailconfig import get_mail_password, get_mail_user_privileges
@@ -11,31 +8,17 @@ DEFAULT_KEY_PATH   = '/var/lib/mailinabox/api.key'
 DEFAULT_AUTH_REALM = 'Mail-in-a-Box Management Server'
 
 class AuthService:
-	def __init__(self):
+	def __init__(self, session):
 		self.auth_realm = DEFAULT_AUTH_REALM
 		self.key_path = DEFAULT_KEY_PATH
 		self.max_session_duration = timedelta(days=2)
 
 		self.init_system_api_key()
-		self.sessions = ExpiringDict(max_len=64, max_age_seconds=self.max_session_duration.total_seconds())
+		self.sessions = session
 
 	def init_system_api_key(self):
 		"""Write an API key to a local file so local processes can use the API"""
 
-		# def create_file_with_mode(path, mode):
-		# 	# Based on answer by A-B-B: http://stackoverflow.com/a/15015748
-		# 	old_umask = os.umask(0)
-		# 	try:
-		# 		return os.fdopen(os.open(path, os.O_WRONLY | os.O_CREAT, mode), 'w')
-		# 	finally:
-		# 		os.umask(old_umask)
-
-		# self.key = secrets.token_hex(32)
-
-		# os.makedirs(os.path.dirname(self.key_path), exist_ok=True)
-
-		# with create_file_with_mode(self.key_path, 0o640) as key_file:
-		# 	key_file.write(self.key + '\n')
 		with open(self.key_path, 'r') as file:
 			self.key = file.read()
 

--- a/management/auth.py
+++ b/management/auth.py
@@ -11,7 +11,6 @@ class AuthService:
 	def __init__(self, session):
 		self.auth_realm = DEFAULT_AUTH_REALM
 		self.key_path = DEFAULT_KEY_PATH
-		self.max_session_duration = timedelta(days=2)
 
 		self.init_system_api_key()
 		self.sessions = session

--- a/management/daemon.py
+++ b/management/daemon.py
@@ -15,17 +15,18 @@ import multiprocessing.pool, subprocess
 
 from functools import wraps
 
-from flask import Flask, request, render_template, abort, Response, send_from_directory, make_response
+from flask import Flask, request, render_template, abort, Response, send_from_directory, make_response, session
 
 import auth, utils
 from mailconfig import get_mail_users, get_mail_users_ex, get_admins, add_mail_user, set_mail_password, remove_mail_user
 from mailconfig import get_mail_user_privileges, add_remove_mail_user_privilege
 from mailconfig import get_mail_aliases, get_mail_aliases_ex, get_mail_domains, add_mail_alias, remove_mail_alias
 from mfa import get_public_mfa_state, provision_totp, validate_totp_secret, enable_mfa, disable_mfa
+from datetime import timedelta
+
+DEFAULT_SESSION_SECRET_PATH = '/var/lib/mailinabox/session.key'
 
 env = utils.load_environment()
-
-auth_service = auth.AuthService()
 
 # We may deploy via a symbolic link, which confuses flask's template finding.
 me = __file__
@@ -43,6 +44,16 @@ with open(os.path.join(os.path.dirname(me), "csr_country_codes.tsv")) as f:
 		csr_country_codes.append((code, name))
 
 app = Flask(__name__, template_folder=os.path.abspath(os.path.join(os.path.dirname(me), "templates")))
+
+# sets up Flask session to be permanent and lasting 2 days.
+with open(DEFAULT_SESSION_SECRET_PATH, 'r') as file:
+	app.secret_key = file.read()
+app.config['SESSION_PERMANENT'] = True
+app.config['SESSION_TYPE'] = 'filesystem'
+app.config['PERMANENT_SESSION_LIFETIME']=timedelta(days=2)
+
+# AuthService uses the Flask session
+auth_service = auth.AuthService(session)
 
 # Decorator to protect views that require a user with 'admin' privileges.
 def authorized_personnel_only(viewfunc):
@@ -162,7 +173,7 @@ def login():
 		"privileges": privs,
 		"api_key": auth_service.create_session_key(email, env, type='login'),
 	}
-
+	session.permanent = True
 	app.logger.info("New login session created for {}".format(email))
 
 	# Return.

--- a/management/wsgi.py
+++ b/management/wsgi.py
@@ -1,0 +1,6 @@
+from daemon import app
+
+app.logger.addHandler(utils.create_syslog_handler())
+
+if __name__ == "__main__":
+    app.run(port=10222)

--- a/management/wsgi.py
+++ b/management/wsgi.py
@@ -1,15 +1,6 @@
 from daemon import app
 import auth, utils
 
-from werkzeug.middleware.proxy_fix import ProxyFix
-
-app.wsgi_app = ProxyFix(
-    app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1
-)
-
-env = utils.load_environment()
-auth_service = auth.AuthService()
-
 app.logger.addHandler(utils.create_syslog_handler())
 
 if __name__ == "__main__":

--- a/management/wsgi.py
+++ b/management/wsgi.py
@@ -1,4 +1,5 @@
 from daemon import app
+import utils
 
 app.logger.addHandler(utils.create_syslog_handler())
 

--- a/management/wsgi.py
+++ b/management/wsgi.py
@@ -1,4 +1,4 @@
-from daemon import app
+from management.daemon import app
 import utils
 
 app.logger.addHandler(utils.create_syslog_handler())

--- a/management/wsgi.py
+++ b/management/wsgi.py
@@ -1,5 +1,14 @@
-from management.daemon import app
-import utils
+from daemon import app
+import auth, utils
+
+from werkzeug.middleware.proxy_fix import ProxyFix
+
+app.wsgi_app = ProxyFix(
+    app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1
+)
+
+env = utils.load_environment()
+auth_service = auth.AuthService()
 
 app.logger.addHandler(utils.create_syslog_handler())
 

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -106,7 +106,7 @@ chmod 640 /var/lib/mailinabox/{api,session}.key
 
 source $venv/bin/activate
 export PYTHONPATH=$(pwd)/management
-exec gunicorn -b localhost:10222 -w 1 wsgi:app
+exec gunicorn -b localhost:10222 -w 2 wsgi:app
 EOF
 chmod +x $inst_dir/start
 cp --remove-destination conf/mailinabox.service /lib/systemd/system/mailinabox.service # target was previously a symlink so remove it first

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -99,7 +99,7 @@ export LANG=en_US.UTF-8
 export LC_TYPE=en_US.UTF-8
 
 mkdir -p /var/lib/mailinabox
-{ tr -cd '[:xdigit:]' < /dev/urandom | head -c 32 } > /var/lib/mailinabox/api.key
+tr -cd '[:xdigit:]' < /dev/urandom | head -c 32 > /var/lib/mailinabox/api.key
 
 source $venv/bin/activate
 export PYTHONPATH=$(pwd)/management

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -99,8 +99,7 @@ export LANG=en_US.UTF-8
 export LC_TYPE=en_US.UTF-8
 
 source $venv/bin/activate
-cd $(pwd)/management
-exec gunicorn -b localhost:10222 -w 2 wsgi:app
+exec gunicorn -b localhost:10222 -w 2 management.wsgi:app
 EOF
 chmod +x $inst_dir/start
 cp --remove-destination conf/mailinabox.service /lib/systemd/system/mailinabox.service # target was previously a symlink so remove it first

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -100,7 +100,7 @@ export LC_TYPE=en_US.UTF-8
 
 source $venv/bin/activate
 export PYTHONPATH=$(pwd)
-exec gunicorn -b localhost:10222 -w 2 wsgi:app
+exec gunicorn -b localhost:10222 -w 1 wsgi:app
 EOF
 chmod +x $inst_dir/start
 cp --remove-destination conf/mailinabox.service /lib/systemd/system/mailinabox.service # target was previously a symlink so remove it first

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -50,7 +50,7 @@ hide_output $venv/bin/pip install --upgrade pip
 # NOTE: email_validator is repeated in setup/questions.sh, so please keep the versions synced.
 hide_output $venv/bin/pip install --upgrade \
 	rtyaml "email_validator>=1.0.0" "exclusiveprocess" \
-	flask dnspython python-dateutil expiringdict \
+	flask dnspython python-dateutil expiringdict gunicorn \
 	qrcode[pil] pyotp \
 	"idna>=2.0.0" "cryptography==37.0.2" psutil postfix-mta-sts-resolver \
 	b2sdk boto3

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -99,7 +99,8 @@ export LANG=en_US.UTF-8
 export LC_TYPE=en_US.UTF-8
 
 source $venv/bin/activate
-exec gunicorn -b localhost:10222 -w 2 management.wsgi:app
+export PYTHONPATH=$(pwd)
+exec gunicorn -b localhost:10222 -w 2 wsgi:app
 EOF
 chmod +x $inst_dir/start
 cp --remove-destination conf/mailinabox.service /lib/systemd/system/mailinabox.service # target was previously a symlink so remove it first

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -99,7 +99,7 @@ export LANG=en_US.UTF-8
 export LC_TYPE=en_US.UTF-8
 
 source $venv/bin/activate
-export PYTHONPATH=$(pwd)
+export PYTHONPATH=$(pwd)/management
 exec gunicorn -b localhost:10222 -w 1 wsgi:app
 EOF
 chmod +x $inst_dir/start

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -90,6 +90,7 @@ rm -f /tmp/bootstrap.zip
 
 # Create an init script to start the management daemon and keep it
 # running after a reboot.
+# Note: Authentication currently breaks with more than 1 gunicorn worker.
 cat > $inst_dir/start <<EOF;
 #!/bin/bash
 # Set character encoding flags to ensure that any non-ASCII don't cause problems.
@@ -100,10 +101,11 @@ export LC_TYPE=en_US.UTF-8
 
 mkdir -p /var/lib/mailinabox
 tr -cd '[:xdigit:]' < /dev/urandom | head -c 32 > /var/lib/mailinabox/api.key
+chmod 640 /var/lib/mailinabox/api.key
 
 source $venv/bin/activate
 export PYTHONPATH=$(pwd)/management
-exec gunicorn -b localhost:10222 -w 2 wsgi:app
+exec gunicorn -b localhost:10222 -w 1 wsgi:app
 EOF
 chmod +x $inst_dir/start
 cp --remove-destination conf/mailinabox.service /lib/systemd/system/mailinabox.service # target was previously a symlink so remove it first

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -101,12 +101,11 @@ export LC_TYPE=en_US.UTF-8
 
 mkdir -p /var/lib/mailinabox
 tr -cd '[:xdigit:]' < /dev/urandom | head -c 32 > /var/lib/mailinabox/api.key
-tr -cd '[:alnum:]'  < /dev/urandom | head -c 64 > /var/lib/mailinabox/session.key
-chmod 640 /var/lib/mailinabox/{api,session}.key
+chmod 640 /var/lib/mailinabox/api.key
 
 source $venv/bin/activate
 export PYTHONPATH=$(pwd)/management
-exec gunicorn -b localhost:10222 -w 2 wsgi:app
+exec gunicorn -b localhost:10222 -w 1 wsgi:app
 EOF
 chmod +x $inst_dir/start
 cp --remove-destination conf/mailinabox.service /lib/systemd/system/mailinabox.service # target was previously a symlink so remove it first

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -98,9 +98,12 @@ export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
 export LC_TYPE=en_US.UTF-8
 
+mkdir -p /var/lib/mailinabox
+{ tr -cd '[:xdigit:]' < /dev/urandom | head -c 32 } > /var/lib/mailinabox/api.key
+
 source $venv/bin/activate
 export PYTHONPATH=$(pwd)/management
-exec gunicorn -b localhost:10222 -w 1 wsgi:app
+exec gunicorn -b localhost:10222 -w 2 wsgi:app
 EOF
 chmod +x $inst_dir/start
 cp --remove-destination conf/mailinabox.service /lib/systemd/system/mailinabox.service # target was previously a symlink so remove it first

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -99,7 +99,8 @@ export LANG=en_US.UTF-8
 export LC_TYPE=en_US.UTF-8
 
 source $venv/bin/activate
-exec python $(pwd)/management/daemon.py
+cd $(pwd)/management
+exec gunicorn -b localhost:10222 -w 2 wsgi:app
 EOF
 chmod +x $inst_dir/start
 cp --remove-destination conf/mailinabox.service /lib/systemd/system/mailinabox.service # target was previously a symlink so remove it first

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -101,7 +101,8 @@ export LC_TYPE=en_US.UTF-8
 
 mkdir -p /var/lib/mailinabox
 tr -cd '[:xdigit:]' < /dev/urandom | head -c 32 > /var/lib/mailinabox/api.key
-chmod 640 /var/lib/mailinabox/api.key
+tr -cd '[:alnum:]'  < /dev/urandom | head -c 64 > /var/lib/mailinabox/session.key
+chmod 640 /var/lib/mailinabox/{api,session}.key
 
 source $venv/bin/activate
 export PYTHONPATH=$(pwd)/management


### PR DESCRIPTION
Now I know that we are behind a proxy, but Flask's built-in WSGI server isn't really made for production use. This patch replaces the built in Flask WSGI server with a single-worker gunicorn. 

The Flask devs warn against use of their WSGI server in their docs:

https://flask.palletsprojects.com/en/2.2.x/deploying/
> “Production” means “not development”, which applies whether you’re serving your application publicly to millions of users or privately / locally to a single user. Do not use the development server when deploying to production. It is intended for use only during local development. It is not designed to be particularly secure, stable, or efficient.

There is also a message on the WSGI server itself:
> WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead

I really tried to get this to work with multiple gunicorn workers, but I think changes to the auth.py module need to be made that are beyond my capabilities (and probably the project's interest). Here's a summary of my changes:

- I have moved the creation of a secret token to the start script so that multiple workers will load the same token.
- Added gunicorn to the pip dependencies
- Created a new entrypoint wsgi.py for gunicorn to use.

Anyways, given the management interface is probably going to see pretty low traffic, I am guessing 1 gunicorn worker should be fine and we shoudl stop here while we're ahead. If there is interest to keep going to make this work for multiple worksers, I'd be game. Nevertheless, I think this patch as-is will be an improvement to mail-in-a-box security.
