### PR TITLE
Fix for Munin dynazoom due to change in handling su in Ubuntu 22.04

### DIFF
--- a/management/daemon.py
+++ b/management/daemon.py
@@ -709,7 +709,7 @@ def munin_cgi(filename):
 	support infrastructure like spawn-fcgi.
 	"""
 
-	COMMAND = 'su - munin --preserve-environment --shell=/bin/bash -c /usr/lib/munin/cgi/munin-cgi-graph'
+	COMMAND = 'su munin --preserve-environment --shell=/bin/bash -c /usr/lib/munin/cgi/munin-cgi-graph'
 	# su changes user, we use the munin user here
 	# --preserve-environment retains the environment, which is where Popen's `env` data is
 	# --shell=/bin/bash ensures the shell used is bash


### PR DESCRIPTION
Seems ( afaik ) that in Ubuntu 22.04 the behavior in su changed, making - ( alias for -l, --login ) mutually exclusive with --preserve-environment which is required for passing enviroment variables for cgi to work for the dynazoom feature in munin.
Dropping - fixes the issue

see man su

       -, -l, --login
           Start the shell as a login shell with an environment similar to a real login:

           •   clears all the environment variables except TERM and variables specified by --whitelist-environment

           •   initializes the environment variables HOME, SHELL, USER, LOGNAME, and PATH

           •   changes to the target user’s home directory

           •   sets argv[0] of the shell to '-' in order to make the shell a login shell

       -m, -p, --preserve-environment
           Preserve the entire environment, i.e., do not set HOME, SHELL, USER or LOGNAME. This option is ignored if the
           option --login is specified.