### PR TITLE
Fix z-push-admin broken in v60

### DIFF
--- a/setup/zpush.sh
+++ b/setup/zpush.sh
@@ -41,7 +41,15 @@ if [ $needs_update == 1 ]; then
 	mv /tmp/z-push/*/src /usr/local/lib/z-push
 	rm -rf /tmp/z-push.zip /tmp/z-push
 
+	# Create admin and top scripts with PHP_VER  
 	rm -f /usr/sbin/z-push-{admin,top}
+    echo '#!/bin/bash' > /usr/sbin/z-push-admin
+    echo php$PHP_VER /usr/local/lib/z-push/z-push-admin.php '"$@"' >> /usr/sbin/z-push-admin
+    chmod 755 /usr/sbin/z-push-admin
+    echo '#!/bin/bash' > /usr/sbin/z-push-top
+    echo php$PHP_VER /usr/local/lib/z-push/z-push-top.php '"$@"' >> /usr/sbin/z-push-top
+    chmod 755 /usr/sbin/z-push-top
+	
 	echo $VERSION > /usr/local/lib/z-push/version
 fi
 


### PR DESCRIPTION
update zpush.sh to create two sbin bash scripts for z-push-admin and z-push-top using PHP_VER.

Fixes https://github.com/mail-in-a-box/mailinabox/issues/2178

Using Bash scripts instead of symlinks, this enables using PHP_VER used elsewhere in script. 

This change will only take effect when an upgrade of Z-Push occurs, will provide a separate script solution in the issue for users currently on 2.7.0.

(Edit: spelling) 