### PR TITLE
Upgrade roundcube to 1.6.5

### DIFF
--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -36,8 +36,8 @@ apt_install \
 #   https://github.com/mstilkerich/rcmcarddav/releases
 # The easiest way to get the package hashes is to run this script and get the hash from
 # the error message.
-VERSION=1.6.4
-HASH=bfc693d6590542d63171e6a3997fc29f0a5f12ca
+VERSION=1.6.5
+HASH=326fcc206cddc00355e98d1e40fd0bcd9baec69f
 PERSISTENT_LOGIN_VERSION=bde7b6840c7d91de627ea14e81cf4133cbb3c07a # version 5.3
 HTML5_NOTIFIER_VERSION=68d9ca194212e15b3c7225eb6085dbcf02fd13d7 # version 0.6.4+
 CARDDAV_VERSION=4.4.3


### PR DESCRIPTION
Yet another [security update](https://roundcube.net/news/2023/11/05/security-updates-1.6.5-and-1.5.6) from roundcube.