### PR TITLE
[v61.1] Fix SSL certificates provisionning for new Mail-in-a-box instances

### DIFF
--- a/management/ssl_certificates.py
+++ b/management/ssl_certificates.py
@@ -342,8 +342,9 @@ def provision_certificates(env, limit_domains):
 						"certbot",
 						"certonly",
 						#"-v", # just enough to see ACME errors
-						"--non-interactive", # will fail if user hasn't registered during Mail-in-a-Box setup
-
+						"--non-interactive",
+						"--agree-tos",                              # needed because Mail-in-a-Box does not create (and register)
+						"--email", "administrator@" + domain_list[0], # administrator user in setup anymore
 						"-d", ",".join(domain_list), # first will be main domain
 
 						"--csr", csr_file.name, # use our private key; unfortunately this doesn't work with auto-renew so we need to save cert manually


### PR DESCRIPTION
New Mail-in-a-Box setup does not create administrator user and so, not registering the email address to Letsencrypt. Provisionning certificates fails because of that in UI and when running management/ssl_certificates.py script.

Users already registered to LetsEncrypt are not impacted by this behavior.