### PR TITLE
More robust reading of sshd configuration

### DIFF
--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -9,7 +9,7 @@ import ipaddress
 import rtyaml
 import dns.resolver
 
-from utils import shell, load_env_vars_from_file, safe_domain_name, sort_domains
+from utils import shell, load_env_vars_from_file, safe_domain_name, sort_domains, get_ssh_port
 from ssl_certificates import get_ssl_certificates, check_certificate
 
 # From https://stackoverflow.com/questions/3026957/how-to-validate-a-domain-name-using-regex-php/16491074#16491074
@@ -454,16 +454,10 @@ def build_sshfp_records():
 	# if SSH has been configured to listen on a nonstandard port, we must
 	# specify that port to sshkeyscan.
 
-	port = 22
-	with open('/etc/ssh/sshd_config', 'r') as f:
-		for line in f:
-			s = line.rstrip().split()
-			if len(s) == 2 and s[0] == 'Port':
-				try:
-					port = int(s[1])
-				except ValueError:
-					pass
-				break
+	port = get_ssh_port()
+	# If nothing returned, assume default
+	if not port:
+		port = 22
 
 	keys = shell("check_output", ["ssh-keyscan", "-4", "-t", "rsa,dsa,ecdsa,ed25519", "-p", str(port), "localhost"])
 	keys = sorted(keys.split("\n"))

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -449,9 +449,10 @@ def build_sshfp_records():
 	# specify that port to sshkeyscan.
 
 	port = get_ssh_port()
-	# If nothing returned, assume default
+
+	# If nothing returned, SSH is probably not installed.
 	if not port:
-		port = 22
+		return
 
 	keys = shell("check_output", ["ssh-keyscan", "-4", "-t", "rsa,dsa,ecdsa,ed25519", "-p", str(port), "localhost"])
 	keys = sorted(keys.split("\n"))

--- a/management/utils.py
+++ b/management/utils.py
@@ -178,6 +178,30 @@ def wait_for_service(port, public, env, timeout):
 				return False
 		time.sleep(min(timeout/4, 1))
 
+def get_ssh_port():
+        return int(get_ssh_config_value("port"))
+
+def get_ssh_config_value(parameter_name):
+        # Returns ssh port
+        try:
+                output = shell('check_output', ['sshd', '-T'])
+        except FileNotFoundError:
+                # sshd is not installed. That's ok.
+                return None
+        except subprocess.CalledProcessError:
+                # error while calling shell command
+                return None
+
+        returnNext = False
+        for e in output.split():
+                if returnNext:
+                        return e
+                if e == parameter_name:
+                        returnNext = True
+
+        # Did not find port!
+        return None
+
 if __name__ == "__main__":
 	from web_update import get_web_domains
 	env = load_environment()

--- a/management/utils.py
+++ b/management/utils.py
@@ -181,7 +181,7 @@ def wait_for_service(port, public, env, timeout):
 
 def get_ssh_port():
 	port_value = get_ssh_config_value("port")
-	
+
 	if port_value:
 		return int(port_value)
 
@@ -198,12 +198,11 @@ def get_ssh_config_value(parameter_name):
 		# error while calling shell command
 		return None
 
-	returnNext = False
-	for e in output.split():
-		if returnNext:
-			return e
-		if e == parameter_name:
-			returnNext = True
+	for line in output.split("\n"):
+		if " " not in line: continue # there's a blank line at the end
+		key, values = line.split(" ", 1)
+		if key == parameter_name:
+			return values # space-delimited if there are multiple values
 
 	# Did not find the parameter!
 	return None

--- a/management/utils.py
+++ b/management/utils.py
@@ -180,28 +180,33 @@ def wait_for_service(port, public, env, timeout):
 		time.sleep(min(timeout/4, 1))
 
 def get_ssh_port():
-        return int(get_ssh_config_value("port"))
+	port_value = get_ssh_config_value("port")
+	
+	if port_value:
+		return int(port_value)
+
+	return None
 
 def get_ssh_config_value(parameter_name):
-        # Returns ssh port
-        try:
-                output = shell('check_output', ['sshd', '-T'])
-        except FileNotFoundError:
-                # sshd is not installed. That's ok.
-                return None
-        except subprocess.CalledProcessError:
-                # error while calling shell command
-                return None
+	# Returns ssh configuration value for the provided parameter
+	try:
+		output = shell('check_output', ['sshd', '-T'])
+	except FileNotFoundError:
+		# sshd is not installed. That's ok.
+		return None
+	except subprocess.CalledProcessError:
+		# error while calling shell command
+		return None
 
-        returnNext = False
-        for e in output.split():
-                if returnNext:
-                        return e
-                if e == parameter_name:
-                        returnNext = True
+	returnNext = False
+	for e in output.split():
+		if returnNext:
+			return e
+		if e == parameter_name:
+			returnNext = True
 
-        # Did not find port!
-        return None
+	# Did not find the parameter!
+	return None
 
 if __name__ == "__main__":
 	from web_update import get_web_domains


### PR DESCRIPTION
This pull request uses the command `sshd -T` to obtain the sshd configuration instead of directly reading the configuration files. This has the advantage of:
- Taking into account actually running configuration
- Taking into account configurations using `/etc/ssh/sshd_config.d/` as a configuration directory


I think I got all places where sshd configuration is used, e.g. for port number and for checking passwordauthentication.