### PR TITLE
Z-Push admin and top update with PHP_VER change

### DIFF
--- a/setup/zpush.sh
+++ b/setup/zpush.sh
@@ -41,17 +41,17 @@ if [ $needs_update == 1 ]; then
 	mv /tmp/z-push/*/src /usr/local/lib/z-push
 	rm -rf /tmp/z-push.zip /tmp/z-push
 
-	# Create admin and top scripts with PHP_VER  
-	rm -f /usr/sbin/z-push-{admin,top}
-    echo '#!/bin/bash' > /usr/sbin/z-push-admin
-    echo php"$PHP_VER" /usr/local/lib/z-push/z-push-admin.php '"$@"' >> /usr/sbin/z-push-admin
-    chmod 755 /usr/sbin/z-push-admin
-    echo '#!/bin/bash' > /usr/sbin/z-push-top
-    echo php"$PHP_VER" /usr/local/lib/z-push/z-push-top.php '"$@"' >> /usr/sbin/z-push-top
-    chmod 755 /usr/sbin/z-push-top
-	
 	echo $VERSION > /usr/local/lib/z-push/version
 fi
+
+# Create admin and top scripts with PHP_VER  
+rm -f /usr/sbin/z-push-{admin,top}
+echo '#!/bin/bash' > /usr/sbin/z-push-admin
+echo php"$PHP_VER" /usr/local/lib/z-push/z-push-admin.php '"$@"' >> /usr/sbin/z-push-admin
+chmod 755 /usr/sbin/z-push-admin
+echo '#!/bin/bash' > /usr/sbin/z-push-top
+echo php"$PHP_VER" /usr/local/lib/z-push/z-push-top.php '"$@"' >> /usr/sbin/z-push-top
+chmod 755 /usr/sbin/z-push-top
 
 # Configure default config.
 sed -i "s^define('TIMEZONE', .*^define('TIMEZONE', '$(cat /etc/timezone)');^" /usr/local/lib/z-push/config.php


### PR DESCRIPTION
Came across this while testing updating to PHP 8.1. 

/usr/sbin/z-push-admin and /usr/sbin/z-push-top scripts aren't updated when changing PHP_VER from 8.0 to 8.1. These only update when a Z-Push version upgrade occurs.