### PR TITLE
Web statistics using goaccess.

### DIFF
--- a/conf/fail2ban/filter.d/miab-munin.conf
+++ b/conf/fail2ban/filter.d/miab-munin.conf
@@ -3,5 +3,5 @@
 before = common.conf
 
 [Definition]
-failregex=<HOST> - .*GET /admin/munin/.* HTTP/\d+\.\d+\" 401.*
+failregex=^.+?:\d+ <HOST> - .*GET /admin/munin/.* HTTP/\d+\.\d+\" 401.*
 ignoreregex =

--- a/conf/goaccess_persist
+++ b/conf/goaccess_persist
@@ -1,0 +1,2 @@
+#!/usr/bin/env /bin/bash
+/usr/bin/goaccess --process-and-exit

--- a/conf/nginx-top.conf
+++ b/conf/nginx-top.conf
@@ -10,3 +10,10 @@ upstream php-fpm {
 	server unix:/var/run/php/php8.0-fpm.sock;
 }
 
+# Reconfigure access log to include vhost to match goaccess VCOMBINED.
+# Cancel default logging, re-enabled in servers.
+access_log off;
+# Log format to match goaccess.
+log_format vcombined '$host:$server_port $remote_addr - $remote_user [$time_local] '
+                    '"$request" $status $body_bytes_sent '
+                    '"$http_referer" "$http_user_agent"';

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -10,6 +10,8 @@ server {
 	server_name $HOSTNAME;
 	root /tmp/invalid-path-nothing-here;
 
+	access_log /var/log/nginx/access.log vcombined;
+
 	# Improve privacy: Hide version an OS information on
 	# error pages and in the "Server" HTTP-Header.
 	server_tokens off;
@@ -35,6 +37,8 @@ server {
 	listen [::]:443 ssl http2;
 
 	server_name $HOSTNAME;
+
+	access_log /var/log/nginx/access.log vcombined;
 
 	# Improve privacy: Hide version an OS information on
 	# error pages and in the "Server" HTTP-Header.

--- a/management/daily_tasks.sh
+++ b/management/daily_tasks.sh
@@ -15,6 +15,11 @@ if [ "$(date "+%u")" -eq 1 ]; then
     management/mail_log.py -t week | management/email_administrator.py "Mail-in-a-Box Usage Report"
 fi
 
+# On Mondays, i.e. once a week, send the administrator a web analytics report.
+if [ "$(date "+%u")" -eq 1 ]; then
+    goaccess -o html | management/email_administrator_attachment.py "MIAB Web Analytics Report" "Mail-in-a-Box Web analytics report is attached." "webstats.html"
+fi
+
 # Take a backup.
 management/backup.py 2>&1 | management/email_administrator.py "Backup Status"
 

--- a/management/email_administrator_attachment.py
+++ b/management/email_administrator_attachment.py
@@ -1,0 +1,73 @@
+#!/usr/local/lib/mailinabox/env/bin/python
+
+# Reads in STDIN. If the stream is not empty, mail it to the system administrator.
+
+import sys
+
+import html
+import smtplib
+import email
+
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.mime.base import MIMEBase
+from email import encoders
+
+# In Python 3.6:
+#from email.message import Message
+
+from utils import load_environment
+
+# Load system environment info.
+env = load_environment()
+
+# Process command line args.
+subject = sys.argv[1] or 'MIAB Administration'
+body = sys.argv[2] or 'Please see the attachment. --Mail-in-a-Box'
+attachmentname = sys.argv[3] or 'attachment.html'
+
+# Administrator's email address.
+admin_addr = "administrator@" + env['PRIMARY_HOSTNAME']
+
+# Read in STDIN.
+attachment = sys.stdin.read().strip()
+
+# If there's nothing coming in, just exit.
+if attachment == "":
+    sys.exit(0)
+
+# create MIME message
+msg = MIMEMultipart('alternative')
+
+# In Python 3.6:
+#msg = Message()
+
+msg['From'] = '"{}" <{}>'.format(env['PRIMARY_HOSTNAME'], admin_addr)
+msg['To'] = admin_addr
+msg['Subject'] = "[{}] {}".format(env['PRIMARY_HOSTNAME'], subject)
+
+body_html = f'<html><body><pre style="overflow-x: scroll; white-space: pre;">{html.escape(body)}</pre></body></html>'
+
+msg.attach(MIMEText(body, 'plain'))
+msg.attach(MIMEText(body_html, 'html'))
+
+# Attach content as file
+part = MIMEBase('application', 'octet-stream')
+part.set_payload(attachment);
+encoders.encode_base64(part);
+part.add_header('Content-Disposition', f"attachment; filename={attachmentname}")
+
+msg.attach(part);
+           
+# In Python 3.6:
+#msg.set_content(content)
+#msg.add_alternative(content_html, "html")
+
+# send
+smtpclient = smtplib.SMTP('127.0.0.1', 25)
+smtpclient.ehlo()
+smtpclient.sendmail(
+        admin_addr, # MAIL FROM
+        admin_addr, # RCPT TO
+        msg.as_string())
+smtpclient.quit()

--- a/tools/parse-nginx-log-bootstrap-accesses.py
+++ b/tools/parse-nginx-log-bootstrap-accesses.py
@@ -23,7 +23,7 @@ for fn in glob.glob("/var/log/nginx/access.log*"):
 			# Find lines that are GETs on the bootstrap script by either curl or wget.
 			# (Note that we purposely skip ...?ping=1 requests which is the admin panel querying us for updates.)
 			# (Also, the URL changed in January 2016, but we'll accept both.)
-			m = re.match(rb"(?P<ip>\S+) - - \[(?P<date>.*?)\] \"GET /(bootstrap.sh|setup.sh) HTTP/.*\" 200 \d+ .* \"(?:curl|wget)", line, re.I)
+			m = re.match(rb"(?P<hostport>\S+) (?P<ip>\S+) - - \[(?P<date>.*?)\] \"GET /(bootstrap.sh|setup.sh) HTTP/.*\" 200 \d+ .* \"(?:curl|wget)", line, re.I)
 			if m:
 				date, time = m.group("date").decode("ascii").split(":", 1)
 				date = dateutil.parser.parse(date).date().isoformat()


### PR DESCRIPTION
This generates weekly web usage statistics and emails the report to the administrator. It installs and configures GoAccess, which is standard on Ubuntu.

I wanted web stats for my MIAB static sites, but without using a separate web property or service. Not looking for minute-by-minute analytics, only a casual, general sense of usage. Another contributor proposed adding AWStats to MIAB some time ago, which would mean a separate process and web interface.

This patch installs [GoAccess](https://goaccess.io), configures it for 7 days of database retention, runs it on logrotate and to generate the HTML stats report on Mondays along with the other reports. It emails the report to the site administrator as an attachment, a self-contained HTML page with lots of graphs and numbers.

**Breaking changes:** this patch alters the Nginx log file to include virtual host name (and port, not used). I have altered the Munin jail which watches access.log, and @JoshData's setup tracking script (not fully tested). It changes the stock Nginx log_format in what I read is a correct way (turn off globally, define w/ custom in each server), would like confirmation.

**Left to do:** the GoAccess configuration is largely stock, including dashboard layout. It can do geographic analysis, which is very interesting but requires extra configuration & files which may or may not be straightforward. The /mail/ etc. URLs appear in the stats, which might not be desired. Not sure what happens if GoAccess runs on logrotate and daily_tasks at the same time. GoAccess can't be made completely --quiet, need to verify this won't cause problems.

- _Why GoAccess?_
It can run completely batch. The reports are presentable (& self-contained, no remote dependencies per browser console). Development is ongoing. There are others, the same approach could easily work for a different batch processor.
- _Why not use GoAccess' live HTML statistics page?_
GoAccess can serve an HTML page and use WebSockets to update the dashboard. This means a separate web presence, which could be done but adds complexity.
If the administrator wants live access they can ssh in, run goaccess and use the ncurses interface, which is also very slick, probably enough to diagnose in-the-moment issues. 
- _Why not use separate virtual host access logs?_
Could do, but that's a bigger discussion.
- _Why not make the report HTML mail instead of an attachment?_
The static report that GoAccess generates is largely script and JSON, RoundCube strips out the scripts and metas.

It is far along enough to fail usefully. It works in Vagrant for setup and normal running. Did my best idiomatic python and bash, but, y'know.... Would like to see if there's any appetite before I go any further. --Thanks, K.
