### PR TITLE
Update roundcube to 1.6.12

### DIFF
--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -36,8 +36,8 @@ apt_install \
 #   https://github.com/mstilkerich/rcmcarddav/releases
 # The easiest way to get the package hashes is to run this script and get the hash from
 # the error message.
-VERSION=1.6.11
-HASH=d72da06b5f65142dab8b574f7676e0220541a3d4
+VERSION=1.6.12
+HASH=544bc6b91a19bf1cc4a1255c5106a732325e1ce7
 PERSISTENT_LOGIN_VERSION=bde7b6840c7d91de627ea14e81cf4133cbb3c07a # version 5.3
 HTML5_NOTIFIER_VERSION=68d9ca194212e15b3c7225eb6085dbcf02fd13d7 # version 0.6.4+
 CARDDAV_VERSION=4.4.3


### PR DESCRIPTION
Roundcube has [another update](https://github.com/roundcube/roundcubemail/releases/tag/1.6.12) Two security vulnerabilities are fixed and some other stuff.