### PR TITLE
Remove ssl stapling from nginx configuration

### DIFF
--- a/conf/nginx-ssl.conf
+++ b/conf/nginx-ssl.conf
@@ -12,8 +12,6 @@ ssl_session_timeout 1d;
 # nginx 1.5.9+ ONLY
 ssl_buffer_size 1400; 
 
-ssl_stapling on;
-ssl_stapling_verify on;
 resolver 127.0.0.1 valid=86400;
 resolver_timeout 10;
 


### PR DESCRIPTION
As reported in #2458 and [on the forum](https://discourse.mailinabox.email/t/how-to-resolve-ssl-stapling-ignored-no-ocsp-responder-url-in-the-certificate-error/12993) Let's Encrypt has stopped support for SSL Stapling. Now nginx complains about this:
```"ssl_stapling" ignored, no OCSP responder URL in the certificate```

This pull request removes the nginx configuration for ssl stapling.