### PR TITLE
Fix broken links for scp and DAV

### DIFF
--- a/management/templates/sync-guide.html
+++ b/management/templates/sync-guide.html
@@ -26,13 +26,11 @@
 
 			<p>If you set up your <a href="#mail-guide">mail</a> using Exchange/ActiveSync,
 			your contacts and calendar may already appear on your device.</p>
-			<p>Otherwise, here are some apps that can synchronize your contacts and calendar to your Android phone.</p>
+			<p>Otherwise, the app below can synchronize your contacts and calendar to your Android phone.</p>
 
 			<table class="table">
-			<thead><tr><th>For...</th> <th>Use...</th></tr></thead>
-			<tr><td>Contacts and Calendar</td> <td><a href="https://play.google.com/store/apps/details?id=at.bitfire.davdroid">DAVx⁵</a> ($5.99; free <a href="https://f-droid.org/packages/at.bitfire.davdroid/">here</a>)</td></tr>
-			<tr><td>Only Contacts</td> <td><a href="https://play.google.com/store/apps/details?id=org.dmfs.carddav.sync">CardDAV-Sync free</a> (free)</td></tr>
-			<tr><td>Only Calendar</td> <td><a href="https://play.google.com/store/apps/details?id=org.dmfs.caldav.lib">CalDAV-Sync</a> ($2.99)</td></tr>
+			<thead><tr><th>Google Play</th> <th>F-Droid</th></tr></thead>
+			<tr><td><a href="https://play.google.com/store/apps/details?id=at.bitfire.davdroid">DAVx⁵</a> (paid)</td> <td><a href="https://f-droid.org/packages/at.bitfire.davdroid/">DAVx⁵</a> (free)</td></tr>
 			</table>
 
 			<p>Use the following settings:</p>

--- a/management/templates/web.html
+++ b/management/templates/web.html
@@ -12,7 +12,7 @@
 <ol>
 <li>Ensure that any domains you are publishing a website for have no problems on the <a href="#system_status">Status Checks</a> page.</li>
 
-<li>On your personal computer, install an SSH file transfer program such as <a href="https://filezilla-project.org/">FileZilla</a> or <a href="http://linuxcommand.org/man_pages/scp1.html">scp</a>.</li>
+<li>On your personal computer, install an SSH file transfer program such as <a href="https://filezilla-project.org/">FileZilla</a> or <a href="https://man.openbsd.org/scp.1">scp</a>.</li>
 
 <li>Log in to this machine with the file transfer program. The server is <strong>{{hostname}}</strong>, the protocol is SSH or SFTP, and use the <strong>SSH login credentials</strong> that you used when you originally created this machine at your cloud host provider. This is <strong>not</strong> what you use to log in either for email or this control panel. Your SSH credentials probably involves a private key file.</li>
 


### PR DESCRIPTION
It looks like dmfs's apps for CalDAV and CardDAV are no longer available on the Google Play Store, so will remove those apps and only recommend DAVx⁵ for now. 

The official scp man page link has also been updated.