### PR TITLE
Update Nextcloud filter for fail2ban

### DIFF
--- a/conf/fail2ban/filter.d/miab-owncloud.conf
+++ b/conf/fail2ban/filter.d/miab-owncloud.conf
@@ -3,6 +3,8 @@
 before = common.conf
 
 [Definition]
-datepattern = %%Y-%%m-%%d %%H:%%M:%%S
-failregex=Login failed: .*Remote IP: '<HOST>[\)']
-ignoreregex =
+_groupsre = (?:(?:,?\s*"\w+":(?:"[^"]+"|\w+))*)
+failregex = ^\{%(_groupsre)s,?\s*"remoteAddr":"<HOST>"%(_groupsre)s,?\s*"message":"Login failed:
+            ^\{%(_groupsre)s,?\s*"remoteAddr":"<HOST>"%(_groupsre)s,?\s*"message":"Trusted domain error.
+datepattern = ,?\s*"time"\s*:\s*"%%Y-%%m-%%d[T ]%%H:%%M:%%S(%%z)?"
+


### PR DESCRIPTION
Updated the fail2ban filter for Nextcloud as described [in the Nextcloud documentation](https://docs.nextcloud.com/server/26/admin_manual/installation/harden_server.html#setup-a-filter-and-a-jail-for-nextcloud) Triggered by the discussion in issue #2505 