### PR TITLE
Fix resolv.conf failing to delete due to file attributes

### DIFF
--- a/setup/system.sh
+++ b/setup/system.sh
@@ -356,6 +356,10 @@ fi
 # which is where bind9 will be running. Obviously don't do this before
 # installing bind9 or else apt won't be able to resolve a server to
 # download bind9 from.
+# Deleting resolv.conf fails if the file has the immutable attribute
+# or the append only attribute. So we ensure those attributes are not set
+# before attempting to delete the file.
+chattr -a -i /etc/resolv.conf
 rm -f /etc/resolv.conf
 tools/editconf.py /etc/systemd/resolved.conf DNSStubListener=no
 echo "nameserver 127.0.0.1" > /etc/resolv.conf


### PR DESCRIPTION
Hi,

When I was installing Mail-in-a-Box, the installation process was interrupted because the script failed to delete `/etc/resolv.conf`. The specific error message I recieved was `rm: cannot remove '/etc/resolv.conf': Operation not permitted`. I found out that the reason the script was unable to delete the file was because it had the immutable file attribute set. If the attribute is not set, the script can delete the file and continue as usual. Deletion of the file also fails if the file has the append only file attribute. I make this pull request to suggest modifying the script to make it to remove the attributes automatically before deleting the file so the user does not have to troubleshoot and fix it manually. Thank you.

Regards,
Sean