### PR TITLE
Handle no existence of expired certificates before trying to move them into ssl.expired subdirectory

### DIFF
--- a/tools/ssl_cleanup
+++ b/tools/ssl_cleanup
@@ -2,8 +2,7 @@
 # Cleanup SSL certificates which expired more than 7 days ago from $STORAGE_ROOT/ssl and move them to $STORAGE_ROOT/ssl.expired
 
 source /etc/mailinabox.conf
-shopt -s extglob
-shopt -s nullglob
+shopt -s extglob nullglob
 
 retain_after="$(date --date="7 days ago" +%Y%m%d)"
 

--- a/tools/ssl_cleanup
+++ b/tools/ssl_cleanup
@@ -4,14 +4,16 @@
 source /etc/mailinabox.conf
 shopt -s extglob
 
-retain_after="$(date --date="7 days ago" +%Y%m%d)"
+if ls "$STORAGE_ROOT/ssl/"*-+([0-9])-+([0-9a-f]).pem &>/dev/null; then
+  retain_after="$(date --date="7 days ago" +%Y%m%d)"
 
-mkdir -p $STORAGE_ROOT/ssl.expired
-for file in $STORAGE_ROOT/ssl/*-+([0-9])-+([0-9a-f]).pem; do
-  pem="$(basename "$file")"
-  not_valid_after="$(cut -d- -f1 <<< "${pem: -21}")"
+  mkdir -p $STORAGE_ROOT/ssl.expired
+  for file in $STORAGE_ROOT/ssl/*-+([0-9])-+([0-9a-f]).pem; do
+    pem="$(basename "$file")"
+    not_valid_after="$(cut -d- -f1 <<< "${pem: -21}")"
 
-  if [ "$not_valid_after" -lt "$retain_after" ]; then
-    mv "$file" "$STORAGE_ROOT/ssl.expired/${pem}"
-  fi
-done
+    if [ "$not_valid_after" -lt "$retain_after" ]; then
+      mv "$file" "$STORAGE_ROOT/ssl.expired/${pem}"
+    fi
+  done
+fi

--- a/tools/ssl_cleanup
+++ b/tools/ssl_cleanup
@@ -3,17 +3,16 @@
 
 source /etc/mailinabox.conf
 shopt -s extglob
+shopt -s nullglob
 
-if ls "$STORAGE_ROOT/ssl/"*-+([0-9])-+([0-9a-f]).pem &>/dev/null; then
-  retain_after="$(date --date="7 days ago" +%Y%m%d)"
+retain_after="$(date --date="7 days ago" +%Y%m%d)"
 
-  mkdir -p $STORAGE_ROOT/ssl.expired
-  for file in $STORAGE_ROOT/ssl/*-+([0-9])-+([0-9a-f]).pem; do
-    pem="$(basename "$file")"
-    not_valid_after="$(cut -d- -f1 <<< "${pem: -21}")"
+mkdir -p $STORAGE_ROOT/ssl.expired
+for file in $STORAGE_ROOT/ssl/*-+([0-9])-+([0-9a-f]).pem; do
+  pem="$(basename "$file")"
+  not_valid_after="$(cut -d- -f1 <<< "${pem: -21}")"
 
-    if [ "$not_valid_after" -lt "$retain_after" ]; then
-      mv "$file" "$STORAGE_ROOT/ssl.expired/${pem}"
-    fi
-  done
-fi
+  if [ "$not_valid_after" -lt "$retain_after" ]; then
+    mv "$file" "$STORAGE_ROOT/ssl.expired/${pem}"
+  fi
+done


### PR DESCRIPTION
Check if expired certificates matching the file name pattern exist before trying to move them into ssl.expired subdirectory.

The for loop alone enters even if there are no matching files causing an error in mv. Checking first using ls prevents the loop to enter if there are no files to move.