### PR TITLE
Update Roundcube to 1.6.6

### DIFF
--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -36,8 +36,8 @@ apt_install \
 #   https://github.com/mstilkerich/rcmcarddav/releases
 # The easiest way to get the package hashes is to run this script and get the hash from
 # the error message.
-VERSION=1.6.5
-HASH=326fcc206cddc00355e98d1e40fd0bcd9baec69f
+VERSION=1.6.6
+HASH=7705d2736890c49e7ae3ac75e3ae00ba56187056
 PERSISTENT_LOGIN_VERSION=bde7b6840c7d91de627ea14e81cf4133cbb3c07a # version 5.3
 HTML5_NOTIFIER_VERSION=68d9ca194212e15b3c7225eb6085dbcf02fd13d7 # version 0.6.4+
 CARDDAV_VERSION=4.4.3


### PR DESCRIPTION
Update roundcube to version 1.6.6. See https://roundcube.net/news/2024/01/20/update-1.6.6-released for more information.