### PR TITLE
Allow DSA end EllipticCurve private keys to be used additionally to RSA for HTTPS certificates

### DIFF
--- a/management/ssl_certificates.py
+++ b/management/ssl_certificates.py
@@ -14,7 +14,7 @@ def get_ssl_certificates(env):
 	# that the certificates are good for to the best certificate for
 	# the domain.
 
-	from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+	from cryptography.hazmat.primitives.asymmetric import dsa, rsa, ec
 	from cryptography.x509 import Certificate
 
 	# The certificates are all stored here:
@@ -59,13 +59,15 @@ def get_ssl_certificates(env):
 			# Not a valid PEM format for a PEM type we care about.
 			continue
 
-		# Is it a private key?
-		if isinstance(pem, RSAPrivateKey):
-			private_keys[pem.public_key().public_numbers()] = { "filename": fn, "key": pem }
-
 		# Is it a certificate?
 		if isinstance(pem, Certificate):
 			certificates.append({ "filename": fn, "cert": pem })
+		# It is a private key
+		elif (isinstance(pem, rsa.RSAPrivateKey)
+			or isinstance(pem, dsa.DSAPrivateKey)
+			or isinstance(pem, ec.EllipticCurvePrivateKey)):
+			private_keys[pem.public_key().public_numbers()] = { "filename": fn, "key": pem }
+
 
 	# Process the certificates.
 	domains = { }
@@ -505,7 +507,7 @@ def check_certificate(domain, ssl_certificate, ssl_private_key, warn_if_expiring
 	# Check that the ssl_certificate & ssl_private_key files are good
 	# for the provided domain.
 
-	from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+	from cryptography.hazmat.primitives.asymmetric import rsa, dsa, ec
 	from cryptography.x509 import Certificate
 
 	# The ssl_certificate file may contain a chain of certificates. We'll
@@ -539,7 +541,9 @@ def check_certificate(domain, ssl_certificate, ssl_private_key, warn_if_expiring
 		except ValueError as e:
 			return (f"The private key file {ssl_private_key} is not a private key file: {e!s}", None)
 
-		if not isinstance(priv_key, RSAPrivateKey):
+		if (not isinstance(priv_key, rsa.RSAPrivateKey)
+			and not isinstance(priv_key, dsa.DSAPrivateKey)
+			and not isinstance(priv_key, ec.EllipticCurvePrivateKey)):
 			return ("The private key file %s is not a private key file." % ssl_private_key, None)
 
 		if priv_key.public_key().public_numbers() != cert.public_key().public_numbers():
@@ -639,7 +643,7 @@ def load_pem(pem):
 		msg = "File is not a valid PEM-formatted file."
 		raise ValueError(msg)
 	pem_type = pem_type.group(1)
-	if pem_type in {b"RSA PRIVATE KEY", b"PRIVATE KEY"}:
+	if pem_type.endswith(b"PRIVATE KEY"):
 		return serialization.load_pem_private_key(pem, password=None, backend=default_backend())
 	if pem_type == b"CERTIFICATE":
 		return load_pem_x509_certificate(pem, default_backend())


### PR DESCRIPTION
The purpose of the changes is to allow EC and DSA based private key (and in turn SSL certificates) to be used additionally to RSA private keys. In order to achieve this checking the types of loaded PEM files has been extended. Checking of the first line of the PEM files on the other side has been reduced to the ending, so that something like "EC PRIVATE KEY" gets accepted as well as "RSA PRIVATE KEY" or just "PRIVATE KEY".