### PR TITLE
fix(rsync-backup): Provide default port 22 for rsync usage in backup.py

### DIFF
--- a/management/backup.py
+++ b/management/backup.py
@@ -221,7 +221,9 @@ def get_duplicity_additional_args(env):
 			port = urlsplit(config["target"]).port
 		except ValueError:
 			port = 22
-
+		if port is None:
+			port = 22
+						
 		return [
 			f"--ssh-options= -i /root/.ssh/id_rsa_miab -p {port}",
 			f"--rsync-options= -e \"/usr/bin/ssh -oStrictHostKeyChecking=no -oBatchMode=yes -p {port} -i /root/.ssh/id_rsa_miab\"",
@@ -424,6 +426,8 @@ def list_target_files(config):
 			port = target.port
 		except ValueError:
 			 port = 22
+		if port is None:
+			port = 22
 
 		target_path = target.path
 		if not target_path.endswith('/'):


### PR DESCRIPTION
This fixes what is arguably a migration issue: existing installations do not have the rsync/ssh port in the target in `custom.yaml`, and the code expects a valid port.  However, rather than doing a migration, this simple code change puts in the default port if no port is provided in the target, and thus supports targets that don't specify a port.

I tested this by hand editing `custom.yaml` to remove the port specification in the target, restarted the daemon, and successfully loaded the Backup Status page.