### PR TITLE
Fixes to DNS lookups

### DIFF
--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -1040,7 +1040,7 @@ def set_secondary_dns(hostnames, env):
 					try:
 						response = resolver.resolve(item, "AAAA")
 					except (dns.resolver.NoNameservers, dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
-						pass
+						raise ValueError("Could not resolve the IP address of %s due to dns error." % item)
 					except (dns.resolver.Timeout):
 						raise ValueError("Could not resolve the IP address of %s due to timeout." % item)
 				except (dns.resolver.Timeout):

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -1036,15 +1036,11 @@ def set_secondary_dns(hostnames, env):
 				# Resolve hostname.
 				try:
 					response = resolver.resolve(item, "A")
-				except (dns.resolver.NoNameservers, dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
+				except (dns.resolver.NoNameservers, dns.resolver.NXDOMAIN, dns.resolver.NoAnswer, dns.resolver.Timeout):
 					try:
 						response = resolver.resolve(item, "AAAA")
-					except (dns.resolver.NoNameservers, dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
-						raise ValueError("Could not resolve the IP address of %s due to dns error." % item)
-					except (dns.resolver.Timeout):
-						raise ValueError("Could not resolve the IP address of %s due to timeout." % item)
-				except (dns.resolver.Timeout):
-					raise ValueError("Could not resolve the IP address of %s due to timeout." % item)
+					except (dns.resolver.NoNameservers, dns.resolver.NXDOMAIN, dns.resolver.NoAnswer, dns.resolver.Timeout):
+						raise ValueError("Could not resolve the IP address of %s." % item)
 			else:
 				# Validate IP address.
 				try:

--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -308,6 +308,8 @@ def run_network_checks(env, output):
 		output.print_ok("IP address is not blacklisted by zen.spamhaus.org.")
 	elif zen == "[timeout]":
 		output.print_warning("Connection to zen.spamhaus.org timed out. We could not determine whether your server's IP address is blacklisted. Please try again later.")
+	elif zen == "[Not Set]":
+		output.print_warning("Could not connect to zen.spamhaus.org. We could not determine whether your server's IP address is blacklisted. Please try again later.")
 	else:
 		output.print_error("""The IP address of this machine %s is listed in the Spamhaus Block List (code %s),
 			which may prevent recipients from receiving your email. See http://www.spamhaus.org/query/ip/%s."""
@@ -744,6 +746,8 @@ def check_mail_domain(domain, env, output):
 		output.print_ok("Domain is not blacklisted by dbl.spamhaus.org.")
 	elif dbl == "[timeout]":
 		output.print_warning("Connection to dbl.spamhaus.org timed out. We could not determine whether the domain {} is blacklisted. Please try again later.".format(domain))
+	elif dbl == "[Not Set]":
+		output.print_warning("Could not connect to dbl.spamhaus.org. We could not determine whether the domain {} is blacklisted. Please try again later.".format(domain))
 	else:
 		output.print_error("""This domain is listed in the Spamhaus Domain Block List (code %s),
 			which may prevent recipients from receiving your mail.


### PR DESCRIPTION
This pull request is one of a series of three I created after chasing some dns lookup issues (e.g. [here](https://github.com/mail-in-a-box/mailinabox/issues/2143) and [here](https://github.com/mail-in-a-box/mailinabox/issues/1614) but there are more reports of dns issues on github and on the forum).

1. (This pull request) Basic changes
2. Changes to dns request timeout handling
3. Replace bind9 with unbound

This pull request fixes the following:
- Set dns resolver lifetime
  In addition to timeout, set the value of lifetime to the same value. The difference between those values as [documented](https://dnspython.readthedocs.io/en/latest/resolver-class.html) seems to be that the timeout value is per server, while the lifetime entails the complete dns question (could be multiple servers are involved).
- query_dns returns either none, an answer or the strings [Not Set] or [timeout]. Several places do not take the handling of these strings into account.
- (timeout) Exception handling