### PR TITLE
feat(rsync-backup-ui): Add a Copy button to put public key on clipboard in rsync UI

### DIFF
--- a/management/templates/system-backup.html
+++ b/management/templates/system-backup.html
@@ -377,7 +377,8 @@ const url_split = url => {
     }
 };
   
-// hide Copy button if not in a modern clipboard-supporting environment
+// Hide Copy button if not in a modern clipboard-supporting environment.
+// Using document API because jQuery is not necessarily available in this script scope.
 if (!(navigator && navigator.clipboard && navigator.clipboard.writeText)) {
     document.getElementById('copy_pub_key_div').hidden = true;
 }

--- a/management/templates/system-backup.html
+++ b/management/templates/system-backup.html
@@ -73,6 +73,9 @@
         passwordless authentication from your mail-in-a-box server and your backup server.
       </div>
     </div>
+    <div id="copy_pub_key_div" class="col-sm">
+      <button type="button" class="btn btn-small" onclick="copy_pub_key_to_clipboard()">Copy</button>
+    </div> 
   </div>
   <!-- S3 BACKUP -->
   <div class="form-group backup-target-s3">
@@ -374,4 +377,14 @@ const url_split = url => {
     }
 };
   
+// hide Copy button if not in a modern clipboard-supporting environment
+if (!(navigator && navigator.clipboard && navigator.clipboard.writeText)) {
+    document.getElementById('copy_pub_key_div').hidden = true;
+}
+
+function copy_pub_key_to_clipboard() {
+    const ssh_pub_key = $("#ssh-pub-key").val();
+    navigator.clipboard.writeText(ssh_pub_key);
+}  
+
 </script>


### PR DESCRIPTION
Add a button for copying the public key to the clipboard.  Button is hidden in browsers that don't have the `writeText` API.

![image](https://user-images.githubusercontent.com/6404010/214704387-16c1c121-1b16-4f81-9657-e9b22b852d9d.png)
