### PR TITLE
Fixed broken relative path

### DIFF
--- a/tools/mail.py
+++ b/tools/mail.py
@@ -1,3 +1,3 @@
 #!/bin/bash
 # This script has moved.
-management/cli.py "$@"
+../management/cli.py "$@"


### PR DESCRIPTION
Relative path redirecting to cli.py was not working when executed from the tools directory.  Updated path with '..' to fixed broken reference.