### PR TITLE
Fixed year in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-Version 61.1 (January 28, 2022)
+Version 61.1 (January 28, 2023)
 -------------------------------
 
 * Fixed rsync backups not working with the default port.


### PR DESCRIPTION
Fixed year of version 61.1 (2022 -> 2023)