### PR TITLE
Silence "wal" output on setup using hide_output

### DIFF
--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -217,7 +217,7 @@ sed -i.miabold 's/^[^#]\+.\+PRAGMA journal_mode = WAL.\+$/#&/' \
 # Because Roundcube wants to set the PRAGMA we just deleted from the source, we apply it here
 # to the roundcube database (see https://github.com/roundcube/roundcubemail/issues/8035)
 # Database should exist, created by migration script
-sqlite3 $STORAGE_ROOT/mail/roundcube/roundcube.sqlite 'PRAGMA journal_mode=WAL;' | 2>&1
+hide_output sqlite3 $STORAGE_ROOT/mail/roundcube/roundcube.sqlite 'PRAGMA journal_mode=WAL;'
 
 # Enable PHP modules.
 phpenmod -v $PHP_VER imap


### PR DESCRIPTION
On a new install, I've experienced the setup exiting after running `sqlite3 $STORAGE_ROOT/mail/roundcube/roundcube.sqlite 'PRAGMA journal_mode=WAL;' | 2>&1` changed on #2356.  The sqlite3 command seems to have an exit code of 0, but something with the combination of `| 2>&1` `set -eou pipefail` doesn't like?

I've not seen the usage of `| 2>&1` to silence output before, usually using `>/dev/null 2>&1` Removing it allowed setup to continue.

You can duplicate the issue with a fresh install
Or on an existing install with:
```
cd mailinabox
source /etc/mailinabox.conf
mv $STORAGE_ROOT/mail/roundcube/roundcube.sqlite{,.backup}
bash -x setup/webmail.sh
# notice it exit after the sqlite3 command
# move your old roundcube.sqlite file back
mv $STORAGE_ROOT/mail/roundcube/roundcube.sqlite{.backup,}
```