### PR TITLE
Fix missing PUBLIC_IPV6 in test for whether custom AAAA record blocks SSL certificate generation

### DIFF
--- a/management/web_update.py
+++ b/management/web_update.py
@@ -52,7 +52,7 @@ def get_domains_with_a_records(env):
 	domains = set()
 	dns = get_custom_dns_config(env)
 	for domain, rtype, value in dns:
-		if rtype == "CNAME" or (rtype in {"A", "AAAA"} and value not in {"local", env['PUBLIC_IP']}):
+		if rtype == "CNAME" or (rtype in {"A", "AAAA"} and value not in {"local", env['PUBLIC_IP'], env['PUBLIC_IPV6']}):
 			domains.add(domain)
 	return domains
 


### PR DESCRIPTION
On new installation, if you create AAAA record for mydomain.tld then mydomain.tld isn't available for SSL certificate or website.

It erroneously reports that it's hosted elsewhere.