### PR TITLE
Upgrade to php8.1 and upgrade old nextcloud versions using docker

### DIFF
--- a/conf/nginx-top.conf
+++ b/conf/nginx-top.conf
@@ -7,6 +7,6 @@
 ##       your own --- please do not ask for help from us.
 
 upstream php-fpm {
-	server unix:/var/run/php/php8.0-fpm.sock;
+	server unix:/var/run/php/php8.1-fpm.sock;
 }
 

--- a/management/backup.py
+++ b/management/backup.py
@@ -297,7 +297,7 @@ def perform_backup(full_backup):
 			if quit:
 				sys.exit(code)
 
-	service_command("php8.0-fpm", "stop", quit=True)
+	service_command("php8.1-fpm", "stop", quit=True)
 	service_command("postfix", "stop", quit=True)
 	service_command("dovecot", "stop", quit=True)
 	service_command("postgrey", "stop", quit=True)
@@ -334,7 +334,7 @@ def perform_backup(full_backup):
 		service_command("postgrey", "start", quit=False)
 		service_command("dovecot", "start", quit=False)
 		service_command("postfix", "start", quit=False)
-		service_command("php8.0-fpm", "start", quit=False)
+		service_command("php8.1-fpm", "start", quit=False)
 
 	# Remove old backups. This deletes all backup data no longer needed
 	# from more than 3 days ago.

--- a/setup/functions.sh
+++ b/setup/functions.sh
@@ -4,7 +4,7 @@
 # -o pipefail: don't ignore errors in the non-last command in a pipeline
 set -euo pipefail
 
-PHP_VER=8.0
+PHP_VER=8.1
 
 function hide_output {
 	# This function hides the output of a command unless the command fails

--- a/tools/owncloud-restore.sh
+++ b/tools/owncloud-restore.sh
@@ -26,7 +26,7 @@ if [ ! -f $1/config.php ]; then
 fi
 
 echo "Restoring backup from $1"
-service php8.0-fpm stop
+service php8.1-fpm stop
 
 # remove the current ownCloud/Nextcloud installation
 rm -rf /usr/local/lib/owncloud/
@@ -45,5 +45,5 @@ chown www-data:www-data $STORAGE_ROOT/owncloud/config.php
 
 sudo -u www-data php$PHP_VER /usr/local/lib/owncloud/occ maintenance:mode --off
 
-service php8.0-fpm start
+service php8.1-fpm start
 echo "Done"


### PR DESCRIPTION
In addition to upgrading php to 8.1, this includes a nextcloud upgrade using docker that I had mentioned in https://github.com/mail-in-a-box/mailinabox/pull/2309#issuecomment-1752888284.

1. for jammy systems upgrading from miab <= v64, it removes php8.0 and the ondrej/php PPA and re-installs the system php8.1

2. it adds a docker-based Nextcloud migration that does not rely on the installed php to succeed, allowing backups of older systems to be migrated

As part of the nextcloud migration, I removed the manual download and installation of contacts and calendar.

Installing nextcloud contacts and calendar via the tgz is doing nothing currently.

The downloads are extracted into the nextcloud apps folder as "contacts-5.3.0" and "calendar-4.4.2" then are expected to work as-is. However, they're not usable to Nextcloud. If you do a "occ app:enable contacts-5.3.0" an exception is thrown about a missing composer vendor folder.

The command "occ app:enable contacts" at the bottom of setup/nextcloud.sh actually downloads and installs contacts from the nextcloud app store.

If you run "occ app:list" on a fresh install you'll see calendar 4.5.2 and contacts 5.4.2 installed and not the versions specified by the install script - they show up as disabled by app:list.

With this PR, Nextcloud 20 and higher can be upgraded to the current version 25 (I tested using a v57 duplicity backup). Older versions of Nextcloud could be added to the script as well so they could get upgraded, too. Just need to dig up the hashes.

I understand Docker may be off the table, and using ondrej/php may work just as well, I don't know. But it's an option.
