### PR TITLE
[security] Update roundcube to 1.6.14

### DIFF
--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -36,8 +36,8 @@ apt_install \
 #   https://github.com/mstilkerich/rcmcarddav/releases
 # The easiest way to get the package hashes is to run this script and get the hash from
 # the error message.
-VERSION=1.6.12
-HASH=544bc6b91a19bf1cc4a1255c5106a732325e1ce7
+VERSION=1.6.14
+HASH=c5356ca6c159a27ad14b6861d5eb93b7c454eb11
 PERSISTENT_LOGIN_VERSION=bde7b6840c7d91de627ea14e81cf4133cbb3c07a # version 5.3
 HTML5_NOTIFIER_VERSION=68d9ca194212e15b3c7225eb6085dbcf02fd13d7 # version 0.6.4+
 CARDDAV_VERSION=4.4.3


### PR DESCRIPTION
Update Roundcube to 1.6.14. [Release notes](https://roundcube.net/news/2026/03/18/security-updates-1.7-rc5-1.6.14-1.5.14) include security fixes.