### PR TITLE
Update in Vagrant from Ubuntu v22 to v26

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Mail-in-a-Box
-=============
+# Mail-in-a-Box
 
 By [@JoshData](https://github.com/JoshData) and [contributors](https://github.com/mail-in-a-box/mailinabox/graphs/contributors).
 
@@ -23,7 +22,7 @@ Additionally, this project has a [Code of Conduct](CODE_OF_CONDUCT.md), which su
 In The Box
 ----------
 
-Mail-in-a-Box turns a fresh Ubuntu 22.04 LTS 64-bit machine into a working mail server by installing and configuring various components.
+Mail-in-a-Box turns a fresh Ubuntu 26.04 LTS 64-bit machine into a working mail server by installing and configuring various components.
 
 It is a one-click email appliance. There are no user-configurable setup options. It "just works."
 
@@ -54,7 +53,7 @@ Installation
 
 See the [setup guide](https://mailinabox.email/guide.html) for detailed, user-friendly instructions.
 
-For experts, start with a completely fresh (really, I mean it) Ubuntu 22.04 LTS 64-bit machine. On the machine...
+For experts, start with a completely fresh (really, I mean it) Ubuntu 26.04 LTS 64-bit machine. On the machine...
 
 Clone this repository and checkout the tag corresponding to the most recent release (which you can find in the tags or releases lists on GitHub):
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/jammy64"
+  config.vm.box = "cloud-image/ubuntu-26.04"
 
   # Network config: Since it's a mail server, the machine must be connected
   # to the public web. However, we currently don't want to expose SSH since

--- a/setup/bootstrap.sh
+++ b/setup/bootstrap.sh
@@ -20,16 +20,20 @@ if [ -z "$TAG" ]; then
 	#
 	# Allow point-release versions of the major releases, e.g. 22.04.1 is OK.
 	UBUNTU_VERSION=$( lsb_release -d | sed 's/.*:\s*//' | sed 's/\([0-9]*\.[0-9]*\)\.[0-9]/\1/' )
-	if [ "$UBUNTU_VERSION" == "Ubuntu 22.04 LTS" ]; then
-		# This machine is running Ubuntu 22.04, which is supported by
+	if [ "$UBUNTU_VERSION" == "Ubuntu 26.04 LTS" ]; then
+		# This machine is running Ubuntu 26.04, which is supported by
+		# Mail-in-a-Box versions 76 and later.
+		TAG=v76a
+	elif [ "$UBUNTU_VERSION" == "Ubuntu 22.04 LTS" ]; then
+		# This machine is running Ubuntu 22.04, which is also supported by
 		# Mail-in-a-Box versions 60 and later.
 		TAG=v75
 	elif [ "$UBUNTU_VERSION" == "Ubuntu 18.04 LTS" ]; then
-		# This machine is running Ubuntu 18.04, which is supported by
+		# This machine is running Ubuntu 18.04, which is only supported by
 		# Mail-in-a-Box versions 0.40 through 5x.
 		echo "Support is ending for Ubuntu 18.04."
 		echo "Please immediately begin to migrate your data to"
-		echo "a new machine running Ubuntu 22.04. See:"
+		echo "a new machine running Ubuntu 26.04. See:"
 		echo "https://mailinabox.email/maintenance.html#upgrade"
 		TAG=v57a
 	elif [ "$UBUNTU_VERSION" == "Ubuntu 14.04 LTS" ]; then
@@ -39,7 +43,7 @@ if [ -z "$TAG" ]; then
 		echo "The last version of Mail-in-a-Box supporting Ubuntu 14.04 will be installed."
 		TAG=v0.30
 	else
-		echo "This script may be used only on a machine running Ubuntu 14.04, 18.04, or 22.04."
+		echo "This script may be used only on a machine running Ubuntu 14.04, 18.04, 22.04, or 26.04."
 		exit 1
 	fi
 fi

--- a/setup/functions.sh
+++ b/setup/functions.sh
@@ -5,7 +5,7 @@
 # -o pipefail: don't ignore errors in the non-last command in a pipeline
 set -euo pipefail
 
-PHP_VER=8.0
+PHP_VER=8.5
 
 function hide_output {
 	# This function hides the output of a command unless the command fails
@@ -191,13 +191,23 @@ function wget_verify {
 	HASH=$2
 	DEST=$3
 	CHECKSUM="$HASH  $DEST"
+	# Keep backward compatibility with historical SHA1 pins but support SHA256 too.
+	# Newer upstream artifacts (e.g. Nextcloud core ZIP releases) provide SHA256 sidecars
+	# while SHA1 sidecars are no longer consistently published:
+	# https://download.nextcloud.com/server/releases/nextcloud-33.0.2.zip.sha256
+	# https://download.nextcloud.com/server/releases/nextcloud-33.0.2.zip.sha1
+	if [ ${#HASH} -eq 64 ]; then
+		HASH_CMD=sha256sum
+	else
+		HASH_CMD=sha1sum
+	fi
 	rm -f "$DEST"
 	hide_output wget -O "$DEST" "$URL"
-	if ! echo "$CHECKSUM" | sha1sum --check --strict > /dev/null; then
+	if ! echo "$CHECKSUM" | "$HASH_CMD" --check --strict > /dev/null; then
 		echo "------------------------------------------------------------"
 		echo "Download of $URL did not match expected checksum."
 		echo "Found:"
-		sha1sum "$DEST"
+		"$HASH_CMD" "$DEST"
 		echo
 		echo "Expected:"
 		echo "$CHECKSUM"

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -9,12 +9,12 @@ echo "Installing Mail-in-a-Box system management daemon..."
 
 # duplicity is used to make backups of user data.
 #
-# virtualenv is used to isolate the Python 3 packages we
+# python3-venv is used to isolate the Python 3 packages we
 # install via pip from the system-installed packages.
 #
 # certbot installs EFF's certbot which we use to
 # provision free TLS certificates.
-apt_install duplicity python3-pip virtualenv certbot rsync
+apt_install duplicity python3-pip python3-venv certbot rsync
 
 # b2sdk is used for backblaze backups.
 # boto3 is used for amazon aws backups.
@@ -27,13 +27,7 @@ inst_dir=/usr/local/lib/mailinabox
 mkdir -p $inst_dir
 venv=$inst_dir/env
 if [ ! -d $venv ]; then
-	# A bug specific to Ubuntu 22.04 and Python 3.10 requires
-	# forcing a virtualenv directory layout option (see #2335
-	# and https://github.com/pypa/virtualenv/pull/2415). In
-	# our issue, reportedly installing python3-distutils didn't
-	# fix the problem.)
-	export DEB_PYTHON_INSTALL_LAYOUT='deb'
-	hide_output virtualenv -ppython3 $venv
+	hide_output python3 -m venv $venv
 fi
 
 # Upgrade pip because the Ubuntu-packaged version is out of date.
@@ -46,7 +40,7 @@ hide_output $venv/bin/pip install --upgrade \
 	rtyaml "email_validator>=1.0.0" "exclusiveprocess" \
 	flask dnspython python-dateutil expiringdict gunicorn \
 	qrcode[pil] pyotp \
-	"idna>=2.0.0" "cryptography==37.0.2" psutil postfix-mta-sts-resolver \
+	"idna>=2.0.0" cryptography psutil postfix-mta-sts-resolver \
 	b2sdk boto3
 
 # CONFIGURATION

--- a/setup/nextcloud.sh
+++ b/setup/nextcloud.sh
@@ -32,16 +32,16 @@ nextcloud_hash=d5c10b650e5396d5045131c6d22c02a90572527c
 #   https://github.com/nextcloud/user_external/tags
 #
 # * For these three packages, contact, calendar and user_external, the hash is the SHA1 hash of
-# the ZIP package, which you can find by just running this script and copying it from
-# the error message when it doesn't match what is below:
+# the release tarball (from the releases/download URL, not the source archive), which you can
+# find by running: curl -sL <url> | sha1sum
 
 # Always ensure the versions are supported, see https://apps.nextcloud.com/apps/contacts
 contacts_ver=5.5.3
-contacts_hash=799550f38e46764d90fa32ca1a6535dccd8316e5
+contacts_hash=b234ab410480a4106176a28f39c9b27f471d0473
 
 # Always ensure the versions are supported, see https://apps.nextcloud.com/apps/calendar
 calendar_ver=4.7.6
-calendar_hash=a995bca4effeecb2cab25f3bbeac9bfe05fee766
+calendar_hash=cf8e68e7d945ee71933f5bb71a969faf152da55c
 
 # Always ensure the versions are supported, see https://apps.nextcloud.com/apps/user_external
 user_external_ver=3.3.0
@@ -105,11 +105,11 @@ InstallNextcloud() {
 	# their github repositories.
 	mkdir -p /usr/local/lib/owncloud/apps
 
-	wget_verify "https://github.com/nextcloud-releases/contacts/archive/refs/tags/v$version_contacts.tar.gz" "$hash_contacts" /tmp/contacts.tgz
+	wget_verify "https://github.com/nextcloud-releases/contacts/releases/download/v$version_contacts/contacts-v$version_contacts.tar.gz" "$hash_contacts" /tmp/contacts.tgz
 	tar xf /tmp/contacts.tgz -C /usr/local/lib/owncloud/apps/
 	rm /tmp/contacts.tgz
 
-	wget_verify "https://github.com/nextcloud-releases/calendar/archive/refs/tags/v$version_calendar.tar.gz" "$hash_calendar" /tmp/calendar.tgz
+	wget_verify "https://github.com/nextcloud-releases/calendar/releases/download/v$version_calendar/calendar-v$version_calendar.tar.gz" "$hash_calendar" /tmp/calendar.tgz
 	tar xf /tmp/calendar.tgz -C /usr/local/lib/owncloud/apps/
 	rm /tmp/calendar.tgz
 

--- a/setup/preflight.sh
+++ b/setup/preflight.sh
@@ -8,12 +8,12 @@ if [[ $EUID -ne 0 ]]; then
 	exit 1
 fi
 
-# Check that we are running on Ubuntu 22.04 LTS (or 22.04.xx).
+# Check that we are running on Ubuntu 26.04 LTS (or 26.04.xx).
 # Pull in the variables defined in /etc/os-release but in a
 # namespace to avoid polluting our variables.
 source <(cat /etc/os-release | sed s/^/OS_RELEASE_/)
-if [ "${OS_RELEASE_ID:-}" != "ubuntu" ] || [ "${OS_RELEASE_VERSION_ID:-}" != "22.04" ]; then
-	echo "Mail-in-a-Box only supports being installed on Ubuntu 22.04, sorry. You are running:"
+if [ "${OS_RELEASE_ID:-}" != "ubuntu" ] || [ "${OS_RELEASE_VERSION_ID:-}" != "26.04" ]; then
+	echo "Mail-in-a-Box only supports being installed on Ubuntu 26.04, sorry. You are running:"
 	echo
 	echo "${OS_RELEASE_ID:-"Unknown linux distribution"} ${OS_RELEASE_VERSION_ID:-}"
 	echo

--- a/setup/start.sh
+++ b/setup/start.sh
@@ -4,7 +4,7 @@
 
 source setup/functions.sh # load our functions
 
-# Check system setup: Are we running as root on Ubuntu 18.04 on a
+# Check system setup: Are we running as root on Ubuntu 26.04 on a
 # machine with enough memory? Is /tmp mounted with exec.
 # If not, this shows an error and exits.
 source setup/preflight.sh


### PR DESCRIPTION
Hello team :wave: 

Here's a sneak preview pull request to upgrade Ubuntu :sunglasses: 
The **big goal is to upgrade Nextcloud**. We all want this badly. So, for this, we need to **bump Ubuntu first**, right?

Notable changes:
- `ubuntu/jammy64` > `cloud-image/ubuntu-26.04`
- Next NC version is set to `76a`
- For backward compatibility, honour hashes from older and newer PHP versions both
- Replaced `virtualenv` with `python3-venv` 
- Install lasted `cryptography` version as this issue has been resolved.

Once merged, will consider another PR in isolation to embrace PHP v8.5 with Nextcloud v27. Better not to bump to v33, as it's too risky. We can slowly upgrade & migrate Nextcloud versions in subsequent PRs later.

How's that? :)