### PR TITLE
Add support for Spamhaus DQS

### DIFF
--- a/setup/mail-postfix.sh
+++ b/setup/mail-postfix.sh
@@ -267,7 +267,7 @@ END
 )
 
 	# Cleanup dnsbl reply mapping, potentially set when DQS was enabled previously
-	management/editconf.py /etc/postfix/main.cf -e rbl_reply_maps=
+	tools/editconf.py /etc/postfix/main.cf -e rbl_reply_maps=
 	
 	rm -rf /etc/postfix/dnsbl-reply-map
 else
@@ -297,7 +297,7 @@ EOF
 
 	postmap hash:/etc/postfix/dnsbl-reply-map
 
-	management/editconf.py /etc/postfix/main.cf \
+	tools/editconf.py /etc/postfix/main.cf \
 		rbl_reply_maps=hash:/etc/postfix/dnsbl-reply-map
 fi
 
@@ -320,7 +320,7 @@ END
 )
 
 # Apply configuration
-management/editconf.py /etc/postfix/main.cf -w \
+tools/editconf.py /etc/postfix/main.cf -w \
         smtpd_sender_restrictions="$CONF_SMTPD_SENDER_RESTRICTIONS" \
         smtpd_recipient_restrictions="$CONF_SMTPD_RECIPIENT_RESTRICTIONS"
 

--- a/setup/mail-postfix.sh
+++ b/setup/mail-postfix.sh
@@ -290,9 +290,9 @@ END
 
 	# Setup dnsbl reply mapping, to avoid leaking your DQS key in reject messages
 	cat > /etc/postfix/dnsbl-reply-map <<- EOF;
-	$ZEN_QUERY=127.0.0.[2.255]      \$rbl_code Service unavailable; \$rbl_class [\$rbl_what] blocked using zen.spamhaus.org\${rbl_reason?; \$rbl_reason}
+	$ZEN_QUERY=127.0.0.[2..255]     \$rbl_code Service unavailable; \$rbl_class [\$rbl_what] blocked using zen.spamhaus.org\${rbl_reason?; \$rbl_reason}
 	$DBL_QUERY=127.0.1.[2..99]      \$rbl_code Service unavailable; \$rbl_class [\$rbl_what] blocked using dbl.spamhaus.org\${rbl_reason?; \$rbl_reason}
-	$ZRD_QUERY=127.0.2.[2..24]      \$rbl_code Service unavailable; \$rbl_class [\$rbl_what] blocked using zrd.spamhaus.org\${rbl_reason?; \$rbl_reason}
+	$ZRD_QUERY=127.0.2.2            \$rbl_code Service unavailable; \$rbl_class [\$rbl_what] blocked using zrd.spamhaus.org\${rbl_reason?; \$rbl_reason}
 EOF
 
 	postmap hash:/etc/postfix/dnsbl-reply-map

--- a/setup/mail-postfix.sh
+++ b/setup/mail-postfix.sh
@@ -223,10 +223,12 @@ tools/editconf.py /etc/postfix/main.cf  -e lmtp_destination_recipient_limit=
 # * `reject_non_fqdn_sender`: Reject not-nice-looking return paths.
 # * `reject_unknown_sender_domain`: Reject return paths with invalid domains.
 # * `reject_authenticated_sender_login_mismatch`: Reject if mail FROM address does not match the client SASL login
-# * `reject_rhsbl_sender`: Reject return paths that use blacklisted domains.
 # * `permit_sasl_authenticated`: Authenticated users (i.e. on port 587) can skip further checks.
 # * `permit_mynetworks`: Mail that originates locally can skip further checks.
 # * `reject_rbl_client`: Reject connections from IP addresses blacklisted in zen.spamhaus.org
+# * `reject_rhsbl_sender`: Reject the request when the MAIL FROM domain is listed in spamhaus.org
+# * `reject_rhsbl_helo`: Reject the request when the HELO or EHLO hostname is listed in spamhaus.org
+# * `reject_rhsbl_reverse_client`: Reject the request when the unverified reverse client hostname is listed in spamhaus.org
 # * `reject_unlisted_recipient`: Although Postfix will reject mail to unknown recipients, it's nicer to reject such mail ahead of greylisting rather than after.
 # * `check_policy_service`: Apply greylisting using postgrey.
 #
@@ -236,9 +238,74 @@ tools/editconf.py /etc/postfix/main.cf  -e lmtp_destination_recipient_limit=
 # so these IPs get mail delivered quickly. But when an IP is not listed in the permit_dnswl_client list (i.e. it is not #NODOC
 # whitelisted) then postfix does a DEFER_IF_REJECT, which results in all "unknown user" sorts of messages turning into #NODOC
 # "450 4.7.1 Client host rejected: Service unavailable". This is a retry code, so the mail doesn't properly bounce. #NODOC
-tools/editconf.py /etc/postfix/main.cf \
-	smtpd_sender_restrictions="reject_non_fqdn_sender,reject_unknown_sender_domain,reject_authenticated_sender_login_mismatch,reject_rhsbl_sender dbl.spamhaus.org=127.0.1.[2..99]" \
-	smtpd_recipient_restrictions="permit_sasl_authenticated,permit_mynetworks,reject_rbl_client zen.spamhaus.org=127.0.0.[2..11],reject_unlisted_recipient,check_policy_service inet:127.0.0.1:10023,check_policy_service inet:127.0.0.1:12340"
+# In case the Spamhaus Data Query Service is used, slightly different configuration is needed. Source: https://portal.spamhaus.com/dqs/?ft=1#3.1.2
+# Zero Reputation Domain (ZRD) blocklist is limited to two hour old domains, not 24 like suggested by Spamhaus.
+
+# smtpd_recipient_restrictions is different whether Spamhaus DQS is used or not.
+# Start definition of the configuration here
+CONF_SMTPD_RECIPIENT_RESTRICTIONS=$(cat <<-END
+	permit_sasl_authenticated,
+        permit_mynetworks,
+        check_sender_access              hash:/etc/postfix/sender_access,
+        check_recipient_access           hash:/etc/postfix/recipient_access,
+END
+)
+
+if [ -z "${SPAMHAUS_DQS_KEY:-}" ]; then
+        # Public spamhaus blocklist servers queried
+        DBL_QUERY=dbl.spamhaus.org
+        ZEN_QUERY=zen.spamhaus.org
+
+CONF_SMTPD_RECIPIENT_RESTRICTIONS=$(cat <<-END
+	$CONF_SMTPD_RECIPIENT_RESTRICTIONS
+        reject_rbl_client                $ZEN_QUERY=127.0.0.[2..11],
+        reject_rhsbl_sender              $DBL_QUERY=127.0.1.[2..99],
+        reject_rhsbl_helo                $DBL_QUERY=127.0.1.[2..99],
+        reject_rhsbl_reverse_client      $DBL_QUERY=127.0.1.[2..99],
+        warn_if_reject reject_rbl_client $ZEN_QUERY=127.255.255.[1..255],        
+END
+)
+else
+        # Use Data Query Service for blocklist query URLs
+        DBL_QUERY=$SPAMHAUS_DQS_KEY.dbl.dq.spamhaus.net
+        ZEN_QUERY=$SPAMHAUS_DQS_KEY.zen.dq.spamhaus.net
+        ZRD_QUERY=$SPAMHAUS_DQS_KEY.zrd.dq.spamhaus.net
+
+CONF_SMTPD_RECIPIENT_RESTRICTIONS=$(cat <<-END
+	$CONF_SMTPD_RECIPIENT_RESTRICTIONS
+        reject_rhsbl_sender              $DBL_QUERY=127.0.1.[2..99],
+        reject_rhsbl_helo                $DBL_QUERY=127.0.1.[2..99],
+        reject_rhsbl_reverse_client      $DBL_QUERY=127.0.1.[2..99],
+        reject_rhsbl_sender              $ZRD_QUERY=127.0.2.2,
+        reject_rhsbl_helo                $ZRD_QUERY=127.0.2.2,
+        reject_rhsbl_reverse_client      $ZRD_QUERY=127.0.2.2,
+        reject_rbl_client                $ZEN_QUERY=127.0.0.[2..255],
+END
+)
+fi
+
+# Define configuration for smtpd_sender_restrictions
+CONF_SMTPD_SENDER_RESTRICTIONS=$(cat <<-END
+	reject_non_fqdn_sender,
+        reject_unknown_sender_domain,
+        reject_authenticated_sender_login_mismatch,
+        reject_rhsbl_sender $DBL_QUERY=127.0.1.[2..99]
+END
+)
+
+# Finalize configuration for smtpd_recipient_restrictions
+CONF_SMTPD_RECIPIENT_RESTRICTIONS=$(cat <<-END
+	$CONF_SMTPD_RECIPIENT_RESTRICTIONS
+        reject_unlisted_recipient,
+        check_policy_service             inet:127.0.0.1:10023,
+        check_policy_service             inet:127.0.0.1:12340
+END
+)
+
+# Apply configuration
+management/editconf.py /etc/postfix/main.cf -w \
+        smtpd_sender_restrictions="$CONF_SMTPD_SENDER_RESTRICTIONS" \
+        smtpd_recipient_restrictions="$CONF_SMTPD_RECIPIENT_RESTRICTIONS"
 
 # Postfix connects to Postgrey on the 127.0.0.1 interface specifically. Ensure that
 # Postgrey listens on the same interface (and not IPv6, for instance).


### PR DESCRIPTION
Mail-in-a-Box uses the free blocklists made available by Spamhaus to detect spammy servers, and to verify that our own boxes are not listed with Spamhaus. To do this properly, Mail-in-a-Box includes a local dns resolver (bind) to query the Spamhaus servers.
I recently encountered a limitation with this setup. It turns out that for a number of providers, Spamhaus cannot properly (their words) attribute the DNS queries coming from various VPS providers. For instance [Hetzner](https://www.spamhaus.org/resource-hub/email-security/query-the-legacy-dnsbls-via-hetzner/#the-headlines-for-those-in-a-hurry), [Digital Ocean](https://www.spamhaus.org/resource-hub/email-security/if-you-query-the-legacy-dnsbls-via-digitalocean-move-to-spamhaus-technologys-free-data-query-service/) or [Microsoft](https://www.spamhaus.org/resource-hub/email-security/query-the-legacy-dnsbls-via-microsoft-move-to-spamhaus-technology-s-free-data-query-service/). You can see whether your box is impacted when the Spamhaus DNS blocklists return the code `127.255.255.254`. Mail-in-a-Box recognizes this code, and reports it in the System Status Checks as _"Mail-in-a-Box is configured to use a public DNS server. This is not supported by spamhaus."_ 
Spamhaus also offers a solution: make use of the [Spamhaus Data Query Services](https://www.spamhaus.com/product/data-query-service/). For this you need to create an account with Spamhaus, and configure your DNS queries to make use of the DQS servers.

This pull request adds support for the Spamhaus DQS servers. It configures postfix, spamassassin and the Mail-in-a-Box daemon to use the DQS servers. To enable it, add a line in `/etc/mailinabox.conf` containing: `SPAMHAUS_DQS_KEY=<query_key>` The query_key is the DQS Key that can be generated at https://portal.spamhaus.com/dqs/ If no query key is configured, it defaults to using the public Spamhaus servers, which is what is currently implemented.

I chose to configure this via `/etc/mailinabox.conf`, but if desired I can change it to make use of `/home/user-data/settings.yaml`

Note: If you don´t want to use the Spamhaus DQS, and spamhaus returns the `127.255.255.254` code to your box, that is fine. Mail-in-a-Box recognizes the code and thus ignores this return code. However, you then don´t have the benefit of the Spamhaus bad server reports.