### PR TITLE
Fix hashes ('hash' and 'hash_user_external') for the InstallNextcloud 23.0.12 step.

### DIFF
--- a/setup/nextcloud.sh
+++ b/setup/nextcloud.sh
@@ -204,7 +204,7 @@ if [ ! -d /usr/local/lib/owncloud/ ] || [[ ! ${CURRENT_NEXTCLOUD_VER} =~ ^$nextc
 			CURRENT_NEXTCLOUD_VER="22.2.6"
 		fi
 		if [[ ${CURRENT_NEXTCLOUD_VER} =~ ^22 ]]; then
-			InstallNextcloud 23.0.12 7aa5d61632c1ccf4ca3ff00fb6b295d318c05599 4.1.0 697f6b4a664e928d72414ea2731cb2c9d1dc3077 3.2.2 ce4030ab57f523f33d5396c6a81396d440756f5f 3.0.0 22cabc88b6fc9c26dad3b46be1a652979c9fcf15
+			InstallNextcloud 23.0.12 d138641b8e7aabebe69bb3ec7c79a714d122f729 4.1.0 697f6b4a664e928d72414ea2731cb2c9d1dc3077 3.2.2 ce4030ab57f523f33d5396c6a81396d440756f5f 3.0.0 0df781b261f55bbde73d8c92da3f99397000972f
 			CURRENT_NEXTCLOUD_VER="23.0.12"
 		fi
 		if [[ ${CURRENT_NEXTCLOUD_VER} =~ ^23 ]]; then


### PR DESCRIPTION
Yesterday I finally managed to install an ubuntu 22.04 so that I could upgrade my miab :sweat_smile:

While installing the new miab instance, I bumped into an error while installing nextcloud due to a couple of wrong sha1sums (nextcloud.zip's sha1sum looked *really* suspicious as it was the same as for version 24.0.12 - probably some copy-pasting was done here without a coffee in the morning :wink: ).

With the values in this commit, I was able to continue with the installation.