### PR TITLE
Upgrade Nextcloud to 27.1.11

### DIFF
--- a/setup/nextcloud.sh
+++ b/setup/nextcloud.sh
@@ -21,8 +21,8 @@ echo "Installing Nextcloud (contacts/calendar)..."
 #   we automatically install intermediate versions as needed.
 # * The hash is the SHA1 hash of the ZIP package, which you can find by just running this script and
 #   copying it from the error message when it doesn't match what is below.
-nextcloud_ver=26.0.13
-nextcloud_hash=d5c10b650e5396d5045131c6d22c02a90572527c
+nextcloud_ver=27.1.11
+nextcloud_hash=9f30c01a021c2e5a9e7baff119955afb3c552ebc
 
 # Nextcloud apps
 # --------------
@@ -36,16 +36,16 @@ nextcloud_hash=d5c10b650e5396d5045131c6d22c02a90572527c
 # find by running: curl -sL <url> | sha1sum
 
 # Always ensure the versions are supported, see https://apps.nextcloud.com/apps/contacts
-contacts_ver=5.5.3
-contacts_hash=b234ab410480a4106176a28f39c9b27f471d0473
+contacts_ver=5.5.4
+contacts_hash=c4e3f2183a0088b829f8aa1b3af1f87c9a4c46a2
 
 # Always ensure the versions are supported, see https://apps.nextcloud.com/apps/calendar
-calendar_ver=4.7.6
-calendar_hash=cf8e68e7d945ee71933f5bb71a969faf152da55c
+calendar_ver=4.7.20
+calendar_hash=12d876904e227156e39ca4335b18481b42a6d00f
 
 # Always ensure the versions are supported, see https://apps.nextcloud.com/apps/user_external
-user_external_ver=3.3.0
-user_external_hash=280d24eb2a6cb56b4590af8847f925c28d8d853e
+user_external_ver=3.4.0
+user_external_hash=7f9d8f4dd6adb85a0e3d7622d85eeb7bfe53f3b4
 
 # Developer advice (test plan)
 # ----------------------------
@@ -238,6 +238,10 @@ if [ ! -d /usr/local/lib/owncloud/ ] || [[ ! ${CURRENT_NEXTCLOUD_VER} =~ ^$nextc
         if [[ ${CURRENT_NEXTCLOUD_VER} =~ ^24 ]]; then
 			InstallNextcloud 25.0.7 a5a565c916355005c7b408dd41a1e53505e1a080 5.3.0 4b0a6666374e3b55cfd2ae9b72e1d458b87d4c8c 4.4.2 21a42e15806adc9b2618760ef94f1797ef399e2f 3.2.0 a494073dcdecbbbc79a9c77f72524ac9994d2eec
 			CURRENT_NEXTCLOUD_VER="25.0.7"
+		fi
+		if [[ ${CURRENT_NEXTCLOUD_VER} =~ ^25 ]]; then
+			InstallNextcloud 26.0.13 d5c10b650e5396d5045131c6d22c02a90572527c 5.5.3 b234ab410480a4106176a28f39c9b27f471d0473 4.7.6 cf8e68e7d945ee71933f5bb71a969faf152da55c 3.3.0 280d24eb2a6cb56b4590af8847f925c28d8d853e
+			CURRENT_NEXTCLOUD_VER="26.0.13"
 		fi
 	fi
 

--- a/setup/nextcloud.sh
+++ b/setup/nextcloud.sh
@@ -32,16 +32,16 @@ nextcloud_hash=d5c10b650e5396d5045131c6d22c02a90572527c
 #   https://github.com/nextcloud/user_external/tags
 #
 # * For these three packages, contact, calendar and user_external, the hash is the SHA1 hash of
-# the ZIP package, which you can find by just running this script and copying it from
-# the error message when it doesn't match what is below:
+# the release tarball (from the releases/download URL, not the source archive), which you can
+# find by running: curl -sL <url> | sha1sum
 
 # Always ensure the versions are supported, see https://apps.nextcloud.com/apps/contacts
 contacts_ver=5.5.3
-contacts_hash=799550f38e46764d90fa32ca1a6535dccd8316e5
+contacts_hash=b234ab410480a4106176a28f39c9b27f471d0473
 
 # Always ensure the versions are supported, see https://apps.nextcloud.com/apps/calendar
 calendar_ver=4.7.6
-calendar_hash=a995bca4effeecb2cab25f3bbeac9bfe05fee766
+calendar_hash=cf8e68e7d945ee71933f5bb71a969faf152da55c
 
 # Always ensure the versions are supported, see https://apps.nextcloud.com/apps/user_external
 user_external_ver=3.3.0
@@ -105,11 +105,11 @@ InstallNextcloud() {
 	# their github repositories.
 	mkdir -p /usr/local/lib/owncloud/apps
 
-	wget_verify "https://github.com/nextcloud-releases/contacts/archive/refs/tags/v$version_contacts.tar.gz" "$hash_contacts" /tmp/contacts.tgz
+	wget_verify "https://github.com/nextcloud-releases/contacts/releases/download/v$version_contacts/contacts-v$version_contacts.tar.gz" "$hash_contacts" /tmp/contacts.tgz
 	tar xf /tmp/contacts.tgz -C /usr/local/lib/owncloud/apps/
 	rm /tmp/contacts.tgz
 
-	wget_verify "https://github.com/nextcloud-releases/calendar/archive/refs/tags/v$version_calendar.tar.gz" "$hash_calendar" /tmp/calendar.tgz
+	wget_verify "https://github.com/nextcloud-releases/calendar/releases/download/v$version_calendar/calendar-v$version_calendar.tar.gz" "$hash_calendar" /tmp/calendar.tgz
 	tar xf /tmp/calendar.tgz -C /usr/local/lib/owncloud/apps/
 	rm /tmp/calendar.tgz
 


### PR DESCRIPTION
## What

Upgrade Nextcloud from 26.0.13 to **27.1.11** (latest 27.x), with the bundled apps bumped to the highest versions still compatible with NC 27:
- contacts 5.5.3 → **5.5.4**
- calendar 4.7.6 → **4.7.20**
- user_external 3.3.0 → **3.4.0**

Also adds the intermediate **25 → 26** step to the upgrade chain so existing installs migrate 25 → 26 → 27 in a single run.

Closes #2399.

## Why

Nextcloud 26 has been end-of-life for ~1.5 years and has accumulated published security advisories (see #2399). v27 is the highest release that still runs on the PHP 8.0 that Mail-in-a-Box currently ships — v28+ require PHP 8.1, tracked separately (#2398 / #2309). As @yodax noted in #2399, PHP 8.0 is deprecated but not removed, so v27 works today. This is the transitional step before the eventual PHP 8.1 + v28 work, in the order suggested in the issue (v27 → PHP 8.1 → vNext).

## Changes

`setup/nextcloud.sh`:
- `nextcloud_ver` 26.0.13 → 27.1.11 (+ hash)
- `contacts_ver` → 5.5.4, `calendar_ver` → 4.7.20, `user_external_ver` → 3.4.0 (+ hashes)
- new `^25` branch in the upgrade chain that installs 26.0.13 before the final hop to 27

App versions are the highest whose `appinfo/info.xml` `max-version` still covers NC 27 (contacts 6.x needs NC 29, calendar 5.x is NC 28+, user_external 4.x needs NC 31). The core zip SHA-256 matches the official `.zip.sha256`; app SHA-1s were computed from the release tarballs.

## Testing

On a Mail-in-a-Box v76 box (PHP 8.0) at Nextcloud 26.0.13, running `setup/nextcloud.sh`:
- core + apps downloaded and verified (all `wget_verify` checks pass)
- `occ upgrade` migrated the DB through to 27, **code integrity check passed**, "Update successful"
- `occ status` → 27.1.11, `maintenance: false`, `needsDbUpgrade: false`
- contacts 5.5.4 / calendar 4.7.20 / user_external 3.4.0 enabled; no errors in the Nextcloud log afterwards
- completed with **no file-permission issue** — the chown from #2377 is sufficient, no extra chmod needed

## Depends on #2588

The newer contacts/calendar releases must be fetched as release tarballs (GitHub source archives omit the built assets), which #2588 introduces. This PR is layered on #2588 and should be merged after it (or rebased once it lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
