### PR TITLE
Allow for `Union[None, List[datetime.datetime]]` values when printing user table in weekly mail logs

### DIFF
--- a/management/mail_log.py
+++ b/management/mail_log.py
@@ -679,7 +679,7 @@ def print_user_table(users, data=None, sub_data=None, activity=None, latest=None
                 data_accum[col] += d[row]
 
         try:
-            if None not in {latest, earliest}:
+            if None not in [latest, earliest]:
                 vert_pos = len(line)
                 e = earliest[row]
                 l = latest[row]
@@ -732,7 +732,7 @@ def print_user_table(users, data=None, sub_data=None, activity=None, latest=None
         else:
             header += l.rjust(max(5, len(l) + 1, col_widths[col]))
 
-    if None not in {latest, earliest}:
+    if None not in [latest, earliest]:
         header += " │ timespan   "
 
     lines.insert(0, header.rstrip())
@@ -757,7 +757,7 @@ def print_user_table(users, data=None, sub_data=None, activity=None, latest=None
         footer += temp.format(data_accum[row])
 
     try:
-        if None not in {latest, earliest}:
+        if None not in [latest, earliest]:
             max_l = max(latest)
             min_e = min(earliest)
             timespan = relativedelta(max_l, min_e)

--- a/management/mail_log.py
+++ b/management/mail_log.py
@@ -679,7 +679,7 @@ def print_user_table(users, data=None, sub_data=None, activity=None, latest=None
                 data_accum[col] += d[row]
 
         try:
-            if None not in [latest, earliest]:
+            if None not in [latest, earliest]: # noqa PLR6201
                 vert_pos = len(line)
                 e = earliest[row]
                 l = latest[row]
@@ -732,7 +732,7 @@ def print_user_table(users, data=None, sub_data=None, activity=None, latest=None
         else:
             header += l.rjust(max(5, len(l) + 1, col_widths[col]))
 
-    if None not in [latest, earliest]:
+    if None not in [latest, earliest]: # noqa PLR6201
         header += " │ timespan   "
 
     lines.insert(0, header.rstrip())
@@ -757,7 +757,7 @@ def print_user_table(users, data=None, sub_data=None, activity=None, latest=None
         footer += temp.format(data_accum[row])
 
     try:
-        if None not in [latest, earliest]:
+        if None not in [latest, earliest]: # noqa PLR6201
             max_l = max(latest)
             min_e = min(earliest)
             timespan = relativedelta(max_l, min_e)


### PR DESCRIPTION
# Effect

I received the following in my weekly mail log email (**Cron <root@mail> (cd /root/mailinabox && management/daily_tasks.sh)**):

```
Traceback (most recent call last):
  File "/root/mailinabox/management/mail_log.py", line 869, in <module>
    scan_mail_log(env_vars)
  File "/root/mailinabox/management/mail_log.py", line 146, in scan_mail_log
    print_user_table(
  File "/root/mailinabox/management/mail_log.py", line 682, in print_user_table
    if None not in {latest, earliest}:
TypeError: unhashable type: 'list'

```

# Cause

[This](https://github.com/mail-in-a-box/mailinabox/pull/2343/commits/49124cc9caee228cf5595381203b667e82c8750f) was overzealous in that it didn't accommodate for the fact that `earliest` and `latest` have the type `Union[None, List[datetime.dateime]]`.

I think this PR supersedes mail-in-a-box/mailinabox#2376.