### PR TITLE
Fix issue in management daemon name resolution

### DIFF
--- a/setup/management.sh
+++ b/setup/management.sh
@@ -101,7 +101,7 @@ chmod 640 /var/lib/mailinabox/api.key
 
 source $venv/bin/activate
 export PYTHONPATH=$PWD/management
-exec gunicorn -b localhost:10222 -w 1 --timeout 630 wsgi:app
+exec gunicorn -b 127.0.0.1:10222 -w 1 --timeout 630 wsgi:app
 EOF
 chmod +x $inst_dir/start
 cp --remove-destination conf/mailinabox.service /lib/systemd/system/mailinabox.service # target was previously a symlink so remove it first


### PR DESCRIPTION
In some scenarios localhost resolves to the external ip. Adapted management daemon to reflect check performed in `start.sh`