### PR TITLE
feat(status page): Add summary of ok/error/warning counts

### DIFF
--- a/management/templates/system-status.html
+++ b/management/templates/system-status.html
@@ -103,9 +103,7 @@ function show_system_status() {
       const error_symbol = "✖";
       const warning_symbol = "?";
 
-      let num_ok = 0;
-      let num_error = 0;
-      let num_warning = 0;
+      let count_by_status = { ok: 0, error: 0, warning: 0 };
 
       for (var i = 0; i < r.length; i++) {
         var n = $("<tr><td class='status'/><td class='message'><p style='margin: 0'/><div class='extra'/><a class='showhide' href='#'/></tr>");
@@ -115,18 +113,10 @@ function show_system_status() {
         else
                 n.addClass("status-" + r[i].type)
 
-	if (r[i].type == "ok") {
-	    ++num_ok;
-	    n.find('td.status').text(ok_symbol);
-	}
-	else if (r[i].type == "error") {
-	    ++num_error;
-	    n.find('td.status').text(error_symbol);
-	}
-	else if (r[i].type == "warning") {
-	    ++num_warning;
-	    n.find('td.status').text(warning_symbol);
-	}
+        if (r[i].type == "ok") n.find('td.status').text(ok_symbol);
+        if (r[i].type == "error") n.find('td.status').text(error_symbol);
+        if (r[i].type == "warning") n.find('td.status').text(warning_symbol);
+        count_by_status[r[i].type]++;
 
         n.find('td.message p').text(r[i].text)
         $('#system-checks tbody').append(n);
@@ -149,11 +139,14 @@ function show_system_status() {
       }
 
       // Summary counts
-      const all_ok = (num_error + num_warning == 0) ? 'All ' : '';
-      summary.append($('<span class="summary-ok"/>').text(`${all_ok}${num_ok} ${ok_symbol} Ok`));
-      if (num_error > 0) summary.append($('<span class="summary-error"/>').text(`, ${num_error} ${error_symbol} Error`));
-      if (num_warning > 0) summary.append($('<span class="summary-warning"/>').text(`, ${num_warning} ${warning_symbol} Warning`));
-      if (num_error > 0 || num_warning > 0) summary.append($('<span/>').text(`, out of ${num_ok + num_error + num_warning} checks`));
+      summary.html("Summary: ");
+      if (count_by_status['error'] + count_by_status['warning'] == 0) {
+        summary.append($('<span class="summary-ok"/>').text(`All ${count_by_status['ok']} ${ok_symbol} OK`));
+      } else {
+        summary.append($('<span class="summary-ok"/>').text(`${count_by_status['ok']} ${ok_symbol} OK, `));
+        summary.append($('<span class="summary-error"/>').text(`${count_by_status['error']} ${error_symbol} Error, `));
+        summary.append($('<span class="summary-warning"/>').text(`${count_by_status['warning']} ${warning_symbol} Warning`));
+      }
     })
 }
 

--- a/management/templates/system-status.html
+++ b/management/templates/system-status.html
@@ -10,13 +10,13 @@
   border-top: none;
   padding-top: 0;
 }
-#system-checks .status-error td {
+#system-checks .status-error td, .summary-error {
   color: #733;
 }
-#system-checks .status-warning td {
+#system-checks .status-warning td, .summary-warning {
   color: #770;
 }
-#system-checks .status-ok td {
+#system-checks .status-ok td, .summary-ok {
   color: #040;
 }
 #system-checks div.extra {
@@ -52,6 +52,9 @@
 	</div> <!-- /col -->
 	<div class="col-md-pull-3 col-md-8">
 
+          <div id="system-checks-summary">
+          </div>
+
 <table id="system-checks" class="table" style="max-width: 60em">
   <thead>
   </thead>
@@ -64,6 +67,9 @@
 
 <script>
 function show_system_status() {
+  const summary = $('#system-checks-summary');
+  summary.html("");
+
   $('#system-checks tbody').html("<tr><td colspan='2' class='text-muted'>Loading...</td></tr>")
 
   api(
@@ -93,6 +99,14 @@ function show_system_status() {
     { },
     function(r) {
       $('#system-checks tbody').html("");
+      const ok_symbol = "✓";
+      const error_symbol = "✖";
+      const warning_symbol = "?";
+
+      let num_ok = 0;
+      let num_error = 0;
+      let num_warning = 0;
+
       for (var i = 0; i < r.length; i++) {
         var n = $("<tr><td class='status'/><td class='message'><p style='margin: 0'/><div class='extra'/><a class='showhide' href='#'/></tr>");
         if (i == 0) n.addClass('first')
@@ -100,9 +114,20 @@ function show_system_status() {
                 n.addClass(r[i].type)
         else
                 n.addClass("status-" + r[i].type)
-        if (r[i].type == "ok") n.find('td.status').text("✓")
-        if (r[i].type == "error") n.find('td.status').text("✖")
-        if (r[i].type == "warning") n.find('td.status').text("?")
+
+	if (r[i].type == "ok") {
+	    ++num_ok;
+	    n.find('td.status').text(ok_symbol);
+	}
+	else if (r[i].type == "error") {
+	    ++num_error;
+	    n.find('td.status').text(error_symbol);
+	}
+	else if (r[i].type == "warning") {
+	    ++num_warning;
+	    n.find('td.status').text(warning_symbol);
+	}
+
         n.find('td.message p').text(r[i].text)
         $('#system-checks tbody').append(n);
 
@@ -122,8 +147,14 @@ function show_system_status() {
           n.find('> td.message > div').append(m);
         }
       }
-    })
 
+      // Summary counts
+      const all_ok = (num_error + num_warning == 0) ? 'All ' : '';
+      summary.append($('<span class="summary-ok"/>').text(`${all_ok}${num_ok} ${ok_symbol} Ok`));
+      if (num_error > 0) summary.append($('<span class="summary-error"/>').text(`, ${num_error} ${error_symbol} Error`));
+      if (num_warning > 0) summary.append($('<span class="summary-warning"/>').text(`, ${num_warning} ${warning_symbol} Warning`));
+      if (num_error > 0 || num_warning > 0) summary.append($('<span/>').text(`, out of ${num_ok + num_error + num_warning} checks`));
+    })
 }
 
 var current_privacy_setting = null;


### PR DESCRIPTION
Add a one-line summary of ok/error/warning to Status Checks page.  Eliminates need to scroll and search for errors if everything is ok.  Also serves as a legend for the status symbols.

If all checks are ok:
![image](https://user-images.githubusercontent.com/6404010/202550255-e3ae4f9b-ad11-4987-bd87-6b6bf8800c60.png)


But, if there are any issues:
![image](https://user-images.githubusercontent.com/6404010/202550428-99695ad5-b5a9-4eb6-bcd7-4b71714b201c.png)

