### PR TITLE
Update Roundcube to 1.6.4

### DIFF
--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -36,9 +36,9 @@ apt_install \
 #   https://github.com/mstilkerich/rcmcarddav/releases
 # The easiest way to get the package hashes is to run this script and get the hash from
 # the error message.
-VERSION=1.6.1
-HASH=0e1c771ab83ea03bde1fd0be6ab5d09e60b4f293
-PERSISTENT_LOGIN_VERSION=bde7b6840c7d91de627ea14e81cf4133cbb3c07a # version 5.2
+VERSION=1.6.3
+HASH=3a4beb75b0853ec76a3869bf7f2d2d74545933a2
+PERSISTENT_LOGIN_VERSION=bde7b6840c7d91de627ea14e81cf4133cbb3c07a # version 5.3
 HTML5_NOTIFIER_VERSION=68d9ca194212e15b3c7225eb6085dbcf02fd13d7 # version 0.6.4+
 CARDDAV_VERSION=4.4.3
 CARDDAV_HASH=74f8ba7aee33e78beb9de07f7f44b81f6071b644

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -36,8 +36,8 @@ apt_install \
 #   https://github.com/mstilkerich/rcmcarddav/releases
 # The easiest way to get the package hashes is to run this script and get the hash from
 # the error message.
-VERSION=1.6.3
-HASH=3a4beb75b0853ec76a3869bf7f2d2d74545933a2
+VERSION=1.6.4
+HASH=bfc693d6590542d63171e6a3997fc29f0a5f12ca
 PERSISTENT_LOGIN_VERSION=bde7b6840c7d91de627ea14e81cf4133cbb3c07a # version 5.3
 HTML5_NOTIFIER_VERSION=68d9ca194212e15b3c7225eb6085dbcf02fd13d7 # version 0.6.4+
 CARDDAV_VERSION=4.4.3


### PR DESCRIPTION
Roundcube has [security](https://roundcube.net/news/2023/09/15/security-update-1.6.3-released) [upgrades](https://roundcube.net/news/2023/10/16/security-update-1.6.4-released) so this pull request provides Roundcube 1.6.4.
I also took the opportunity to update the persistent login plugin from 5.2 to 5.3

This also now shows the correct persistent login plugin version.

See #2304 for earlier discussion on Roundcube 1.6.3.