### PR TITLE
Change hour of daily tasks to run at 1am and only run full backups on weekends

### DIFF
--- a/management/backup.py
+++ b/management/backup.py
@@ -9,6 +9,7 @@
 
 import os, os.path, re, datetime, sys
 import dateutil.parser, dateutil.relativedelta, dateutil.tz
+from datetime import date
 import rtyaml
 from exclusiveprocess import Lock
 
@@ -157,6 +158,8 @@ def should_force_full(config, env):
 	# since the last full backup is greater than half the size
 	# of that full backup.
 	inc_size = 0
+	# Check if day of week is a weekend day
+	weekend = date.today().weekday()>=5
 	for bak in backup_status(env)["backups"]:
 		if not bak["full"]:
 			# Scan through the incremental backups cumulating
@@ -165,12 +168,14 @@ def should_force_full(config, env):
 		else:
 			# ...until we reach the most recent full backup.
 			# Return if we should to a full backup, which is based
-			# on the size of the increments relative to the full
-			# backup, as well as the age of the full backup.
-			if inc_size > .5*bak["size"]:
-				return True
-			if dateutil.parser.parse(bak["date"]) + datetime.timedelta(days=config["min_age_in_days"]*10+1) < datetime.datetime.now(dateutil.tz.tzlocal()):
-				return True
+			# on whether it is a weekend day, the size of the
+			# increments relative to the full backup, as well as
+			# the age of the full backup.
+			if weekend:
+				if inc_size > .5*bak["size"]:
+					return True
+				if dateutil.parser.parse(bak["date"]) + datetime.timedelta(days=config["min_age_in_days"]*10+1) < datetime.datetime.now(dateutil.tz.tzlocal()):
+					return True
 			return False
 	else:
 		# If we got here there are no (full) backups, so make one.

--- a/management/backup.py
+++ b/management/backup.py
@@ -9,7 +9,6 @@
 
 import os, os.path, re, datetime, sys
 import dateutil.parser, dateutil.relativedelta, dateutil.tz
-from datetime import date
 import rtyaml
 from exclusiveprocess import Lock
 
@@ -263,9 +262,6 @@ def get_target_type(config):
 def perform_backup(full_backup):
 	env = load_environment()
 
-	# Check if day of week is a weekend day
-	weekend = date.today().weekday()>=5
-
 	# Create an global exclusive lock so that the backup script
 	# cannot be run more than one.
 	Lock(die=True).forever()
@@ -280,11 +276,11 @@ def perform_backup(full_backup):
 		return
 
 	# On the first run, always do a full backup. Incremental
-	# will fail. Otherwise do a full backup on weekends when
-	# the size of the increments since the most recent full
-	# backup are large.
+	# will fail. Otherwise do a full backup when the size of
+	# the increments since the most recent full backup are
+	# large.
 	try:
-		full_backup = (full_backup and weekend) or should_force_full(config, env)
+		full_backup = full_backup or should_force_full(config, env)
 	except Exception as e:
 		# This was the first call to duplicity, and there might
 		# be an error already.

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -116,7 +116,7 @@ minute=$((RANDOM % 60))  # avoid overloading mailinabox.email
 cat > /etc/cron.d/mailinabox-nightly << EOF;
 # Mail-in-a-Box --- Do not edit / will be overwritten on update.
 # Run nightly tasks: backup, status checks.
-$minute 3 * * *	root	(cd $PWD && management/daily_tasks.sh)
+$minute 1 * * *	root	(cd $PWD && management/daily_tasks.sh)
 EOF
 
 # Start the management server.


### PR DESCRIPTION
With large amounts of email, full backups can take a lot of time.  This PR addresses the first option suggested from https://discourse.mailinabox.email/t/full-backups-taking-a-long-time/12242.