### PR TITLE
add php8.0-intl package to Z-Push setup

### DIFF
--- a/setup/zpush.sh
+++ b/setup/zpush.sh
@@ -17,7 +17,7 @@ source /etc/mailinabox.conf # load global vars
 
 echo "Installing Z-Push (Exchange/ActiveSync server)..."
 apt_install \
-       php"${PHP_VER}"-soap php"${PHP_VER}"-imap libawl-php php"$PHP_VER"-xml
+       php"${PHP_VER}"-soap php"${PHP_VER}"-imap libawl-php php"$PHP_VER"-xml php"${PHP_VER}"-intl
 
 phpenmod -v "$PHP_VER" imap
 


### PR DESCRIPTION
php8.0-intl already installed with webmail and nextcloud. Including it in Z-Push as it is a requirement for 2.7.1