### PR TITLE
Make reading of previous status check result more robust

### DIFF
--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -965,7 +965,11 @@ def run_and_output_changes(env, pool):
 	cache_fn = "/var/cache/mailinabox/status_checks.json"
 	if os.path.exists(cache_fn):
 		with open(cache_fn, 'r') as f:
-			prev = json.load(f)
+			try:
+				prev = json.load(f)
+			except json.JSONDecodeError:
+				logging.debug('Could not decode previous status checks JSON file')
+				prev = []
 
 		# Group the serial output into categories by the headings.
 		def group_by_heading(lines):

--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -968,7 +968,6 @@ def run_and_output_changes(env, pool):
 			try:
 				prev = json.load(f)
 			except json.JSONDecodeError:
-				logging.debug('Could not decode previous status checks JSON file')
 				prev = []
 
 		# Group the serial output into categories by the headings.


### PR DESCRIPTION
Apparently it sometimes happens that the json file that stores the previous status check result gets corrupted (see e.g. [here](https://discourse.mailinabox.email/t/status-checks-change-notice-error/10797/8))
This pull request simply ignores any errors happening during reading of the json file. Although the previous result is now empty, thus no differences between the current and previous status check can be generated, it is better then the alternative.
Because of the empty prev variable, a new json file will be generated, so next time it is read, everything should be a-ok.