### PR TITLE
Increase management daemon proxy timeout

### DIFF
--- a/conf/nginx-primaryonly.conf
+++ b/conf/nginx-primaryonly.conf
@@ -8,6 +8,7 @@
 	rewrite ^/admin/munin$ /admin/munin/ redirect;
 	location /admin/ {
 		proxy_pass http://127.0.0.1:10222/;
+		proxy_read_timeout 600s;
 		proxy_set_header X-Forwarded-For $remote_addr;
 		add_header X-Frame-Options "DENY";
 		add_header X-Content-Type-Options nosniff;


### PR DESCRIPTION
This change increases the timeout for the nginx proxy that provides access to the Mailinabox management daemon. This helps people who get a time-out on e.g. the status check page for large deployments (many domains).
I chose the value 600 based on the [gunicorn timeout](https://github.com/mail-in-a-box/mailinabox/blob/1b3e5e818c2272fb3b71afa6087ea3d4601125b0/setup/management.sh#L104)