### PR TITLE
update: use nginx http2 directive

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -31,8 +31,9 @@ server {
 
 # The secure HTTPS server.
 server {
-	listen 443 ssl http2;
-	listen [::]:443 ssl http2;
+	listen 443 ssl;
+	listen [::]:443 ssl;
+	http2 on;
 
 	server_name $HOSTNAME;
 


### PR DESCRIPTION
Hi,

In this PR, I've updated the nginx config to follow (nginx's recommendations)[https://nginx.org/en/docs/http/ngx_http_v2_module.html#http2] and remove warnings when running the `nginx -t` command.

## Changes

- removed the http2 directive from the listen instructions for ports 443
- added the http2 on; directive to explicitly enable HTTP/2.

## Note

To fully eliminate the warnings, it is essential that all nginx config files follow this same recommendation, including any custom configurations.
