### PR TITLE
Update zpush.sh to version 2.7.6 CVE-2025-8264

### DIFF
--- a/setup/zpush.sh
+++ b/setup/zpush.sh
@@ -22,8 +22,8 @@ apt_install \
 phpenmod -v "$PHP_VER" imap
 
 # Copy Z-Push into place.
-VERSION=2.7.5
-TARGETHASH=f0b0b06e255f3496173ab9d28a4f2d985184720e
+VERSION=2.7.6
+TARGETHASH=a0591c8c58b2cdb3ba25cd7a9115a40a3f76a72c
 needs_update=0 #NODOC
 if [ ! -f /usr/local/lib/z-push/version ]; then
 	needs_update=1 #NODOC


### PR DESCRIPTION
Updating to latest release, CVE-2025-8264 fix no new features.

Release: https://github.com/Z-Hub/Z-Push/releases/tag/2.7.6

Diff between 2.7.4 and 2.7.5: https://github.com/Z-Hub/Z-Push/compare/2.7.5...2.7.6