### PR TITLE
Thunderbird fails to autoconfig with the realse v73

### DIFF
--- a/conf/mozilla-autoconfig.xml
+++ b/conf/mozilla-autoconfig.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <clientConfig version="1.1">
     <emailProvider id="PRIMARY_HOSTNAME">
+      <domain>PRIMARY_HOSTNAME</domain>
       <domain purpose="mx">PRIMARY_HOSTNAME</domain>
 
       <displayName>PRIMARY_HOSTNAME (Mail-in-a-Box)</displayName>


### PR DESCRIPTION
PR #2499 has introduced a change to line 4 in [conf/mozilla-autoconfig.xml](https://github.com/mail-in-a-box/mailinabox/pull/2499/files#diff-701f9d98d9c3dd5986653aca8d12b06916c729fc286a051ceae7f16082614d11) which purpose I can only find in https://datatracker.ietf.org/doc/draft-ietf-mailmaint-autoconfig/ which states:
>    A <domain purpose="mx"> specifies the domain name of the MX server of
   the email address, and is used config file lookup using MX server
   names, as specified in section MX.  The purpose attribute is mainly
   informational and may be ignored.
https://www.ietf.org/archive/id/draft-ietf-mailmaint-autoconfig-03.html#section-3.2.3-5

As for the reason of this issue/PR; I was setting up new domains for my mail services, upgraded MiaB from v71 to v73 and noticed that neither Thunderbird 141 nor Thunderbird 128 would pick up the autoconfig on the new domains.

As such I started looking for changes and noticed that PR #2499. Following that, tested these configurations:

v71 config, which Thunderbird autoconfig picked up properly
```
<domain>example.com</domain>
```

And properly following the draft-ietf-mailmaint-autoconfig-03, which Thunderbird autoconfig also picked up properly
```
<domain>example.com</domain>
<domain purpose="mx">example.com</domain>
```

Quite ironic, I must say.