### PR TITLE
Ignoring duplicity informational messages for some backends (e.g. rsync)

### DIFF
--- a/management/daily_tasks.sh
+++ b/management/daily_tasks.sh
@@ -15,8 +15,9 @@ if [ "$(date "+%u")" -eq 1 ]; then
     management/mail_log.py -t week | management/email_administrator.py "Mail-in-a-Box Usage Report"
 fi
 
-# Take a backup.
-management/backup.py 2>&1 | management/email_administrator.py "Backup Status"
+# Take a backup (ignoring informational output from duplicity for some backends).
+export DUPLICITY_VALIDATION_INFO="File size can't be validated, because of missing capabilities of the backend. Please verify the backup separately."
+management/backup.py 2>&1 | sed 's/'"$DUPLICITY_VALIDATION_INFO"'//g' | management/email_administrator.py "Backup Status"
 
 # Provision any new certificates for new domains or domains with expiring certificates.
 management/ssl_certificates.py -q  2>&1 | management/email_administrator.py "TLS Certificate Provisioning Result"


### PR DESCRIPTION
Fix for #2371