### PR TITLE
Fix chown during Nexcloud upgrades

### DIFF
--- a/setup/nextcloud.sh
+++ b/setup/nextcloud.sh
@@ -131,7 +131,7 @@ InstallNextcloud() {
 	# Make sure permissions are correct or the upgrade step won't run.
 	# $STORAGE_ROOT/owncloud may not yet exist, so use -f to suppress
 	# that error.
-	chown -f -R www-data:www-data "$STORAGE_ROOT/owncloud /usr/local/lib/owncloud" || /bin/true
+	chown -f -R www-data:www-data "$STORAGE_ROOT/owncloud" /usr/local/lib/owncloud || /bin/true
 
 	# If this isn't a new installation, immediately run the upgrade script.
 	# Then check for success (0=ok and 3=no upgrade needed, both are success).


### PR DESCRIPTION
Fixes chown during Nextcloud upgrades

Fixes:
```
...
Upgrading to Nextcloud version 26.0.12

Cannot write into "config" directory!
This can usually be fixed by giving the web server write access to the config directory.

But, if you prefer to keep config.php file read only, set the option "config_is_read_only" to true in it.
See https://docs.nextcloud.com/server/26/go.php?to=admin-config
Cannot write into "config" directory!
This can usually be fixed by giving the web server write access to the config directory.

But, if you prefer to keep config.php file read only, set the option "config_is_read_only" to true in it.
See https://docs.nextcloud.com/server/26/go.php?to=admin-config
Cannot write into "config" directory!
This can usually be fixed by giving the web server write access to the config directory.

But, if you prefer to keep config.php file read only, set the option "config_is_read_only" to true in it.
See https://docs.nextcloud.com/server/26/go.php?to=admin-config
Cannot write into "config" directory!
This can usually be fixed by giving the web server write access to the config directory.

But, if you prefer to keep config.php file read only, set the option "config_is_read_only" to true in it.
See https://docs.nextcloud.com/server/26/go.php?to=admin-config
Cannot write into "config" directory!
This can usually be fixed by giving the web server write access to the config directory.

But, if you prefer to keep config.php file read only, set the option "config_is_read_only" to true in it.
See https://docs.nextcloud.com/server/26/go.php?to=admin-config
Cannot write into "config" directory!
This can usually be fixed by giving the web server write access to the config directory.

But, if you prefer to keep config.php file read only, set the option "config_is_read_only" to true in it.
See https://docs.nextcloud.com/server/26/go.php?to=admin-config\
...
```