### PR TITLE
Replace bind9 with unbound

### DIFF
--- a/conf/unbound.conf
+++ b/conf/unbound.conf
@@ -1,0 +1,68 @@
+server:
+      # the working directory.
+      directory: "/etc/unbound"
+
+      # run as the unbound user
+      username: unbound
+
+      verbosity: 0      # uncomment and increase to get more logging.
+      # logfile: "/var/log/unbound.log" # won't work due to apparmor
+      # use-syslog: no
+
+      # By default listen only to localhost
+      #interface: ::1
+      #interface: 127.0.0.1
+      port: 53
+
+      # Only allow localhost to use this Unbound instance.
+      access-control: 127.0.0.1/8 allow
+      access-control: ::1/128 allow
+
+      # Private IP ranges, which shall never be returned or forwarded as public DNS response.
+      private-address: 10.0.0.0/8
+      private-address: 172.16.0.0/12
+      private-address: 192.168.0.0/16
+      private-address: 169.254.0.0/16
+      private-address: fd00::/8
+      private-address: fe80::/10
+
+      # Functionality
+      do-ip4: yes
+      do-ip6: yes
+      do-udp: yes
+      do-tcp: yes
+
+      # Performance
+      num-threads: 2
+      cache-min-ttl: 300
+      cache-max-ttl: 86400
+      serve-expired: yes
+      neg-cache-size: 4M
+      msg-cache-size: 50m
+      rrset-cache-size: 100m
+
+      so-reuseport: yes
+      so-rcvbuf: 4m
+      so-sndbuf: 4m
+
+      # Privacy / hardening
+      # hide server info from clients
+      hide-identity: yes
+      hide-version: yes
+      harden-glue: yes
+      harden-dnssec-stripped: yes
+      harden-algo-downgrade: yes
+      harden-large-queries: yes
+      harden-short-bufsize: yes
+
+      rrset-roundrobin: yes
+      minimal-responses: yes
+      identity: "Server" 
+
+      # Include possible white/blacklists
+      include: /etc/unbound/lists.d/*.conf
+
+remote-control:
+      control-enable: yes
+      control-port: 953
+

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -120,7 +120,7 @@ def do_dns_update(env, force=False):
 
 	# Clear unbound's DNS cache so our own DNS resolver is up to date.
 	# (ignore errors with trap=True)
-	shell('check_call', ["/usr/sbin/unbound-control", "flush_zone", "."], trap=True)
+	shell('check_call', ["/usr/sbin/unbound-control", "flush_zone", ".", "-q"], trap=True)
 
 	if len(updated_domains) == 0:
 		# if nothing was updated (except maybe OpenDKIM's files), don't show any output

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -118,9 +118,9 @@ def do_dns_update(env, force=False):
 			# If this is the only thing that changed?
 			updated_domains.append("OpenDKIM configuration")
 
-	# Clear bind9's DNS cache so our own DNS resolver is up to date.
+	# Clear unbound's DNS cache so our own DNS resolver is up to date.
 	# (ignore errors with trap=True)
-	shell('check_call', ["/usr/sbin/rndc", "flush"], trap=True)
+	shell('check_call', ["/usr/sbin/unbound-control", "flush_zone", "."], trap=True)
 
 	if len(updated_domains) == 0:
 		# if nothing was updated (except maybe OpenDKIM's files), don't show any output

--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -56,7 +56,7 @@ def run_checks(rounded_values, env, output, pool, domains_to_check=None):
 	# clear unbound's DNS cache so our DNS checks are up to date
 	# (ignore errors; if unbound isn't running we'd already report
 	# that in run_services checks.)
-	shell('check_call', ["/usr/sbin/unbound-control", "flush_zone", "."], trap=True)
+	shell('check_call', ["/usr/sbin/unbound-control", "flush_zone", ".", "-q"], trap=True)
 
 	run_system_checks(rounded_values, env, output)
 

--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -22,9 +22,8 @@ from utils import shell, sort_domains, load_env_vars_from_file, load_settings
 
 def get_services():
 	return [
-		{ "name": "Local DNS (bind9)", "port": 53, "public": False, },
-		#{ "name": "NSD Control", "port": 8952, "public": False, },
-		{ "name": "Local DNS Control (bind9/rndc)", "port": 953, "public": False, },
+		{ "name": "Local DNS (unbound)", "port": 53, "public": False, },
+		{ "name": "Local DNS Control (unbound)", "port": 953, "public": False, },
 		{ "name": "Dovecot LMTP LDA", "port": 10026, "public": False, },
 		{ "name": "Postgrey", "port": 10023, "public": False, },
 		{ "name": "Spamassassin", "port": 10025, "public": False, },
@@ -49,15 +48,15 @@ def run_checks(rounded_values, env, output, pool, domains_to_check=None):
 
 	# check that services are running
 	if not run_services_checks(env, output, pool):
-		# If critical services are not running, stop. If bind9 isn't running,
+		# If critical services are not running, stop. If unbound isn't running,
 		# all later DNS checks will timeout and that will take forever to
 		# go through, and if running over the web will cause a fastcgi timeout.
 		return
 
-	# clear bind9's DNS cache so our DNS checks are up to date
-	# (ignore errors; if bind9/rndc isn't running we'd already report
+	# clear unbound's DNS cache so our DNS checks are up to date
+	# (ignore errors; if unbound isn't running we'd already report
 	# that in run_services checks.)
-	shell('check_call', ["/usr/sbin/rndc", "flush"], trap=True)
+	shell('check_call', ["/usr/sbin/unbound-control", "flush_zone", "."], trap=True)
 
 	run_system_checks(rounded_values, env, output)
 
@@ -785,7 +784,7 @@ def query_dns(qname, rtype, nxdomain='[Not Set]', at=None, as_list=False):
 		qname += "."
 
 	# Use the default nameservers (as defined by the system, which is our locally
-	# running bind server), or if the 'at' argument is specified, use that host
+	# running unbound server), or if the 'at' argument is specified, use that host
 	# as the nameserver.
 	resolver = dns.resolver.get_default_resolver()
 	if at:

--- a/setup/dns.sh
+++ b/setup/dns.sh
@@ -12,7 +12,7 @@ source /etc/mailinabox.conf # load global vars
 
 # Prepare nsd's configuration.
 # We configure nsd before installation as we only want it to bind to some addresses
-# and it otherwise will have port / bind conflicts with bind9 used as the local resolver
+# and it otherwise will have port / bind conflicts with unbound used as the local resolver
 mkdir -p /var/run/nsd
 mkdir -p /etc/nsd
 mkdir -p /etc/nsd/zones
@@ -38,7 +38,7 @@ server:
 
 EOF
 
-# Since we have bind9 listening on localhost for locally-generated
+# Since we have unbound listening on localhost for locally-generated
 # DNS queries that require a recursive nameserver, and the system
 # might have other network interfaces for e.g. tunnelling, we have
 # to be specific about the network interfaces that nsd binds to.


### PR DESCRIPTION
This pull request is one of a series of three I created after chasing some dns issues (e.g. [here](https://github.com/mail-in-a-box/mailinabox/issues/2143) and [here](https://github.com/mail-in-a-box/mailinabox/issues/1614) but there are more reports of dns issues on github and on the forum)

1. (#2191) Basic changes
2. (#2192) Changes to dns request timeout handling
3. Replace bind9 with unbound

This pull request can be used separate from the other two (#2191 and #2192). It replaces the bind9 dns resolver with the unbound dns resolver. Reasons: Mail-in-a-Box only uses the recursive part of bind9. Thus replacing with unbound makes for a simpler installation and configuration. It is also a good companion to nsd which is for authorative DNS only.