### PR TITLE
feat(rsync-port): Add support for non-standard ssh port for rsync backup

### DIFF
--- a/management/backup.py
+++ b/management/backup.py
@@ -213,9 +213,18 @@ def get_duplicity_additional_args(env):
 	config = get_backup_config(env)
 
 	if get_target_type(config) == 'rsync':
+		# Extract a port number for the ssh transport.  Duplicity accepts the
+		# optional port number syntax in the target, but it doesn't appear to act
+		# on it, so we set the ssh port explicitly via the duplicity options.
+		from urllib.parse import urlsplit
+		try:
+			port = urlsplit(config["target"]).port
+		except ValueError:
+			port = 22
+
 		return [
-			"--ssh-options= -i /root/.ssh/id_rsa_miab",
-			"--rsync-options= -e \"/usr/bin/ssh -oStrictHostKeyChecking=no -oBatchMode=yes -p 22 -i /root/.ssh/id_rsa_miab\"",
+			f"--ssh-options= -i /root/.ssh/id_rsa_miab -p {port}",
+			f"--rsync-options= -e \"/usr/bin/ssh -oStrictHostKeyChecking=no -oBatchMode=yes -p {port} -i /root/.ssh/id_rsa_miab\"",
 		]
 	elif get_target_type(config) == 's3':
 		# See note about hostname in get_duplicity_target_url.
@@ -408,6 +417,14 @@ def list_target_files(config):
 		rsync_fn_size_re = re.compile(r'.*    ([^ ]*) [^ ]* [^ ]* (.*)')
 		rsync_target = '{host}:{path}'
 
+		# Strip off any trailing port specifier because it's not valid in rsync's
+		# DEST syntax.  Explicitly set the port number for the ssh transport.
+		user_host, *_ = target.netloc.rsplit(':', 1)
+		try:
+			port = target.port
+		except ValueError:
+			 port = 22
+
 		target_path = target.path
 		if not target_path.endswith('/'):
 			target_path = target_path + '/'
@@ -416,11 +433,11 @@ def list_target_files(config):
 
 		rsync_command = [ 'rsync',
 					'-e',
-					'/usr/bin/ssh -i /root/.ssh/id_rsa_miab -oStrictHostKeyChecking=no -oBatchMode=yes',
+					f'/usr/bin/ssh -i /root/.ssh/id_rsa_miab -oStrictHostKeyChecking=no -oBatchMode=yes -p {port}',
 					'--list-only',
 					'-r',
 					rsync_target.format(
-						host=target.netloc,
+						host=user_host,
 						path=target_path)
 				]
 

--- a/management/templates/system-backup.html
+++ b/management/templates/system-backup.html
@@ -45,6 +45,10 @@
     <label for="backup-target-rsync-host" class="col-sm-2 control-label">Hostname</label>
     <div class="col-sm-8">
       <input type="text" placeholder="hostname.local" class="form-control" rows="1" id="backup-target-rsync-host">
+      <div class="small" style="margin-top: 2px">
+	The hostname at your rsync provider, e.g. <tt>da2327.rsync.net</tt>.  Optionally includes a colon
+	and the provider's non-standard ssh port number, e.g. <tt>u215843.your-storagebox.de:23</tt>. 
+      </div>
     </div>
   </div>
   <div class="form-group backup-target-rsync">


### PR DESCRIPTION
These changes add that the user can configure the ssh port used for rsync backup.  This was surprising simple in the end because the existing plumbing for the target url already implicitly supported the port number because URL syntax includes an option for the port in the net_loc slot: https://datatracker.ietf.org/doc/html/rfc1738#section-3.1

Un-intrusive UI change just adds guiding commentary to Hostname field
![image](https://user-images.githubusercontent.com/6404010/203316829-9e222c80-5032-4885-8cf9-6d0cee7ce0bb.png)


This PR addresses the core concerns of several Issues:
- #2104
- #1914 
- #1758 
- #1147 

See also PR #2207 which fixes the broken display of rsync settings (and where I realized that supporting port configuration isn't difficult).
