### PR TITLE
Remove extraneous use of sudo from /etc/cron.d/mailinabox-nextcloud

### DIFF
--- a/setup/nextcloud.sh
+++ b/setup/nextcloud.sh
@@ -413,8 +413,8 @@ sqlite3 "$STORAGE_ROOT/owncloud/owncloud.db" "UPDATE oc_users_external SET backe
 cat > /etc/cron.d/mailinabox-nextcloud << EOF;
 #!/bin/bash
 # Mail-in-a-Box
-*/5 * * * *	root	sudo -u www-data php$PHP_VER -f /usr/local/lib/owncloud/cron.php
-*/5 * * * *	root	sudo -u www-data php$PHP_VER -f /usr/local/lib/owncloud/occ dav:send-event-reminders
+*/5 * * * *	www-data	php$PHP_VER -f /usr/local/lib/owncloud/cron.php
+*/5 * * * *	www-data	php$PHP_VER -f /usr/local/lib/owncloud/occ dav:send-event-reminders
 EOF
 chmod +x /etc/cron.d/mailinabox-nextcloud
 


### PR DESCRIPTION
I installed logwatch to be a little more aware of what's going on and noticed that `sudo` was being used regularly throughout the day by root to become www-data and run nextcloud maintenance scripts.

The file `/etc/cron.d/mailinabox-nextcloud` created by setup/nextcloud.sh was created such that it runs as root but then sudo's to www-data to run the nextcloud maintenance commands.

My change just puts `www-data` in the cron user field and eliminates the need for sudo. Tested on my install.