### PR TITLE
Alter postfix config to use public IPv6 address for outbound mails

### DIFF
--- a/setup/mail-postfix.sh
+++ b/setup/mail-postfix.sh
@@ -56,7 +56,7 @@ apt_install postfix postfix-sqlite postfix-pcre postgrey ca-certificates
 tools/editconf.py /etc/postfix/main.cf \
 	inet_interfaces=all \
 	smtp_bind_address=$PRIVATE_IP \
-	smtp_bind_address6=$PRIVATE_IPV6 \
+	smtp_bind_address6=$PUBLIC_IPV6 \
 	myhostname=$PRIMARY_HOSTNAME\
 	smtpd_banner="\$myhostname ESMTP Hi, I'm a Mail-in-a-Box (Ubuntu/Postfix; see https://mailinabox.email/)" \
 	mydestination=localhost


### PR DESCRIPTION
This change alters the Postfix configuration to use the public IPv6 address instead of the private IPv6 address when sending outbound mails over IPv6.

I'm not sure what the reasoning was for the current method.  If there are use cases which require the private IPv6 to be used for outbound emails over IPv6 then this PR will need to be extended to allow this to be a configurable choice.

This PR will fix #1738 which is the exact scenario which led to me discovering the problem.

I'm happy to make this PR more involved/optionally configured if some users need to be able to retain the original behavior.  I have a suspicion, though, that this is the desired behavior in all cases.  What would the use-case be where the user wants Postfix to use the private IPv6 address which will not be covered by "spf -mx" and which (in the case of a hosted VPS provider like Linode) is much more likely to be un-avoidably listed in smtp blackholes like spamhaus XBL/CSS or equivalent which apply to the entire /64 which might be shared among multiple customers at the hosting provider.

I'm not aware of any hosting provider that does address translation with IPv6 the way NAT is employed with IPv4 and such a configuration would be at best strongly discouraged.  The private/public distinction doesn't make sense with IPv6 to me at all.