### PR TITLE
Migrate from php8.0 to php8.1

### DIFF
--- a/conf/nginx-top.conf
+++ b/conf/nginx-top.conf
@@ -7,6 +7,6 @@
 ##       your own --- please do not ask for help from us.
 
 upstream php-fpm {
-	server unix:/var/run/php/php8.0-fpm.sock;
+	server unix:/var/run/php/php{{phpver}}-fpm.sock;
 }
 

--- a/management/backup.py
+++ b/management/backup.py
@@ -12,7 +12,7 @@ import dateutil.parser, dateutil.relativedelta, dateutil.tz
 import rtyaml
 from exclusiveprocess import Lock
 
-from utils import load_environment, shell, wait_for_service
+from utils import load_environment, shell, wait_for_service, get_php_version
 
 def backup_status(env):
 	# If backups are dissbled, return no status.
@@ -262,6 +262,7 @@ def get_target_type(config):
 
 def perform_backup(full_backup):
 	env = load_environment()
+	php_fpm = f"php{get_php_version()}-fpm"
 
 	# Create an global exclusive lock so that the backup script
 	# cannot be run more than one.
@@ -297,7 +298,7 @@ def perform_backup(full_backup):
 			if quit:
 				sys.exit(code)
 
-	service_command("php8.0-fpm", "stop", quit=True)
+	service_command(php_fpm, "stop", quit=True)
 	service_command("postfix", "stop", quit=True)
 	service_command("dovecot", "stop", quit=True)
 	service_command("postgrey", "stop", quit=True)
@@ -334,7 +335,7 @@ def perform_backup(full_backup):
 		service_command("postgrey", "start", quit=False)
 		service_command("dovecot", "start", quit=False)
 		service_command("postfix", "start", quit=False)
-		service_command("php8.0-fpm", "start", quit=False)
+		service_command(php_fpm, "start", quit=False)
 
 	# Remove old backups. This deletes all backup data no longer needed
 	# from more than 3 days ago.

--- a/management/utils.py
+++ b/management/utils.py
@@ -178,6 +178,10 @@ def wait_for_service(port, public, env, timeout):
 				return False
 		time.sleep(min(timeout/4, 1))
 
+def get_php_version():
+	# Gets the version of PHP installed in the system.
+	return shell("check_output", ["/usr/bin/php", "-v"])[4:7]
+
 if __name__ == "__main__":
 	from web_update import get_web_domains
 	env = load_environment()

--- a/management/web_update.py
+++ b/management/web_update.py
@@ -7,7 +7,7 @@ import os.path, re, rtyaml
 from mailconfig import get_mail_domains
 from dns_update import get_custom_dns_config, get_dns_zones
 from ssl_certificates import get_ssl_certificates, get_domain_ssl_files, check_certificate
-from utils import shell, safe_domain_name, sort_domains
+from utils import shell, safe_domain_name, sort_domains, get_php_version
 
 def get_web_domains(env, include_www_redirects=True, include_auto=True, exclude_dns_elsewhere=True):
 	# What domains should we serve HTTP(S) for?
@@ -83,6 +83,7 @@ def do_web_update(env):
 
 	# Build an nginx configuration file.
 	nginx_conf = read_conf("nginx-top.conf")
+	nginx_conf = re.sub("{{phpver}}", get_php_version(), nginx_conf)
 
 	# Load the templates.
 	template0 = read_conf("nginx.conf")

--- a/setup/functions.sh
+++ b/setup/functions.sh
@@ -4,8 +4,6 @@
 # -o pipefail: don't ignore errors in the non-last command in a pipeline
 set -euo pipefail
 
-PHP_VER=8.0
-
 function hide_output {
 	# This function hides the output of a command unless the command fails
 	# and returns a non-zero exit code.
@@ -222,3 +220,8 @@ function git_clone {
 	mv $TMPPATH/$SUBDIR $TARGETPATH
 	rm -rf $TMPPATH
 }
+
+function php_version {
+	php --version | head -n 1 | cut -d " " -f 2 | cut -c 1-3
+}
+

--- a/setup/nextcloud.sh
+++ b/setup/nextcloud.sh
@@ -48,10 +48,12 @@ user_external_hash=a494073dcdecbbbc79a9c77f72524ac9994d2eec
 
 apt-get purge -qq -y owncloud* # we used to use the package manager
 
-apt_install curl php${PHP_VER} php${PHP_VER}-fpm \
-	php${PHP_VER}-cli php${PHP_VER}-sqlite3 php${PHP_VER}-gd php${PHP_VER}-imap php${PHP_VER}-curl \
-	php${PHP_VER}-dev php${PHP_VER}-gd php${PHP_VER}-xml php${PHP_VER}-mbstring php${PHP_VER}-zip php${PHP_VER}-apcu \
-	php${PHP_VER}-intl php${PHP_VER}-imagick php${PHP_VER}-gmp php${PHP_VER}-bcmath
+apt_install curl php8.1 php8.1-fpm \
+	php8.1-cli php8.1-sqlite3 php8.1-gd php8.1-imap php8.1-curl \
+	php8.1-dev php8.1-xml php8.1-mbstring php8.1-zip php8.1-apcu \
+	php8.1-intl php8.1-imagick php8.1-gmp php8.1-bcmath
+
+PHP_VER=$(php_version)
 
 # Enable APC before Nextcloud tools are run.
 tools/editconf.py /etc/php/$PHP_VER/mods-available/apcu.ini -c ';' \
@@ -195,6 +197,32 @@ if [ ! -d /usr/local/lib/owncloud/ ] || [[ ! ${CURRENT_NEXTCLOUD_VER} =~ ^$nextc
 			return 0
 		fi
 
+		# Install php 8.0 for older versions of nextcloud that don't support 8.1
+		if [[ ${CURRENT_NEXTCLOUD_VER} =~ ^2[0123] ]]; then
+			# Version 20 is the latest version from the 18.04 version of miab. To upgrade to version 21, install php8.0. This is
+			# not supported by version 20, but that does not matter, as the InstallNextcloud function only runs the version 21 code.
+			# We need php 8.0 for nextcloud 21-23, as php 8.1 is supported starting nextcloud 24
+			
+			# Install the ppa
+			add-apt-repository --yes ppa:ondrej/php
+			
+			# Prevent installation of old packages
+			apt-mark hold php7.0-apcu php7.1-apcu php7.2-apcu php7.3-apcu php7.4-apcu
+			
+			# Install older php version
+			apt_install php8.0 php8.0-fpm php8.0-apcu php8.0-cli php8.0-sqlite3 php8.0-gd php8.0-imap \
+				php8.0-curl php8.0-dev php8.0-xml php8.0-mbstring php8.0-zip
+			
+			# set older php version as default
+			update-alternatives --set php /usr/bin/php8.0
+
+			PHP_VER=$(php_version)
+
+			# Make sure apc is enabled
+			tools/editconf.py /etc/php/$PHP_VER/mods-available/apcu.ini -c ';' \
+				apc.enabled=1	\
+				apc.enable_cli=1
+		fi
 		if [[ ${CURRENT_NEXTCLOUD_VER} =~ ^20 ]]; then
 			InstallNextcloud 21.0.7 f5c7079c5b56ce1e301c6a27c0d975d608bb01c9 4.0.7 45e7cf4bfe99cd8d03625cf9e5a1bb2e90549136 3.0.4 d0284b68135777ec9ca713c307216165b294d0fe
 			CURRENT_NEXTCLOUD_VER="21.0.7"
@@ -210,6 +238,22 @@ if [ ! -d /usr/local/lib/owncloud/ ] || [[ ! ${CURRENT_NEXTCLOUD_VER} =~ ^$nextc
 		if [[ ${CURRENT_NEXTCLOUD_VER} =~ ^23 ]]; then
 			InstallNextcloud 24.0.12 7aa5d61632c1ccf4ca3ff00fb6b295d318c05599 4.1.0 697f6b4a664e928d72414ea2731cb2c9d1dc3077 3.2.2 ce4030ab57f523f33d5396c6a81396d440756f5f 3.0.0 0df781b261f55bbde73d8c92da3f99397000972f
 			CURRENT_NEXTCLOUD_VER="24.0.12"
+		fi
+		if [[ ${CURRENT_NEXTCLOUD_VER} =~ ^2[45678] ]]; then
+			# From nextcloud 24 and higher, php8.1 is supported, so we can now remove the php8.0 ppa and packages
+			
+			# Reset the default php version used
+			update-alternatives --auto php
+			
+			PHP_VER=$(php_version)
+
+			# Remove older php version
+			apt-get purge -qq -y php8.0 php8.0-fpm php8.0-apcu php8.0-cli php8.0-sqlite3 php8.0-gd \
+				php8.0-imap php8.0-curl php8.0-dev php8.0-xml php8.0-mbstring php8.0-zip \
+				php8.0-common php8.0-opcache php8.0-readline
+			
+			# Remove the ppa
+			add-apt-repository --yes --remove ppa:ondrej/php
 		fi
 	fi
 

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -100,10 +100,6 @@ hide_output add-apt-repository -y universe
 # Install the duplicity PPA.
 hide_output add-apt-repository -y ppa:duplicity-team/duplicity-release-git
 
-# Stock PHP is now 8.1, but we're transitioning through 8.0 because
-# of Nextcloud.
-hide_output add-apt-repository --y ppa:ondrej/php
-
 # ### Update Packages
 
 # Update system packages to make sure we have the latest upstream versions

--- a/setup/web.sh
+++ b/setup/web.sh
@@ -19,9 +19,11 @@ fi
 
 echo "Installing Nginx (web server)..."
 
-apt_install nginx php${PHP_VER}-cli php${PHP_VER}-fpm idn2
+apt_install nginx php8.1-cli php8.1-fpm idn2
 
 rm -f /etc/nginx/sites-enabled/default
+
+PHP_VER=$(php_version)
 
 # Copy in a nginx configuration file for common and best-practices
 # SSL settings from @konklone. Replace STORAGE_ROOT so it can find

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -5,6 +5,8 @@
 source setup/functions.sh # load our functions
 source /etc/mailinabox.conf # load global vars
 
+PHP_VER=$(php_version)
+
 # ### Installing Roundcube
 
 # We install Roundcube from sources, rather than from Ubuntu, because:

--- a/setup/zpush.sh
+++ b/setup/zpush.sh
@@ -13,6 +13,8 @@
 source setup/functions.sh # load our functions
 source /etc/mailinabox.conf # load global vars
 
+PHP_VER=$(php_version)
+
 # Prereqs.
 
 echo "Installing Z-Push (Exchange/ActiveSync server)..."

--- a/tools/owncloud-restore.sh
+++ b/tools/owncloud-restore.sh
@@ -26,7 +26,10 @@ if [ ! -f $1/config.php ]; then
 fi
 
 echo "Restoring backup from $1"
-service php8.0-fpm stop
+
+PHP_VER=$(php_version)
+
+service php$PHP_VER-fpm stop
 
 # remove the current ownCloud/Nextcloud installation
 rm -rf /usr/local/lib/owncloud/
@@ -45,5 +48,5 @@ chown www-data:www-data $STORAGE_ROOT/owncloud/config.php
 
 sudo -u www-data php$PHP_VER /usr/local/lib/owncloud/occ maintenance:mode --off
 
-service php8.0-fpm start
+service php$PHP_VER-fpm start
 echo "Done"

--- a/tools/owncloud-unlockadmin.sh
+++ b/tools/owncloud-unlockadmin.sh
@@ -19,5 +19,5 @@ echo If in doubt, press CTRL-C to cancel.
 echo 
 echo Press enter to continue.
 read
-
+PHP_VER=$(php_version)
 sudo -u www-data php$PHP_VER /usr/local/lib/owncloud/occ group:adduser admin $ADMIN && echo Done.


### PR DESCRIPTION
This pull request proposes the upgrade from php8.0 to php8.1. This would remove the dependency on an external ppa.
The logic works by introducing on a number of places a variable containing the php version. This makes the code independent of the used php version.
The upgrade logic is embedded in the nextcloud installation logic. If a version of nextcloud that does not support php8.1 is to be installed, the code will also install php8.0. Once a new enough version of nextcloud is detected, php8.0 is removed.

Installation has been tested via vagrant. Todo: test upgrade from v60 to this, and test upgrade from v57 to this.
