### PR TITLE
Limit readline()

### DIFF
--- a/management/backup.py
+++ b/management/backup.py
@@ -186,7 +186,7 @@ def get_passphrase(env):
 	# length of 32 bytes.
 	backup_root = os.path.join(env["STORAGE_ROOT"], 'backup')
 	with open(os.path.join(backup_root, 'secret_key.txt'), encoding="utf-8") as f:
-		passphrase = f.readline().strip()
+		passphrase = f.readline(5_000_000).strip()
 	if len(passphrase) < 43: raise Exception("secret_key.txt's first line is too short!")
 
 	return passphrase

--- a/management/mail_log.py
+++ b/management/mail_log.py
@@ -587,7 +587,7 @@ def readline(filename):
     """
     with open(filename, errors='replace', encoding='utf-8') as file:
         while True:
-          line = file.readline()
+          line = file.readline(5_000_000)
           if not line:
               break
           yield line


### PR DESCRIPTION
This codemod hardens all [`readline()`](https://docs.python.org/3/library/io.html#io.IOBase.readline) calls from file objects returned from an `open()` call, `StringIO` and `BytesIO` against denial of service attacks. A stream influenced by an attacker could keep providing bytes until the system runs out of memory, causing a crash.

Fixing it is straightforward by providing adding a size argument to any `readline()` calls.
The changes from this codemod look like this:

```diff
  file = open('some_file.txt')
- file.readline()
+ file.readline(5_000_000)
```

<details>
  <summary>More reading</summary>

  * [https://cwe.mitre.org/data/definitions/400.html](https://cwe.mitre.org/data/definitions/400.html)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/limit-readline](https://docs.pixee.ai/codemods/python/pixee_python_limit-readline)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2Fmailinabox%7C79073bad9270b44e140d7346726be63215661d34)

<!--{"type":"DRIP","codemod":"pixee:python/limit-readline"}-->