### PR TITLE
 Add Configurations to Handle AWS SDK Checksum Changes for Third-Party S3-Compatible Services

### DIFF
--- a/management/backup.py
+++ b/management/backup.py
@@ -258,6 +258,8 @@ def get_duplicity_env_vars(env):
 	if get_target_type(config) == 's3':
 		env["AWS_ACCESS_KEY_ID"] = config["target_user"]
 		env["AWS_SECRET_ACCESS_KEY"] = config["target_pass"]
+		env["AWS_REQUEST_CHECKSUM_CALCULATION"] = "WHEN_REQUIRED"
+		env["AWS_RESPONSE_CHECKSUM_VALIDATION"] = "WHEN_REQUIRED"
 
 	return env
 


### PR DESCRIPTION
**Summary:**
This pull request addresses recent changes in the AWS SDKs that enable checksum validations by default. These changes have caused compatibility issues with third-party S3-compatible services that do not support these checksum headers. To resolve these issues, we've introduced configurations to control checksum behaviors, ensuring compatibility with such services.

**Background:**
AWS SDKs have introduced default integrity protections for Amazon S3 operations, automatically enabling checksum validations. While this enhances data integrity, it has led to compatibility problems with third-party S3-compatible services that do not support these checksum features. Users have reported errors  when interacting with these services. (See: https://discourse.mailinabox.email/t/third-party-s3-and-aws-sdk-changes-how-to-fix/12792)

**Changes Introduced:**
   - Set both `request_checksum_calculation` and `response_checksum_validation` to `WHEN_REQUIRED`. This ensures that checksums are only calculated or validated when explicitly required, maintaining compatibility with services that do not support these features. (See: https://github.com/boto/boto3/issues/4398#issuecomment-2727003405)
