### PR TITLE
Remove old dark mode background color

### DIFF
--- a/management/templates/index.html
+++ b/management/templates/index.html
@@ -72,11 +72,6 @@
         html {
           filter: invert(100%) hue-rotate(180deg);
         }
-
-        /* Set explicit background color (necessary for Firefox) */
-        html {
-          background-color: #111;
-        }
           
         /* Override Boostrap theme here to give more contrast. The black turns to white by the filter. */
         .form-control {


### PR DESCRIPTION
Removing this old background color solves the problem of the bottom of short pages (like `/admin`'s login page) being white. The background was being set to black, which would be inverted, so it'd appear white. Since the `filter:` css has [~97% support](https://caniuse.com/?search=filter), I think that this change should be made. 

Tested on latest versions of Chrome (mac and iOS), Firefox, and Safari (mac and iOS).