### PR TITLE
Update roundcube carddav plugin to version 5.1.0

### DIFF
--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -154,6 +154,7 @@ cat > ${RCM_PLUGIN_DIR}/carddav/config.inc.php <<EOF;
 /* Do not edit. Written by Mail-in-a-Box. Regenerated on updates. */
 \$prefs['_GLOBAL']['hide_preferences'] = true;
 \$prefs['_GLOBAL']['suppress_version_warning'] = true;
+\$prefs['_GLOBAL']['pwstore_scheme'] = 'plain';
 \$prefs['ownCloud'] = array(
 	'name'         =>  'ownCloud',
 	'username'     =>  '%u', // login username

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -153,7 +153,6 @@ cat > ${RCM_PLUGIN_DIR}/carddav/config.inc.php <<EOF;
 <?php
 /* Do not edit. Written by Mail-in-a-Box. Regenerated on updates. */
 \$prefs['_GLOBAL']['hide_preferences'] = true;
-\$prefs['_GLOBAL']['suppress_version_warning'] = true;
 \$prefs['_GLOBAL']['pwstore_scheme'] = 'plain';
 \$prefs['ownCloud'] = array(
 	'name'         =>  'ownCloud',
@@ -166,8 +165,6 @@ cat > ${RCM_PLUGIN_DIR}/carddav/config.inc.php <<EOF;
 			'readonly'     =>  false,
 			'refresh_time' => '02:00:00',
 			'fixed'        =>  array('username','password'),
-			'preemptive_auth' => '1',
-			'hide'        =>  false,
 		],
 	],
 );

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -40,8 +40,8 @@ VERSION=1.6.1
 HASH=0e1c771ab83ea03bde1fd0be6ab5d09e60b4f293
 PERSISTENT_LOGIN_VERSION=bde7b6840c7d91de627ea14e81cf4133cbb3c07a # version 5.2
 HTML5_NOTIFIER_VERSION=68d9ca194212e15b3c7225eb6085dbcf02fd13d7 # version 0.6.4+
-CARDDAV_VERSION=4.4.3
-CARDDAV_HASH=74f8ba7aee33e78beb9de07f7f44b81f6071b644
+CARDDAV_VERSION=5.1.0
+CARDDAV_HASH=9f977d319db13ea1b4ca6c9bb98aaef0feb9eebe
 
 UPDATE_KEY=$VERSION:$PERSISTENT_LOGIN_VERSION:$HTML5_NOTIFIER_VERSION:$CARDDAV_VERSION
 
@@ -155,16 +155,20 @@ cat > ${RCM_PLUGIN_DIR}/carddav/config.inc.php <<EOF;
 \$prefs['_GLOBAL']['hide_preferences'] = true;
 \$prefs['_GLOBAL']['suppress_version_warning'] = true;
 \$prefs['ownCloud'] = array(
-	 'name'         =>  'ownCloud',
-	 'username'     =>  '%u', // login username
-	 'password'     =>  '%p', // login password
-	 'url'          =>  'https://${PRIMARY_HOSTNAME}/cloud/remote.php/dav/addressbooks/users/%u/contacts/',
-	 'active'       =>  true,
-	 'readonly'     =>  false,
-	 'refresh_time' => '02:00:00',
-	 'fixed'        =>  array('username','password'),
-	 'preemptive_auth' => '1',
-	 'hide'        =>  false,
+	'name'         =>  'ownCloud',
+	'username'     =>  '%u', // login username
+	'password'     =>  '%p', // login password
+	'extra_addressbooks' =>  [
+		[
+			'url'          =>  'https://${PRIMARY_HOSTNAME}/cloud/remote.php/dav/addressbooks/users/%u/contacts/',
+			'active'       =>  true,
+			'readonly'     =>  false,
+			'refresh_time' => '02:00:00',
+			'fixed'        =>  array('username','password'),
+			'preemptive_auth' => '1',
+			'hide'        =>  false,
+		],
+	],
 );
 ?>
 EOF


### PR DESCRIPTION
This updates the carddav plugin for Roundcube to the latest version. 
There is a change in the configuration (usage of 'extra_addressbooks', see https://github.com/mstilkerich/rcmcarddav#upgrading-from-4x) There's also a note that perhaps a manual cleanup of the address books is needed, but that wasn't an issue for me.