### PR TITLE
aliases.html: remove orphan </div> tags breaking #panel_aliases container

### DIFF
--- a/management/templates/aliases.html
+++ b/management/templates/aliases.html
@@ -82,8 +82,6 @@
       <div id="addaliasForwardsToDiv" style="margin-top: .5em; margin-left: 1.4em; display: none;">
         <textarea class="form-control" rows="3" id="addaliasSenders" placeholder="one user per line or separated by commas"></textarea>
       </div>
-    </div>
-  </div>
   <div class="form-group">
     <div class="col-sm-offset-1 col-sm-11">
       <button id="add-alias-button" type="submit" class="btn btn-primary">Add Alias</button>


### PR DESCRIPTION
## Summary

PR #2555 (commit 146ebaa, accessibility refactor wrapping 'Permitted Senders' in `<fieldset>`) left two trailing `</div>` tags from the pre-refactor markup. The new `<div class="form-group"><fieldset>...</fieldset></div>` block is internally balanced, but the two leftover `</div>` tags now have no opener in the local scope and bubble up to close the parent `#panel_aliases` container prematurely.

The browser-tolerant parsing means the page still works, but the `Add Alias` button, the `Existing mail aliases` table, and the `Mail aliases API (advanced)` documentation end up as direct children of `<body>`, escaping the `.admin_panel` show/hide system in `index.html`. They become visible on **every** panel (Welcome, System Status, Users, ...), not just `#aliases`.

## Reproduction

1. Log in to the admin control panel on any MiaB v75 box.
2. Stay on the default `#welcome` URL.
3. Observe the `Existing mail aliases` table and `Mail aliases API` docs rendered underneath the welcome paragraph.

## Fix

Delete the two orphan `</div>` tags (lines 85-86 in current `aliases.html`). HTML `<div>` open/close balance for the file: -1 → 0. No other markup or behaviour change.

## Verification

- `<div>` balance counter on the file goes from -1 to 0.
- After applying the patch + restarting the management daemon, `document.getElementById('panel_aliases').contains(document.getElementById('add-alias-button'))` returns `true` (was `false` before).
- The Aliases UI is no longer visible on `#welcome`. Navigating to `#aliases` displays the panel exactly as expected.

## Test plan

- [ ] Verify HTML validates with `tidy`/W3C validator
- [ ] Visit `/admin#welcome` after login → no stray Aliases UI
- [ ] Visit `/admin#aliases` → form, table and API docs render as before the regression