### PR TITLE
Fixstates only after Z-Push upgrade

### DIFF
--- a/setup/zpush.sh
+++ b/setup/zpush.sh
@@ -112,4 +112,6 @@ restart_service php"$PHP_VER"-fpm
 
 # Fix states after upgrade
 
-hide_output php"$PHP_VER" /usr/local/lib/z-push/z-push-admin.php -a fixstates
+if [ $needs_update == 1 ]; then
+	hide_output php"$PHP_VER" /usr/local/lib/z-push/z-push-admin.php -a fixstates
+fi


### PR DESCRIPTION
This is to only run z-push-admin -a fixstates after a Z-Push upgrade. 

I've checked and the configuration in zpush.sh won't affect the state files.

This will alleviate the problem raised on the forums when there is an upgrade without a Z-Push upgrade.
https://discourse.mailinabox.email/t/problems-with-z-push-mail-sync-after-each-upgrade-of-miab/12145