### PR TITLE
email_administrator.py: fix report formatting

### DIFF
--- a/management/email_administrator.py
+++ b/management/email_administrator.py
@@ -29,7 +29,7 @@ content = sys.stdin.read().strip()
 
 # If there's nothing coming in, just exit.
 if content == "":
-	sys.exit(0)
+    sys.exit(0)
 
 # create MIME message
 msg = MIMEMultipart('alternative')
@@ -41,7 +41,7 @@ msg['From'] = "\"%s\" <%s>" % (env['PRIMARY_HOSTNAME'], admin_addr)
 msg['To'] = admin_addr
 msg['Subject'] = "[%s] %s" % (env['PRIMARY_HOSTNAME'], subject)
 
-content_html = "<html><body><pre>{}</pre></body></html>".format(html.escape(content))
+content_html = '<html><body><pre style="overflow-x: scroll; white-space: pre;">{}</pre></body></html>'.format(html.escape(content))
 
 msg.attach(MIMEText(content, 'plain'))
 msg.attach(MIMEText(content_html, 'html'))


### PR DESCRIPTION
The text in the weekly usage report is wrapped in the iOS mail app, which makes the tables hard to read.

I have added `overflow-x:scroll;white-space:pre` style to the `<pre>` tag, which prevents the automatic wrapping. Without the `overflow-x` the default zoom level/font-size changes, I don't know why, see below. I prefer the zoomed-in one.

| 1 | 2 | 3 |
|--------|--------|--------|
| Current | `overflow-x` + `white-space` | `white-space` |
| ![IMG_6473](https://user-images.githubusercontent.com/13013768/228380023-2c5fc5ac-fd37-4c00-9f6c-e6f96ff44cd1.PNG) | ![IMG_6474](https://user-images.githubusercontent.com/13013768/228380064-ca04880c-2cc4-499f-abf6-da329b6bb638.PNG) | ![IMG_6475](https://user-images.githubusercontent.com/13013768/228380087-49533ae7-d969-4e31-81ea-4ead94b0162b.PNG) | 

I have checked in Thunderbird, Roundcube and the GMail web interface, the e-mail's appearance doesn't change.
