### PR TITLE
setup/preflight.sh: fix some minor shellcheck complaints

### DIFF
--- a/setup/preflight.sh
+++ b/setup/preflight.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Are we running as root?
 if [[ $EUID -ne 0 ]]; then
 	echo "This script must be run as root. Please re-run like this:"
@@ -26,16 +27,16 @@ fi
 #
 # Skip the check if we appear to be running inside of Vagrant, because that's really just for testing.
 TOTAL_PHYSICAL_MEM=$(head -n 1 /proc/meminfo | awk '{print $2}')
-if [ $TOTAL_PHYSICAL_MEM -lt 490000 ]; then
+if [ "$TOTAL_PHYSICAL_MEM" -lt 490000 ]; then
 if [ ! -d /vagrant ]; then
-	TOTAL_PHYSICAL_MEM=$(expr \( \( $TOTAL_PHYSICAL_MEM \* 1024 \) / 1000 \) / 1000)
+	TOTAL_PHYSICAL_MEM=$(( TOTAL_PHYSICAL_MEM * 1024 / 1000 / 1000 ))
 	echo "Your Mail-in-a-Box needs more memory (RAM) to function properly."
 	echo "Please provision a machine with at least 512 MB, 1 GB recommended."
 	echo "This machine has $TOTAL_PHYSICAL_MEM MB memory."
 	exit
 fi
 fi
-if [ $TOTAL_PHYSICAL_MEM -lt 750000 ]; then
+if [ "$TOTAL_PHYSICAL_MEM" -lt 750000 ]; then
 	echo "WARNING: Your Mail-in-a-Box has less than 768 MB of memory."
 	echo "         It might run unreliably when under heavy load."
 fi


### PR DESCRIPTION
This file passes shellcheck now without errors.
This paritally fixes #1457 - the former errors where:

$ shellcheck setup/preflight.sh

In setup/preflight.sh line 1:
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.

In setup/preflight.sh line 29:
if [ $TOTAL_PHYSICAL_MEM -lt 490000 ]; then
     ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if [ "$TOTAL_PHYSICAL_MEM" -lt 490000 ]; then

In setup/preflight.sh line 31:
	TOTAL_PHYSICAL_MEM=$(expr \( \( $TOTAL_PHYSICAL_MEM \* 1024 \) / 1000 \) / 1000)
                             ^--^ SC2003 (style): expr is antiquated. Consider rewriting this using $((..)), ${} or [[ ]].
                                        ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
	TOTAL_PHYSICAL_MEM=$(expr \( \( "$TOTAL_PHYSICAL_MEM" \* 1024 \) / 1000 \) / 1000)

In setup/preflight.sh line 38:
if [ $TOTAL_PHYSICAL_MEM -lt 750000 ]; then
     ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if [ "$TOTAL_PHYSICAL_MEM" -lt 750000 ]; then

For more information:
  https://www.shellcheck.net/wiki/SC2148 -- Tips depend on target shell and y...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2003 -- expr is antiquated. Consider rewr...