### PR TITLE
Fix KeyError when configuring S3 backups on empty buckets

### DIFF
--- a/management/backup.py
+++ b/management/backup.py
@@ -527,7 +527,7 @@ def list_target_files(config):
 			bucket_objects = response.get('Contents', [])
 			backup_list = [(key['Key'][len(path):], key['Size']) for key in bucket_objects]
 		except ClientError as e:
-			raise ValueError(msg)
+			raise ValueError(e)
 		return backup_list
 	if target.scheme == 'b2':
 		from b2sdk.v1 import InMemoryAccountInfo, B2Api


### PR DESCRIPTION
This PR fixes a minor issue I ran into when setting up backups. I created a brand new S3 bucket and intended to have my backups be stored at the top level. I got a 500 internal service error when submitting my configuration using the form on the admin panel, so I investigated syslog and discovered this error:

```
Jan 11 17:38:48 box start[62295]: [2026-01-11 17:38:48,290] ERROR in app: Exception on /system/backup/config [POST]
Jan 11 17:38:48 box start[62295]:   File "/root/mailinabox/management/daemon.py", line 651, in backup_set_custom
Jan 11 17:38:48 box start[62295]:     return json_response(backup_set_custom(env,
Jan 11 17:38:48 box start[62295]:   File "/root/mailinabox/management/backup.py", line 572, in backup_set_custom
Jan 11 17:38:48 box start[62295]:   File "/root/mailinabox/management/backup.py", line 528, in list_target_files
Jan 11 17:38:48 box Exception on /system/backup/config [POST]#012Traceback (most recent call last):#012  File "/usr/local/lib/mailinabox/env/lib/python3.10/site-packages/flask/app.py", line 1511, in wsgi_app#012    response = self.full_dispatch_request()#012  File "/usr/local/lib/mailinabox/env/lib/python3.10/site-packages/flask/app.py", line 919, in full_dispatch_request#012    rv = self.handle_user_exception(e)#012  File "/usr/local/lib/mailinabox/env/lib/python3.10/site-packages/flask/app.py", line 917, in full_dispatch_request#012    rv = self.dispatch_request()#012  File "/usr/local/lib/mailinabox/env/lib/python3.10/site-packages/flask/app.py", line 902, in dispatch_request#012    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]#012  File "/root/mailinabox/management/daemon.py", line 75, in newview#012    return viewfunc(*args, **kwargs)#012  File "/root/mailinabox/management/daemon.py", line 651, in backup_set_custom#012    return json_response(backup_set_custom(env,#012  File "/root/mailinabox/management/backup.py", line 572, in backup_set_custom#012    list_target_files(config)#012  File "/root/mailinabox/management/backup.py", line 528, in list_target_files#012    bucket_objects = s3.list_objects_v2(Bucket=bucket, Prefix=path)['Contents']#012KeyError: 'Contents'
```

I put together this fix:

**Problem**: Configuration fails with `KeyError: 'Contents'` when setting up backups on empty S3 buckets
**Root cause**: list_objects_v2 doesn't return Contents key when bucket/prefix is empty
**Fix**: Use .get('Contents', []) to handle empty buckets gracefully
**Testing**: Used my version of backup.py to configure S3 backups with an empty bucket without an internal error.