### PR TITLE
Fixed the password prompt during interactive setup

### DIFF
--- a/setup/firstuser.sh
+++ b/setup/firstuser.sh
@@ -48,7 +48,7 @@ if [ -z "$(management/cli.py user)" ]; then
 	fi
 
 	# Create the user's mail account. This will ask for a password if none was given above.
-	management/cli.py user add "$EMAIL_ADDR" "${EMAIL_PW:-}"
+	management/cli.py user add "$EMAIL_ADDR" ${EMAIL_PW:+"$EMAIL_PW"}
 
 	# Make it an admin.
 	hide_output management/cli.py user make-admin "$EMAIL_ADDR"


### PR DESCRIPTION
* Fixed the password prompt during interactive setup, which was broken in 30c4681e802f32c4d0f95c22895abb329ba9d85e. Fixes #2408 

An alternative solution would be to update the `management/cli.py` script to still prompt for a password when the provided one is empty.