### PR TITLE
Another php8.1 upgrade

### DIFF
--- a/conf/nginx-top.conf
+++ b/conf/nginx-top.conf
@@ -7,6 +7,6 @@
 ##       your own --- please do not ask for help from us.
 
 upstream php-fpm {
-	server unix:/var/run/php/php8.0-fpm.sock;
+	server unix:/var/run/php/php8.1-fpm.sock;
 }
 

--- a/management/backup.py
+++ b/management/backup.py
@@ -296,7 +296,7 @@ def perform_backup(full_backup):
 			if quit:
 				sys.exit(code)
 
-	service_command("php8.0-fpm", "stop", quit=True)
+	service_command("php8.1-fpm", "stop", quit=True)
 	service_command("postfix", "stop", quit=True)
 	service_command("dovecot", "stop", quit=True)
 	service_command("postgrey", "stop", quit=True)
@@ -333,7 +333,7 @@ def perform_backup(full_backup):
 		service_command("postgrey", "start", quit=False)
 		service_command("dovecot", "start", quit=False)
 		service_command("postfix", "start", quit=False)
-		service_command("php8.0-fpm", "start", quit=False)
+		service_command("php8.1-fpm", "start", quit=False)
 
 	# Remove old backups. This deletes all backup data no longer needed
 	# from more than 3 days ago.

--- a/setup/functions.sh
+++ b/setup/functions.sh
@@ -5,7 +5,7 @@
 # -o pipefail: don't ignore errors in the non-last command in a pipeline
 set -euo pipefail
 
-PHP_VER=8.0
+PHP_VER=8.1
 
 function hide_output {
 	# This function hides the output of a command unless the command fails

--- a/tools/owncloud-restore.sh
+++ b/tools/owncloud-restore.sh
@@ -26,7 +26,7 @@ if [ ! -f "$1/config.php" ]; then
 fi
 
 echo "Restoring backup from $1"
-service php8.0-fpm stop
+service php8.1-fpm stop
 
 # remove the current ownCloud/Nextcloud installation
 rm -rf /usr/local/lib/owncloud/
@@ -45,5 +45,5 @@ chown www-data:www-data "$STORAGE_ROOT/owncloud/config.php"
 
 sudo -u www-data "php$PHP_VER" /usr/local/lib/owncloud/occ maintenance:mode --off
 
-service php8.0-fpm start
+service php8.1-fpm start
 echo "Done"


### PR DESCRIPTION
This is my take on upgrading to PHP 8.1 with the feedback from @kiekerjan's PR #2309.

Would probably like to move the PHP Version from the if on line 94 in nextcloud.sh and make it an additional mandatory argument for the InstallNextcloud() function. But to keep this PR simple initially I have foregone that.

* this has explicit PHP version as requested in https://github.com/mail-in-a-box/mailinabox/pull/2309#issuecomment-1745650977 and https://github.com/mail-in-a-box/mailinabox/pull/2309#issuecomment-1769586360
* have not made use of docker #2319 
* not modifying the nextcloud package https://github.com/mail-in-a-box/mailinabox/pull/2309#issuecomment-1782382428

I have tested this with upgrading from a v57a backup (nextcloud 20.0.14) successfully.