### PR TITLE
Capture Duplicity stderr

### DIFF
--- a/management/backup.py
+++ b/management/backup.py
@@ -334,7 +334,19 @@ def perform_backup(full_backup):
 			env["STORAGE_ROOT"],
 			get_duplicity_target_url(config),
 			],
-			get_duplicity_env_vars(env))
+			get_duplicity_env_vars(env)
+			capture_stderr=True)
+	except Exception as e:
+		# This and capture_stderr=True above guarantee that
+		# Duplicity will only print its output in case of an error.
+		# The reason for this is that versions of Duplicity prior to
+		# https://gitlab.com/duplicity/duplicity/-/merge_requests/365
+		# will print a warning regarding boto3 compatibility mitigations
+		# even when the workaround has been implemented
+		# (which Mail-in-a-Box does)
+		print(e)
+		raise e
+
 	finally:
 		# Start services again.
 		service_command("postgrey", "start", quit=False)

--- a/management/backup.py
+++ b/management/backup.py
@@ -334,7 +334,7 @@ def perform_backup(full_backup):
 			env["STORAGE_ROOT"],
 			get_duplicity_target_url(config),
 			],
-			get_duplicity_env_vars(env)
+			get_duplicity_env_vars(env),
 			capture_stderr=True)
 	except Exception as e:
 		# This and capture_stderr=True above guarantee that

--- a/management/backup.py
+++ b/management/backup.py
@@ -343,7 +343,7 @@ def perform_backup(full_backup):
 		# https://gitlab.com/duplicity/duplicity/-/merge_requests/365
 		# will print a warning regarding boto3 compatibility mitigations
 		# even when the workaround has been implemented
-		# (which Mail-in-a-Box does)
+		# (which Mail-in-a-Box does).
 		print(e)
 		raise e
 


### PR DESCRIPTION
Fixes https://github.com/mail-in-a-box/mailinabox/issues/2549

@edeso [writes](https://github.com/mail-in-a-box/mailinabox/issues/2549#issuecomment-4406637786):

> hey mail-in-a-box folks. we dissected the issue on our side and lowered the log level of the warning. so the issue should be gone with our next release.
> 
> still, i'd like to suggest that you to collect a complete notice log from `duplicity` on every run and send that depending of the duplicity exit status. mere error/warning level outputs may show the error but lack helpful information to debug. for successful runs the log can be discarded/archived as you prefer.

The inline comment in the code may be excessive; the reason I included it is that this change to Mail-in-a-Box could hypothetically be reverted once the upstream change to Duplicity hits Ubuntu LTS, as Kenneth Loafman [notes](https://gitlab.com/duplicity/duplicity/-/work_items/870#note_3325427788):

> All of you just remember, anything we put in today will not be out in the distros for at least a year, possibly longer for Ubuntu and Debian.

Note that I can't easily test this because I have a Mac, and Vagrant doesn't have ARM boxes [for Ubuntu](https://portal.cloud.hashicorp.com/vagrant/discover/ubuntu).