### PR TITLE
Add environmental variables to cron job

### DIFF
--- a/setup/management.sh
+++ b/setup/management.sh
@@ -116,6 +116,8 @@ minute=$((RANDOM % 60))  # avoid overloading mailinabox.email
 cat > /etc/cron.d/mailinabox-nightly << EOF;
 # Mail-in-a-Box --- Do not edit / will be overwritten on update.
 # Run nightly tasks: backup, status checks.
+AWS_REQUEST_CHECKSUM_CALCULATION=when_required
+AWS_RESPONSE_CHECKSUM_VALIDATION=when_required
 $minute 1 * * *	root	(cd $PWD && management/daily_tasks.sh)
 EOF
 


### PR DESCRIPTION
Fixes https://github.com/mail-in-a-box/mailinabox/issues/2549

For a couple weeks I've been getting this message from Mail-in-a-Box every time it runs a backup.

```
WARNING: Using boto3 >= 1,36.0 with non-amazon s3 services may result in checksum errors. a workaround is to set the following env vars

    export AWS_REQUEST_CHECKSUM_CALCULATION=when_required
    export AWS_RESPONSE_CHECKSUM_VALIDATION=when_required

see https://gitlab.com/duplicity/duplicity/-/issues/870 for details.
```

Note that, yes, I am in fact using a non-Amazon service for object storage.

Adding these environmental variables to `/etc/environment` did not solve make the warning go away, and @dms00 [suggested putting the variables in `/etc/cron.d/mailinabox-nightly`](https://github.com/mail-in-a-box/mailinabox/issues/2549#issuecomment-3768210000), so this Pull Request does just that.

Note that I have not actually tested this, yet; I have, however, added these variables to `/etc/cron.d/mailinabox-nightly` on my Box, so I will see tomorrow if I'm still getting the same error.

> Note that I personally think it would be more ideal if the default values of these environmental variables were set like this by `duplicity` itself, but Duplicity's maintainers seem to be fine with `duplicity` just spamming the user with the same warning over and over and over again instead. I could try and suggest this to them; at this exact moment I just don't have the spoons to deal with drafting an Issue on a Gitlab I've never interacted with before, especially considering the length of [the conversation thread there](https://gitlab.com/duplicity/duplicity/-/issues/870).