### PR TITLE
explicitly enable fail2ban

### DIFF
--- a/setup/system.sh
+++ b/setup/system.sh
@@ -373,3 +373,5 @@ cp -f conf/fail2ban/filter.d/* /etc/fail2ban/filter.d/
 # scripts will ensure the files exist and then fail2ban is given another
 # restart at the very end of setup.
 restart_service fail2ban
+
+systemctl enable fail2ban


### PR DESCRIPTION
Explicitly enable fail2ban (although vendor preset is enabled meaning this should not be necessary but there you go)
Created for issue #2187 