### PR TITLE
Fix critical accessibility bug in control panel modals

### DIFF
--- a/management/templates/index.html
+++ b/management/templates/index.html
@@ -215,11 +215,11 @@
           </div>
         </div>
 
-        <div id="global_modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="errorModalTitle" aria-hidden="true">
+        <div id="global_modal" class="modal fade" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="errorModalTitle">
           <div class="modal-dialog modal-sm">
             <div class="modal-content">
               <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close Dialog">&times;</button>
                 <h4 class="modal-title" id="errorModalTitle"> </h4>
               </div>
               <div class="modal-body">


### PR DESCRIPTION
### Where
`management/templates/index.html`

### Changes
There is a **critical** accessibility bug that blocks access to modals in the control panel for screen reader users. In this PR, I fix this bug and make some technical corrections.  

I changed the code as follows:

- Removed `aria-hidden="true"` from the `global_modal` div.  
  This attribute was set but not updated, causing screen readers to ignore the modal even when it was open. Bootstrap sets and modifies `aria-hidden` automatically, so the correct approach is not to set it manually.  

- The `global_modal` div has `role="dialog"` (correct) but lacked `aria-modal="true"`.  
  The ARIA specification recommends setting this attribute to ensure screen readers know that focus is (and should be) trapped in the modal. I added it.  

- Removed `aria-hidden="true"` from the close button.  
  This button can receive keyboard focus, so it should have an accessible name. If it is hidden, a screen reader user experiences focus on an unnamed element, which is confusing.  

- Added `aria-label="Close Dialog"` to the close button.  
  The visible label `&times;` does not describe the button’s function, but the new ARIA label does.  

### Remarks
- I have verified that the fixes produce the intended results with the NVDA screen reader.  
- **Known issue:** NVDA does not announce “dialog” in modals where focus lands on the close button. If focus lands on another element, it does. This is a minor issue, and the new close button label already makes clear it is a dialog, so we can ignore this problem given the following point.  
- **Future improvement:** The close button has a visual function and is beneficial to mouse users, but for keyboard users it is superfluous since the dialog can be closed by pressing *Escape* or the *OK/Cancel* button. It might be better to make the close button non-focusable. However, this is a design decision I’ll propose in a separate issue so it can be properly discussed without delaying this critical PR.  
- **Future improvement:** Use the `<dialog>` HTML5 element.  

### User Impact / Priority
**Critical:** Modals being `aria-hidden` makes them unusable for screen reader users.  
 