### PR TITLE
Add progress indication to wget

### DIFF
--- a/setup/functions.sh
+++ b/setup/functions.sh
@@ -192,7 +192,7 @@ function wget_verify {
 	DEST=$3
 	CHECKSUM="$HASH  $DEST"
 	rm -f "$DEST"
-	hide_output wget -O "$DEST" "$URL"
+	wget -q --show-progress --progress=dot:giga -O "$DEST" "$URL"
 	if ! echo "$CHECKSUM" | sha1sum --check --strict > /dev/null; then
 		echo "------------------------------------------------------------"
 		echo "Download of $URL did not match expected checksum."


### PR DESCRIPTION
Nextcloud has a history of slow downloads and I encounter this occasionally when upgrading maib. The setup script appears to stall. Perhaps we can add this indication to wget? The giga parameter keeps it from blowing up the output length.

See here #1725  for older ticket where this was originally logged. The ticket starts with complaints that the download server is  just down, which is better because then it immediately fails, but when the download starts going at 10kb/s it can take a long time to finish.

Example output when I tested this parameter combo:

```
ubuntu@box:~$ wget -q --show-progress --progress=dot:giga  -O /tmp/nextcloud.tmp https://download.nextcloud.com/server/releases/nextcloud-26.0.13.zip

     0K ........ ........ ........ ........ 16% 10.1M 15s
 32768K ........ ........ ........ ........ 33% 11.2M 12s
 65536K ........ ........ ........ ........ 50% 9.13M 9s
 98304K ........ ........ ........ ........ 67% 4.36M 8s
131072K ........ ........ ........ ........ 84% 1.95M 6s
163840K ........ ........ ........ ....    100%  923K=65subuntu@box:~$
```