### PR TITLE
Fix broken Z-Push compatibility list link in mail guide

### DIFF
--- a/management/templates/mail-guide.html
+++ b/management/templates/mail-guide.html
@@ -42,7 +42,7 @@
 
 				<h4>Exchange/ActiveSync settings</h4>
 
-					<p>On iOS devices, devices on this <a href="https://wiki.z-hub.io/display/ZP/Compatibility">compatibility list</a>, or using Outlook 2007 or later on Windows 7 and later, you may set up your mail as an Exchange or ActiveSync server. However, we&rsquo;ve found this to be more buggy than using IMAP as described above. If you encounter any problems, please use the manual settings above.</p>
+					<p>On iOS devices, devices on this <a href="https://github.com/Z-Hub/Z-Push/wiki/Compatibility">compatibility list</a>, or using Outlook 2007 or later on Windows 7 and later, you may set up your mail as an Exchange or ActiveSync server. However, we&rsquo;ve found this to be more buggy than using IMAP as described above. If you encounter any problems, please use the manual settings above.</p>
 
 					<table class="table">
 					<tr><th>Server</th> <td>{{hostname}}</td></tr>


### PR DESCRIPTION
The previous link (wiki.z-hub.io) was no longer accessible. It has been replaced with the current official GitHub link: https://github.com/Z-Hub/Z-Push/wiki/Compatibility.