### PR TITLE
[security] SMTP smuggling: update short term fix

### DIFF
--- a/setup/mail-postfix.sh
+++ b/setup/mail-postfix.sh
@@ -73,7 +73,7 @@ tools/editconf.py /etc/postfix/main.cf \
 # This short-term workaround is recommended at https://www.postfix.org/smtp-smuggling.html
 tools/editconf.py /etc/postfix/main.cf \
 	smtpd_data_restrictions=reject_unauth_pipelining \
-	smtpd_discard_ehlo_keywords=chunking
+	smtpd_discard_ehlo_keywords="chunking, silent-discard"
 
 # ### Outgoing Mail
 

--- a/setup/mail-postfix.sh
+++ b/setup/mail-postfix.sh
@@ -72,7 +72,8 @@ tools/editconf.py /etc/postfix/main.cf \
 # Guard against SMTP smuggling
 # This short-term workaround is recommended at https://www.postfix.org/smtp-smuggling.html
 tools/editconf.py /etc/postfix/main.cf \
-	smtpd_data_restrictions=reject_unauth_pipelining
+	smtpd_data_restrictions=reject_unauth_pipelining \
+	smtpd_discard_ehlo_keywords=chunking
 
 # ### Outgoing Mail
 


### PR DESCRIPTION
The [postfix page](https://www.postfix.org/smtp-smuggling.html) on SMTP smuggling has an update to the short term workaround. A second configuration line is to be added:

[smtpd_discard_ehlo_keywords](https://www.postfix.org/postconf.5.html#smtpd_discard_ehlo_keywords) = chunking, silent-discard

[update 2023-12-30]: added silent-discard