### PR TITLE
Update roundcube password plugin configuration

### DIFF
--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -185,10 +185,8 @@ tools/editconf.py ${RCM_PLUGIN_DIR}/password/config.inc.php \
 	"\$config['password_minimum_length']=8;" \
 	"\$config['password_db_dsn']='sqlite:///$STORAGE_ROOT/mail/users.sqlite';" \
 	"\$config['password_query']='UPDATE users SET password=%P WHERE email=%u';" \
-	"\$config['password_algorithm'] = 'dovecot';" \
-	"\$config['password_dovecotpw']='/usr/bin/doveadm pw';" \
-	"\$config['password_dovecotpw_method']='SHA512-CRYPT';" \
-	"\$config['password_dovecotpw_with_method']=true;"
+	"\$config['password_algorithm']='sha512-crypt';" \
+	"\$config['password_algorithm_prefix']='{SHA512-CRYPT}';"
 
 # so PHP can use doveadm, for the password changing plugin
 usermod -a -G dovecot www-data

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -184,7 +184,8 @@ cp ${RCM_PLUGIN_DIR}/password/config.inc.php.dist \
 tools/editconf.py ${RCM_PLUGIN_DIR}/password/config.inc.php \
 	"\$config['password_minimum_length']=8;" \
 	"\$config['password_db_dsn']='sqlite:///$STORAGE_ROOT/mail/users.sqlite';" \
-	"\$config['password_query']='UPDATE users SET password=%D WHERE email=%u';" \
+	"\$config['password_query']='UPDATE users SET password=%P WHERE email=%u';" \
+	"\$config['password_algorithm'] = 'dovecot';" \
 	"\$config['password_dovecotpw']='/usr/bin/doveadm pw';" \
 	"\$config['password_dovecotpw_method']='SHA512-CRYPT';" \
 	"\$config['password_dovecotpw_with_method']=true;"


### PR DESCRIPTION
This pull request updates the configuration for the password plugin so it works. Some configuration options where deprecated. See #2185 
Note there is still the remaining issue of sqlite database becoming unreadable by postfix after (trying to) changing the password through Roundcube. 