### PR TITLE
nginx: increase proxy_read_timeout for /admin/ from 1 to 5 minutes

### DIFF
--- a/conf/nginx-primaryonly.conf
+++ b/conf/nginx-primaryonly.conf
@@ -9,6 +9,7 @@
 	location /admin/ {
 		proxy_pass http://127.0.0.1:10222/;
 		proxy_set_header X-Forwarded-For $remote_addr;
+		proxy_read_timeout 300s;
 		add_header X-Frame-Options "DENY";
 		add_header X-Content-Type-Options nosniff;
 		add_header Content-Security-Policy "frame-ancestors 'none';";


### PR DESCRIPTION
for large number of domains or slow boxes (or both), the default nginx 60 second read timeout can result in admin panel errors on pages like status or tls certs