### PR TITLE
Fix issue where sshkeygen fails when ipv6 is disabled

### DIFF
--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -465,7 +465,7 @@ def build_sshfp_records():
 					pass
 				break
 
-	keys = shell("check_output", ["ssh-keyscan", "-t", "rsa,dsa,ecdsa,ed25519", "-p", str(port), "localhost"])
+	keys = shell("check_output", ["ssh-keyscan", "-4", "-t", "rsa,dsa,ecdsa,ed25519", "-p", str(port), "localhost"])
 	keys = sorted(keys.split("\n"))
 
 	for key in keys:


### PR DESCRIPTION
As reported on the forum (e.g. [here](https://discourse.mailinabox.email/t/solved-ubuntu-22-04-lts-setup-ends-with-http-500-error/10264) there's an issue with the DNS page when ipv6 is disabled for sshd. This patch solves this by always calling ssh-keygen on an ipv4 address. 